### PR TITLE
[bugs] In SWMF Coupling & a few others...

### DIFF
--- a/.github/workflows/Format-Doc-Test.yml
+++ b/.github/workflows/Format-Doc-Test.yml
@@ -32,7 +32,7 @@ jobs:
       - name: Format check entire GITM repository
         run: |
           cd GITM
-          python srcPython/format_GITM.py -f
+          python srcPython/format_GITM.py -f -v
       - name: Get changed files
         id: changed-files
         uses: tj-actions/changed-files@v45

--- a/Config.pl
+++ b/Config.pl
@@ -4,7 +4,7 @@
 use strict;
 
 our $Component       = 'UA';
-our $Code            = 'GITM2';
+our $Code            = 'GITM';
 our $MakefileDefOrig = 'srcMake/Makefile.def';
 our @Arguments       = @ARGV;
 
@@ -278,19 +278,19 @@ sub show_settings{
 ############################################################################
 
 sub print_help{
-    print "Additional options for GITM2/Config.pl:
+    print "Additional options for GITM/Config.pl:
 
--Titan      Configure GITM2 for Titan. This flag is case insensitive.
+-Titan      Configure GITM for Titan. This flag is case insensitive.
 
--Mars       Configure GITM2 for Mars. This flag is case insensitive.
+-Mars       Configure GITM for Mars. This flag is case insensitive.
 
--LV-426     Configure GITM2 for Testing. This flag is case insensitive.
+-LV-426     Configure GITM for Testing. This flag is case insensitive.
 
--Earth      Configure GITM2 for Earth. This flag is case insensitive.
+-Earth      Configure GITM for Earth. This flag is case insensitive.
 
 -s          Show current planet.
 
-Additional examples for GITM2/Config.pl:
+Additional examples for GITM/Config.pl:
 
 Install for Titan:
 
@@ -308,7 +308,7 @@ Set grid to nLon=36, nLat=36, nAlt=50 and the number of blocks to 16:
 
     Config.pl -g=36,36,50,16
 
-Show settings for UA/GITM2:
+Show settings for UA/GITM:
 
     Config.pl -s
  ";

--- a/share/Library/src/ModTriangulate.f90
+++ b/share/Library/src/ModTriangulate.f90
@@ -3,7 +3,7 @@
 module ModTriangulate
 
   use ModUtilities, ONLY: CON_stop
-  
+
   implicit none
 
   private ! except

--- a/src/ModFtaModel.f90
+++ b/src/ModFtaModel.f90
@@ -122,7 +122,7 @@ contains
     implicit none
 
     integer :: LunIndices_, ierror
-    character(len=iCharLenFta_), intent(in) :: NameOfIndexFile
+    character(len=*), intent(in) :: NameOfIndexFile
     character(len=iCharLenLong_) :: line
 
     logical :: done

--- a/src/ModHmeModel.f90
+++ b/src/ModHmeModel.f90
@@ -421,6 +421,8 @@ contains
   ! -----------------------------------------------------------------
   subroutine calc_1tide_1day(u_all, v_all, geopt_all, temp_all, dr_rho_all)
 
+    use ieee_arithmetic
+
     implicit none
 
     character(len=iCharLenHme_) :: hme_tmp
@@ -523,8 +525,8 @@ contains
           end do
         end do
       end do
-      if (count(isnan(geopt)) > 0) then
-        write(*, *) isnan(geopt)
+      if (count(ieee_is_nan(geopt)) > 0) then
+        write(*, *) ieee_is_nan(geopt)
         write(*, *) 'i,ilon,ilat,ialt,hme: ', i, ilon, j, k, hme_tmp
         call stop_gitm('nan was found in geopt, stop')
       end if

--- a/src/ModHmeModel.f90
+++ b/src/ModHmeModel.f90
@@ -80,7 +80,7 @@ contains
 
     implicit none
     integer :: LunIndices_, ierror, iOutputError
-    character(len=iCharLenFile_), intent(in) :: NameOfFile
+    character(len=*), intent(in) :: NameOfFile
 
     integer :: i
 
@@ -112,7 +112,7 @@ contains
     implicit none
 
     integer :: LunIndices_, ierror, iOutputError
-    character(len=iCharLenFile_), intent(in) :: NameOfIndexFile
+    character(len=*), intent(in) :: NameOfIndexFile
     character(len=iCharLenLong_) :: line
 
     logical :: done
@@ -175,7 +175,7 @@ contains
 
     implicit none
     integer :: LunIndices_, ierror, iOutputError
-    character(len=iCharLenFile_), intent(in) :: NameOfIndexFile
+    character(len=*), intent(in) :: NameOfIndexFile
     character(len=iCharLenLong_) :: line
 
     logical :: done
@@ -225,7 +225,7 @@ contains
 
     implicit none
     integer :: n, s, tmp
-    character(len=iCharLenHme_), intent(in) :: hme_tmp
+    character(len=*), intent(in) :: hme_tmp
 
     if (hme_tmp(1:1) .eq. 'D') then
       n = 1
@@ -558,7 +558,7 @@ contains
                       temp_a3, temp_p3, dr_rho_a3, dr_rho_p3)
 
     implicit none
-    character(len=iCharLenHme_), intent(in) :: thme
+    character(len=*), intent(in) :: thme
     character(len=iCharLenFile_) :: NameOfHMEFile
     real, dimension(nLatsHme)  :: u_a, u_p, v_a, v_p, geopt_a, geopt_p, &
                                   temp_a, temp_p, dr_rho_a, dr_rho_p

--- a/src/ModHwm.f90
+++ b/src/ModHwm.f90
@@ -567,7 +567,7 @@ subroutine loadmodel(datafile)
   use NEWmodel
   implicit none
 
-  character(128), intent(in)   :: datafile
+  character(len=*), intent(in)   :: datafile
 
   integer                     :: i, j
   integer                     :: ncomp
@@ -1346,7 +1346,7 @@ subroutine loaddwm(datafile)
 
   implicit none
 
-  character(128), intent(in)   :: datafile
+  character(len=*), intent(in)   :: datafile
 
   external vsh_basis_init
 

--- a/src/ModHwm14.f90
+++ b/src/ModHwm14.f90
@@ -72,7 +72,7 @@ subroutine hwm14(iyd, sec, alt, glat, glon, stl, f107a, f107, ap, path, w)
   real(4), intent(in)        :: ap(2)
   real(4), intent(out)       :: w(2)
   real(4)                   :: dw(2)
-  character(250), intent(in) :: path
+  character(*), intent(in) :: path
 
   pathdefault = path
   if (hwminit) call inithwm()
@@ -338,7 +338,7 @@ subroutine initqwm(filename)
   use hwm, only: omaxhwm, nmaxhwm
   implicit none
 
-  character(128), intent(in)      :: filename
+  character(*), intent(in)      :: filename
   integer(4)                     :: i, j
   integer(4)                     :: ncomp
 

--- a/src/ModNewell.f90
+++ b/src/ModNewell.f90
@@ -502,14 +502,14 @@ contains
 
     if (iError /= 0) then
       write(*, *) "Error in read_single_regression_file"
-      call stop_gitm(cFile//" cannot be opened")
+      call stop_gitm(trim(cFile)//" cannot be opened")
     end if
 
     read(iInputUnit_, *, iostat=iError) year0, day0, year1, day1, nFiles, sf0
 
     if (iError /= 0) then
       write(*, *) "Error in read_single_regression_file"
-      call stop_gitm(cFile//" cannot read first line")
+      call stop_gitm(trim(cFile)//" cannot read first line")
     end if
 
     do iMlt = 1, nMlts
@@ -518,7 +518,7 @@ contains
           i, j, b1a(iMlt, iMlat), b2a(iMlt, iMlat), rfa(iMlt, iMlat)
         if (iError /= 0) then
           write(*, *) "Error in read_single_regression_file:", iMlt, iMlat
-          call stop_gitm(cFile//" error reading file")
+          call stop_gitm(trim(cFile)//" error reading file")
         end if
       end do
     end do
@@ -545,14 +545,14 @@ contains
 
     if (iError /= 0) then
       write(*, *) "Error in read_single_probability_file"
-      call stop_gitm(cFile//" cannot be opened")
+      call stop_gitm(trim(cFile)//" cannot be opened")
     end if
 
     read(iInputUnit_, *, iostat=iError) year0, day0, year1, day1, nFiles, sf0
 
     if (iError /= 0) then
       write(*, *) "Error in read_single_probability_file"
-      call stop_gitm(cFile//" cannot read first line")
+      call stop_gitm(trim(cFile)//" cannot read first line")
     end if
 
     do iMlt = 1, nMlts
@@ -561,7 +561,7 @@ contains
           b1p(iMlt, iMlat), b2p(iMlt, iMlat)
         if (iError /= 0) then
           write(*, *) "Error in read_single_probability_file:", iMlt, iMlat
-          call stop_gitm(cFile//" error reading file")
+          call stop_gitm(trim(cFile)//" error reading file")
         end if
       end do
     end do
@@ -572,7 +572,7 @@ contains
           read(iInputUnit_, *, iostat=iError) Prob(idF, iMlt, iMlat)
           if (iError /= 0) then
             write(*, *) "Error in read_single_probability_file:", idF, iMlt, iMlat
-            call stop_gitm(cFile//" error reading file")
+            call stop_gitm(trim(cFile)//" error reading file")
           end if
         end do
       end do

--- a/src/ModNewell.f90
+++ b/src/ModNewell.f90
@@ -2,10 +2,10 @@
 ! Full license can be found in LICENSE
 
 module ModNewell
-
+  use ModInputs
   implicit none
 
-  integer, parameter        :: iCharLenNewell_ = 400
+  integer, parameter        :: iCharLenNewell_ = iCharLen_
 
   character(len=iCharLenNewell_) :: dir = "UA/DataIn/Aurora/"
 

--- a/src/ModOvationSME.f90
+++ b/src/ModOvationSME.f90
@@ -220,8 +220,7 @@ contains
 
     inquire(file=cFile, EXIST=IsThere)
     if (.not. IsThere) then
-      write(*, *) cFile//" cannot be found by read_ovationsm_files"
-!         call stop_gitm(cFile//" cannot be found by read_ovationsm_files")
+      write(*, *) trim(cFile)//" cannot be found by read_ovationsm_files"
     end if
 
     iError = 0

--- a/src/ModReadGitm3d.f90
+++ b/src/ModReadGitm3d.f90
@@ -59,7 +59,7 @@ contains
 
     implicit none
 
-    character(len=nGitmCharLength), intent(in) :: InDir
+    character(len=*), intent(in) :: InDir
     GitmDir = InDir
 
   end subroutine GitmSetDir
@@ -361,7 +361,7 @@ contains
 
   subroutine GetGitmTime(file, time)
 
-    character(len=nGitmCharLength), intent(in) :: file
+    character(len=*), intent(in) :: file
     real(Real8_), intent(out) :: time
     character(len=nGitmVarCharLength) :: Dummy
 
@@ -450,7 +450,7 @@ contains
 
   subroutine GitmReadFile(InFile, iError)
 
-    character(len=nGitmCharLength), intent(in) :: InFile
+    character(len=*), intent(in) :: InFile
     integer, intent(out) :: iError
 
     character(len=nGitmVarCharLength) :: Dummy

--- a/src/ModSami.f90
+++ b/src/ModSami.f90
@@ -139,7 +139,8 @@ contains
         call time_int_to_real(iTime, SamiStartTime)
 
       case ("#COROTATIONPOTENTIALADDED")
-        read(iSamiUnit, '(L)', iostat=iError) CorotationAdded
+        read(iSamiUnit, '(L8)', iostat=iError) CorotationAdded
+        ! ALB modified the above for nagfor compliance. IDK if its right.
 
       case ("#DIR")
         read(iSamiUnit, '(a)', iostat=iError) SamiDir

--- a/src/ModSami.f90
+++ b/src/ModSami.f90
@@ -139,8 +139,7 @@ contains
         call time_int_to_real(iTime, SamiStartTime)
 
       case ("#COROTATIONPOTENTIALADDED")
-        read(iSamiUnit, '(L8)', iostat=iError) CorotationAdded
-        ! ALB modified the above for nagfor compliance. IDK if its right.
+        read(iSamiUnit, *, iostat=iError) CorotationAdded
 
       case ("#DIR")
         read(iSamiUnit, '(a)', iostat=iError) SamiDir

--- a/src/ModSami.f90
+++ b/src/ModSami.f90
@@ -71,7 +71,7 @@ contains
 
     implicit none
 
-    character(len=nSamiCharLength), intent(in) :: InDir
+    character(len=*), intent(in) :: InDir
     SamiDir = InDir
 
   end subroutine SamiSetDir
@@ -111,7 +111,7 @@ contains
 
     implicit none
 
-    character(len=nSamiCharLength), intent(in) :: inFile
+    character(len=*), intent(in) :: inFile
     character(len=nSamiCharLength) :: line
     integer :: iError
 
@@ -199,7 +199,7 @@ contains
 
     implicit none
 
-    character(len=nSamiCharLength), intent(in) :: inFile
+    character(len=*), intent(in) :: inFile
     integer :: iError
     integer :: iT, iHour, iMinute, iSecond, n
     real :: tHours, uts
@@ -232,7 +232,7 @@ contains
 
     implicit none
 
-    character(len=nSamiCharLength), intent(in) :: inFile
+    character(len=*), intent(in) :: inFile
     integer :: iError, iLon
     real :: lon
 
@@ -272,7 +272,7 @@ contains
 
     implicit none
 
-    character(len=nSamiCharLength), intent(in) :: inFile
+    character(len=*), intent(in) :: inFile
     integer :: iError, iLat
     real :: lat
 
@@ -311,7 +311,7 @@ contains
 
     implicit none
 
-    character(len=nSamiCharLength), intent(in) :: inFile
+    character(len=*), intent(in) :: inFile
     integer :: iError, iAlt
     real :: alt
 
@@ -347,7 +347,7 @@ contains
 
     implicit none
 
-    character(len=nSamiCharLength), intent(in) :: inFile
+    character(len=*), intent(in) :: inFile
     integer, intent(in) :: iTime
     integer :: iError, iT
 

--- a/src/advance_horizontal.f90
+++ b/src/advance_horizontal.f90
@@ -60,6 +60,7 @@ subroutine advance_horizontal(iBlock)
   use ModGITM
   use ModInputs
   use ModSources, only: HorizontalTempSource
+  use ieee_arithmetic
 
   implicit none
 
@@ -381,7 +382,7 @@ subroutine advance_horizontal(iBlock)
       do iLon = 1, nLons
         do iLat = 1, nLats
           do iDir = 1, 3
-            if (isnan(Velocity(iLon, iLat, iAlt, iDir, 1))) &
+            if (ieee_is_nan(Velocity(iLon, iLat, iAlt, iDir, 1))) &
               write(*, *) 'Velocity is nan : ', iLon, iLat, iAlt, iDir
           end do
         end do

--- a/src/aurora.Earth.f90
+++ b/src/aurora.Earth.f90
@@ -184,6 +184,8 @@ subroutine aurora(iBlock)
     call MPI_Bcast(avepower, 1, MPI_Real, 0, iCommGITM, ierror)
 
     call get_hpi(CurrentTime, Hpi, iError)
+    
+    if (avepower == 0) avepower = 1
     ratio = Hpi/avepower
 
     if (iDebugLevel >= 0) then

--- a/src/aurora.Earth.f90
+++ b/src/aurora.Earth.f90
@@ -184,7 +184,7 @@ subroutine aurora(iBlock)
     call MPI_Bcast(avepower, 1, MPI_Real, 0, iCommGITM, ierror)
 
     call get_hpi(CurrentTime, Hpi, iError)
-    
+
     if (avepower == 0) avepower = 1
     ratio = Hpi/avepower
 

--- a/src/calc_chemistry.Earth.f90
+++ b/src/calc_chemistry.Earth.f90
@@ -12,6 +12,7 @@ subroutine calc_chemistry(iBlock)
   use ModInputs, only: &
     iDebugLevel, UseIonChemistry, UseNeutralChemistry, f107, DoCheckForNans
   use ModConstants
+  use ieee_arithmetic
 
   implicit none
 
@@ -2360,7 +2361,7 @@ subroutine calc_chemistry(iBlock)
 
         if (DoCheckForNans) then
           do iNeutral = 1, nSpeciesTotal
-            if (isnan(Neutrals(iNeutral))) then
+            if (ieee_is_nan(Neutrals(iNeutral))) then
               write(*, *) "chemistry : Neutral is nan", iLon, iLat, iAlt, iNeutral
               call stop_gitm("Must stop now.")
             end if

--- a/src/calc_electron_temperature.Earth.f90
+++ b/src/calc_electron_temperature.Earth.f90
@@ -25,6 +25,7 @@ subroutine calc_electron_ion_temperature(iBlock)
   use ModTime
   use ModInputs
   use ModUserGITM
+  use ieee_arithmetic
 
   implicit none
 
@@ -189,22 +190,22 @@ subroutine calc_electron_ion_temperature(iBlock)
 
         if (DoCheckForNans) then
 
-          if (isnan(a(iAlt))) then
+          if (ieee_is_nan(a(iAlt))) then
             write(*, *) "a : ", iLon, iLat, iAlt
             NanFound = .true.
           end if
 
-          if (isnan(b(iAlt))) then
+          if (ieee_is_nan(b(iAlt))) then
             write(*, *) "b : ", iLon, iLat, iAlt
             NanFound = .true.
           end if
 
-          if (isnan(c(iAlt))) then
+          if (ieee_is_nan(c(iAlt))) then
             write(*, *) "c : ", iLon, iLat, iAlt
             NanFound = .true.
           end if
 
-          if (isnan(d(iAlt))) then
+          if (ieee_is_nan(d(iAlt))) then
             write(*, *) "d : ", iLon, iLat, iAlt
             write(*, *) xcoef, tte, eHeatingm(iLon, iLat, iAlt)
             NanFound = .true.
@@ -217,7 +218,7 @@ subroutine calc_electron_ion_temperature(iBlock)
                                         (-2*ilam/hcoef*(zu + zl) + fcoef*(zu**2 - zl**2))*tte
 
         if (DoCheckForNans) then
-          if (isnan(eConduction(iLon, iLat, iAlt))) then
+          if (ieee_is_nan(eConduction(iLon, iLat, iAlt))) then
             write(*, *) "eCondu : ", iLon, iLat, iAlt
             NanFound = .true.
           end if
@@ -240,7 +241,7 @@ subroutine calc_electron_ion_temperature(iBlock)
             (zl**2*neu + zu**2*nel)/hcoef
 
           if (DoCheckForNans) then
-            if (isnan(JParaAlt(iLon, iLat))) then
+            if (ieee_is_nan(JParaAlt(iLon, iLat))) then
               write(*, *) "jpar : ", iLon, iLat, iAlt
               NanFound = .true.
             end if
@@ -479,6 +480,7 @@ subroutine calc_electron_ion_sources(iBlock) !,eHeatingp,iHeatingp,eHeatingm,iHe
   use ModUserGITM
   use ModTime
   use ModInputs
+  use ieee_arithmetic
 
   implicit none
   integer, intent(in) :: iBlock
@@ -624,7 +626,7 @@ subroutine calc_electron_ion_sources(iBlock) !,eHeatingp,iHeatingp,eHeatingm,iHe
     do iLon = 1, nLons
       do iLat = 1, nLats
         do iAlt = 1, nAlts
-          if (isnan(Qphe(iLon, iLat, iAlt))) then
+          if (ieee_is_nan(Qphe(iLon, iLat, iAlt))) then
             write(*, *) iLon, iLat, iAlt
             write(*, *) 'x : ', x(iLon, iLat, iAlt)
             write(*, *) 'ne : ', ne(iLon, iLat, iAlt)
@@ -1252,19 +1254,19 @@ subroutine calc_electron_ion_sources(iBlock) !,eHeatingp,iHeatingp,eHeatingm,iHe
     do iLon = 1, nLons
       do iLat = 1, nLats
         do iAlt = 1, nAlts
-          if (isnan(qphe(iLon, iLat, iAlt))) call stop_gitm('qphe')
-          if (isnan(Qencm(iLon, iLat, iAlt))) call stop_gitm('Qencm')
-          if (isnan(Qeicm(iLon, iLat, iAlt))) call stop_gitm('Qeicm')
-          if (isnan(Qrotm(iLon, iLat, iAlt))) call stop_gitm('Qrotm')
-          if (isnan(Qf(iLon, iLat, iAlt))) call stop_gitm('Qf')
-          if (isnan(Qexc(iLon, iLat, iAlt))) call stop_gitm('Qexc')
-          if (isnan(Qvib_o2(iLon, iLat, iAlt))) call stop_gitm('Qvib_o2')
-          if (isnan(Qvib_n2(iLon, iLat, iAlt))) call stop_gitm('Qvib_n2')
-          if (isnan(Qaurora(iLon, iLat, iAlt))) call stop_gitm('Qaurora')
-          if (isnan(QprecipIon(iLon, iLat, iAlt))) call stop_gitm('QprecipIon')
-          if (isnan(Qenc_v(iLon, iLat, iAlt))) call stop_gitm('Qenc_v')
-          if (isnan(Qeic_v(iLon, iLat, iAlt))) call stop_gitm('Qeic_v')
-          if (isnan(Qeconhm(iLon, iLat, iAlt))) call stop_gitm('Qeconhm')
+          if (ieee_is_nan(qphe(iLon, iLat, iAlt))) call stop_gitm('qphe')
+          if (ieee_is_nan(Qencm(iLon, iLat, iAlt))) call stop_gitm('Qencm')
+          if (ieee_is_nan(Qeicm(iLon, iLat, iAlt))) call stop_gitm('Qeicm')
+          if (ieee_is_nan(Qrotm(iLon, iLat, iAlt))) call stop_gitm('Qrotm')
+          if (ieee_is_nan(Qf(iLon, iLat, iAlt))) call stop_gitm('Qf')
+          if (ieee_is_nan(Qexc(iLon, iLat, iAlt))) call stop_gitm('Qexc')
+          if (ieee_is_nan(Qvib_o2(iLon, iLat, iAlt))) call stop_gitm('Qvib_o2')
+          if (ieee_is_nan(Qvib_n2(iLon, iLat, iAlt))) call stop_gitm('Qvib_n2')
+          if (ieee_is_nan(Qaurora(iLon, iLat, iAlt))) call stop_gitm('Qaurora')
+          if (ieee_is_nan(QprecipIon(iLon, iLat, iAlt))) call stop_gitm('QprecipIon')
+          if (ieee_is_nan(Qenc_v(iLon, iLat, iAlt))) call stop_gitm('Qenc_v')
+          if (ieee_is_nan(Qeic_v(iLon, iLat, iAlt))) call stop_gitm('Qeic_v')
+          if (ieee_is_nan(Qeconhm(iLon, iLat, iAlt))) call stop_gitm('Qeconhm')
         end do
       end do
     end do

--- a/src/calc_euv.f90
+++ b/src/calc_euv.f90
@@ -844,7 +844,7 @@ subroutine Set_Euv(iError, StartTime, EndTime)
 
   inquire(file=cEUVFile, EXIST=IsThere)
   if (.not. IsThere) &
-    call stop_gitm(cEUVFile//" cannot be found by read_inputs")
+    call stop_gitm(trim(cEUVFile)//" cannot be found by read_inputs")
 
   open(unit=iInputUnit_, file=cEUVFile, status="old", IOSTAT=iError)
 

--- a/src/calc_neutral_friction.f90
+++ b/src/calc_neutral_friction.f90
@@ -8,6 +8,7 @@ subroutine calc_neutral_friction(DtIn, oVel, EddyCoef_1d, NDensity_1d, NDensityS
   use ModSources
   use ModPlanet, only: Diff0, DiffExp, IsEarth
   use ModInputs, only: UseNeutralFriction, DoCheckForNans
+  use ieee_arithmetic
 
   implicit none
 
@@ -64,9 +65,9 @@ subroutine calc_neutral_friction(DtIn, oVel, EddyCoef_1d, NDensity_1d, NDensityS
         if (jSpecies == iSpecies) cycle
 
         if (DoCheckForNans) then
-          if (isnan(Temp(iAlt))) write(*, *) "Friction : Temp is nan", iAlt
-          if (isnan(NDensity_1d(iAlt))) write(*, *) "Friction : NDen is nan", iAlt
-          if (isnan(NDensityS_1d(iAlt, jSpecies))) write(*, *) "Friction : NDenS is nan", iAlt, jSpecies
+          if (ieee_is_nan(Temp(iAlt))) write(*, *) "Friction : Temp is nan", iAlt
+          if (ieee_is_nan(NDensity_1d(iAlt))) write(*, *) "Friction : NDen is nan", iAlt
+          if (ieee_is_nan(NDensityS_1d(iAlt, jSpecies))) write(*, *) "Friction : NDenS is nan", iAlt, jSpecies
         end if
 
         ! TempDij are the Dij binary coefficients

--- a/src/check_for_nans.f90
+++ b/src/check_for_nans.f90
@@ -7,7 +7,7 @@ subroutine check_for_nans_ions(cMarker)
   use ModGITM
   use ModPlanet
   use ieee_arithmetic
-  
+
   implicit none
 
   character(LEN=*), intent(in) :: cMarker

--- a/src/check_for_nans.f90
+++ b/src/check_for_nans.f90
@@ -6,7 +6,8 @@ subroutine check_for_nans_ions(cMarker)
   use ModSizeGitm
   use ModGITM
   use ModPlanet
-
+  use ieee_arithmetic
+  
   implicit none
 
   character(LEN=*), intent(in) :: cMarker
@@ -18,7 +19,7 @@ subroutine check_for_nans_ions(cMarker)
     do iLat = -1, nLats + 2
       do iAlt = -1, nAlts + 2
         do iIon = 1, nIons
-          if (isnan(iDensityS(iLon, iLat, iAlt, iIon, 1))) then
+          if (ieee_is_nan(iDensityS(iLon, iLat, iAlt, iIon, 1))) then
             write(*, *) 'Nan found in iDensityS : '
             write(*, *) cMarker
             write(*, *) iLon, iLat, iAlt, iProc, iIon
@@ -44,6 +45,7 @@ subroutine check_for_nans_neutrals(cMarker)
   use ModSizeGitm
   use ModGITM
   use ModPlanet
+  use ieee_arithmetic
 
   implicit none
 
@@ -56,7 +58,7 @@ subroutine check_for_nans_neutrals(cMarker)
     do iLat = -1, nLats + 2
       do iAlt = -1, nAlts + 2
         do iNeu = 1, nSpecies
-          if (isnan(nDensityS(iLon, iLat, iAlt, iNeu, 1))) then
+          if (ieee_is_nan(nDensityS(iLon, iLat, iAlt, iNeu, 1))) then
             write(*, *) 'Nan found in nDensityS : '
             write(*, *) cMarker
             write(*, *) iLon, iLat, iAlt, iProc, iNeu
@@ -82,6 +84,7 @@ subroutine check_for_nans_temps(cMarker)
   use ModSizeGitm
   use ModGITM
   use ModPlanet
+  use ieee_arithmetic
 
   implicit none
 
@@ -93,19 +96,19 @@ subroutine check_for_nans_temps(cMarker)
   do iLon = -1, nLons + 2
     do iLat = -1, nLats + 2
       do iAlt = -1, nAlts + 2
-        if (isnan(Temperature(iLon, iLat, iAlt, 1))) then
+        if (ieee_is_nan(Temperature(iLon, iLat, iAlt, 1))) then
           write(*, *) 'Nan found in Temperature : '
           write(*, *) cMarker
           write(*, *) iLon, iLat, iAlt, iProc
           IsFound = .true.
         end if
-        if (isnan(iTemperature(iLon, iLat, iAlt, 1))) then
+        if (ieee_is_nan(iTemperature(iLon, iLat, iAlt, 1))) then
           write(*, *) 'Nan found in iTemperature : '
           write(*, *) cMarker
           write(*, *) iLon, iLat, iAlt, iProc
           IsFound = .true.
         end if
-        if (isnan(eTemperature(iLon, iLat, iAlt, 1))) then
+        if (ieee_is_nan(eTemperature(iLon, iLat, iAlt, 1))) then
           write(*, *) 'Nan found in eTemperature : '
           write(*, *) cMarker
           write(*, *) iLon, iLat, iAlt, iProc

--- a/src/get_potential.f90
+++ b/src/get_potential.f90
@@ -335,10 +335,8 @@ subroutine get_potential(iBlock)
     call init_get_potential
     call UA_SetnMLTs(nLons + 4)
     call UA_SetnLats(nLats + 4)
-    if (.not. IsFramework) then
-      call IO_SetTime(CurrentTime)
-      call set_indices
-    end if
+    call IO_SetTime(CurrentTime)
+    call set_indices
     call UA_SetNorth
 
     call report("Getting Potential", 1)

--- a/src/init_mpi_w_sami.f90
+++ b/src/init_mpi_w_sami.f90
@@ -42,7 +42,7 @@ subroutine init_mpi_coup
 
   inquire(file=cInputFile, EXIST=IsThere)
   if (.not. IsThere) &
-    call stop_gitm(cInputFile//" cannot be found by read_inputs")
+    call stop_gitm(trim(cInputFile)//" cannot be found by read_inputs")
 
   open(iInputUnit_, file=cInputFile, status="old")
 

--- a/src/initialize.f90
+++ b/src/initialize.f90
@@ -442,7 +442,8 @@ subroutine initialize_gitm(TimeIn)
   call calc_pressure
 
   ! The iLon and iLat are dummy variables...
-  call UA_calc_electrodynamics(iLon, iLat)
+  ! Do not initialize GITM's electrodynamics yet within SWMF
+  if (.not. IsFramework) call UA_calc_electrodynamics(iLon, iLat)
 
   do iBlock = 1, nBlocks
     call calc_eddy_diffusion_coefficient(iBlock)

--- a/src/read_inputs.f90
+++ b/src/read_inputs.f90
@@ -22,7 +22,7 @@ subroutine read_inputs(cFile)
 
     inquire(file=cFile, EXIST=IsThere)
     if (.not. IsThere) &
-      call stop_gitm(cFile//" cannot be found by read_inputs")
+      call stop_gitm(trim(cFile)//" cannot be found by read_inputs")
 
     open(iInputUnit_, file=cFile, status="old")
 

--- a/src/set_vertical_bcs.Earth.f90
+++ b/src/set_vertical_bcs.Earth.f90
@@ -25,6 +25,7 @@ subroutine set_vertical_bcs(LogRho, LogNS, Vel_GD, Temp, LogINS, iVel, VertVel)
   use ModTides, only: TidesNorth, TidesEast, TidesTemp, TidesRhoRat
 
   use EUA_ModMsis90, ONLY: meter6
+  use ieee_arithmetic
 
   implicit none
 

--- a/src/time_routines.f90
+++ b/src/time_routines.f90
@@ -58,7 +58,7 @@ integer function jday(year, mon, day) result(Julian_Day)
   dayofmon(11) = 30
   dayofmon(12) = 31
 
-  if (mod(year, 4) .eq. 0) dayofmon(2) = dayofmon(1) + 1
+  if (mod(year, 4) .eq. 0) dayofmon(2) = dayofmon(2) + 1
   Julian_Day = 0
   do i = 1, mon - 1
     Julian_Day = Julian_Day + dayofmon(i)

--- a/srcGlow/Makefile
+++ b/srcGlow/Makefile
@@ -1,6 +1,6 @@
 include ../Makefile.def
-include ../Makefile.conf
-#include ./Makefile.DEPEND
+include ../srcMake/Makefile.conf
+-include ./Makefile.DEPEND
 #include ./Makefile.RULES
 
 MODULES = Mod_GLOW.o\
@@ -52,10 +52,10 @@ ${MY_LIB}: ${MF} ${MODULES} ${OBJECTS}
 $OBJECTS: $MODULES
 
 
-#DEPEND:
-#	../share/Scripts/depend.pl ./ ../src/ ../share/Library/src/ ${OBJECTS} ${MODULES}
+DEPEND:
+	@perl ${SCRIPTDIR}/depend.pl  ./ ../src/ ../share/Library/src/ ${OBJECTS} ${MODULES}
 
-#GLOW: DEPEND
+GLOW: DEPEND
 	 @make ${EXE}
 #
 #

--- a/srcInterface/Makefile
+++ b/srcInterface/Makefile
@@ -5,7 +5,7 @@ SHELL =/bin/sh
 
 include ../Makefile.def
 include ../Makefile.conf
-include Makefile.DEPEND
+-include Makefile.DEPEND
 
 # Configurable objects
 

--- a/srcSphereAB/Makefile
+++ b/srcSphereAB/Makefile
@@ -1,7 +1,7 @@
 SHELL = /bin/sh
 
 include ../srcMake/Makefile.conf
-
+-include ./Makefile.DEPEND
 #
 #  Makefile for AB2D code:
 #
@@ -25,6 +25,8 @@ libSphere.a:      ${MF} ${MODULES} ${OBJECTS}
 	@echo 'Creating libSphere library'
 	${AR} libSphere.a ${MODULES} ${OBJECTS}
 
+DEPEND:
+	@perl ${SCRIPTDIR}/depend.pl  ./ ../src/ ../share/Library/src/ ${OBJECTS} ${MODULES}
 
 exposed_objects: AB_module.o AB_XFER_module.o AB_ERROR_module.o \
 	         AB_XFER_array_util.o AB_XFER_1blk_util.o AB_SPH_module.o

--- a/srcTests/auto_test/UAM.in.02.test
+++ b/srcTests/auto_test/UAM.in.02.test
@@ -97,7 +97,7 @@ DataIn/ae_20021221.txt
 none              onset time delay file
 
 This is for OVATION-PRIME:
---#NEWELLAURORA
+#NEWELLAURORA
 T                 Use Newell Ovation model of the aurora
 T                 UseNewellAveraged (logical)
 T                 UseNewellMono (logical)
@@ -125,12 +125,6 @@ T		iskappa
 F		If ions are included in the AMIE file, use them. FangEnergy=T!
 
 ------------ E-Field Drivers ------------
-
-#SOLARWIND
-0.0		IMF Bx
-0.0		IMF By
--2.0		IMF Bz
-400.0		Solar wind Vx
 
 This is for amie-like inputs:
 #AMIEFILES
@@ -207,7 +201,7 @@ This stuff is standard for Earth
 #ALTITUDE
 100.0		minimum altitude to use
 600.0		maximum altitude to use (ignored unless the following is F)
-T		use stretched grid
+F		use stretched grid
 
 #INITIAL
 T		initialize thermosphere using MSIS

--- a/srcTests/auto_test/UAM.in.05.test
+++ b/srcTests/auto_test/UAM.in.05.test
@@ -1,0 +1,104 @@
+
+#DEBUG
+0		debug level (0 = no info, 10 = max info)
+0		cpu to watch
+60.0		dt between normal code output to stdout
+T		usebarriers - forces the code to stop and wait more often
+
+--------------------------------------------------------------------------
+Gitm can stop and start again:
+  - Writes files to UA/restartOUT
+  - Reads files from UA/restartIN
+  - Can mv out and link to that directory
+
+#RESTART
+F		Restart Code
+
+--------------------------------------------------------------------------
+start and end times:
+  - don't change start time on restart (code will set correct time!)
+
+#TIMESTART
+2002		year
+12		month
+21		day
+00		hour
+00		minute
+00		second
+
+#TIMEEND
+2002		year
+12		month
+21		day
+00		hour
+05		minute
+00		second
+
+--------------------------------------------------------------------------
+Set blocks in lon and lat. 
+  - total cells in a direction = nBlocks x nCells (set in ModSize)
+  - res = (max - min) / num cells
+
+#NANCHECK
+T
+
+#GRID
+2		number of blocks in longitude
+2		number of blocks in latitude
+-90.0		minimum latitude to model
+90.0		maximum latitude to model
+0.0		longitude start to model (set to 0.0 for whole Earth)
+0.0             longitude end to model (set to 0.0 for whole Earth)
+
+--------------------------------------------------------------------------
+Output file stuff
+
+#LOGFILE
+1.0		dt for output to a log file
+
+#SAVEPLOTS
+7200.0		dt for writing restart files
+1		how many output files do you want
+3DALL		second output style
+300.0		dt for output (1 every 5 min)
+
+
+--------------------------------------------------------------------------
+Specify Drivers:
+
+------------ Solar Drivers ------------
+
+
+#NGDC_INDICES
+UA/DataIn/f107.txt
+
+(All false below is new model of EUV!)
+#EUVMODEL
+F			UseEUVAC
+F			UseTobiska
+F			UseAboveHigh
+F			UseBelowLow
+
+------------ Auroral Drivers ------------
+
+#MHD_INDICES
+DataIn/imf20021221.dat
+
+#NOAAHPI_INDICES
+DataIn/power.test.rcmr_quick
+
+#STATISTICALMODELSONLY
+T		if you want to run with msis and iri only (i.e. not GITM)
+150.0		time step to take if you run with msis and iri
+
+
+#ALTITUDE
+100.0		minimum altitude to use
+600.0		maximum altitude to use (ignored unless the following is F)
+T		use stretched grid
+
+#INITIAL
+T		initialize thermosphere using MSIS
+T		initialize ionosphere using IRI
+
+#END

--- a/util/DATAREAD/srcIndices/IO_set_inputs.f90
+++ b/util/DATAREAD/srcIndices/IO_set_inputs.f90
@@ -7,7 +7,7 @@ subroutine IO_set_inputs(StringInputLines)
 
   implicit none
 
-  character(len=iCharLenIndices_), dimension(*), intent(in) :: StringInputLines
+  character(len=*), dimension(*), intent(in) :: StringInputLines
   character(len=iCharLenIndices_) :: StringLine
   logical :: IsDone
   integer :: iLine

--- a/util/DATAREAD/srcIndices/indices_set_inputs.f90
+++ b/util/DATAREAD/srcIndices/indices_set_inputs.f90
@@ -7,7 +7,7 @@ subroutine indices_set_inputs(StringInputLines)
 
   implicit none
 
-  character(len=iCharLenIndices_), dimension(*), intent(in) :: StringInputLines
+  character(len=*), dimension(*), intent(in) :: StringInputLines
   character(len=iCharLenIndices_) :: StringLine
   logical :: IsDone
   integer :: iLine

--- a/util/EMPIRICAL/srcIE/AMIE_Library.f90
+++ b/util/EMPIRICAL/srcIE/AMIE_Library.f90
@@ -5,7 +5,7 @@
 subroutine AMIE_SetFileName(cFileNameIn)
   use ModAMIE_Interface
   implicit none
-  character(len=iCharLenIE_), intent(in) :: cFileNameIn
+  character(len=*), intent(in) :: cFileNameIn
   AMIE_FileName = cFileNameIn
 end subroutine AMIE_SetFileName
 

--- a/util/EMPIRICAL/srcIE/ED_ReadIonHeat.f90
+++ b/util/EMPIRICAL/srcIE/ED_ReadIonHeat.f90
@@ -13,7 +13,7 @@ subroutine ReadIonHeat(filename, IsIonizationFile)
 
   implicit none
 
-  character(len=iCharLenIE_), intent(in) :: filename
+  character(len=*), intent(in) :: filename
   logical, intent(in)             :: IsIonizationFile
 
   integer ::            ilng, jlat, kalt, i

--- a/util/EMPIRICAL/srcIE/MHD_Library.f90
+++ b/util/EMPIRICAL/srcIE/MHD_Library.f90
@@ -6,7 +6,7 @@ subroutine MHD_SetFileName(cFileNameIn)
   use ModMHD_Interface
   use ModCharSize
   implicit none
-  character(len=iCharLenIE_), intent(in) :: cFileNameIn
+  character(len=*), intent(in) :: cFileNameIn
   MHD_FileName = cFileNameIn
 end subroutine MHD_SetFileName
 

--- a/util/EMPIRICAL/srcIE/ModAMIE_Interface.f90
+++ b/util/EMPIRICAL/srcIE/ModAMIE_Interface.f90
@@ -175,7 +175,7 @@ contains
 
     integer, parameter :: nFieldsMax = 100
     integer, intent(in) :: nFields
-    character(len=30), dimension(nFieldsMax), intent(in) :: Fields
+    character(len=*), dimension(nFieldsMax), intent(in) :: Fields
 
     integer :: iField, iVal
     do iVal = 1, nValues

--- a/util/EMPIRICAL/srcIE/readAMIEoutput.f90
+++ b/util/EMPIRICAL/srcIE/readAMIEoutput.f90
@@ -6,7 +6,7 @@ subroutine readAMIEvariables(AmieFile, nVars, varNames, iDebugLevel)
   use ModCharSize
   implicit none
   integer, parameter :: nFieldsMax = 100
-  character(len=iCharLenIE_), intent(in) :: AmieFile
+  character(len=*), intent(in) :: AmieFile
   integer, intent(out) :: nVars
   character(len=30), dimension(nFieldsMax), intent(out) :: varNames
   integer, intent(in) :: iDebugLevel


### PR DESCRIPTION
# [BUG/FEAT/DOC/] Squashing bugs related to SWMF coupling

Bug extermination continues... Some of these are just related to SWMF coupling, some are also in GITM.  Fixes some of issue #14 , but all of #12 (I hope)  and #11 . 

## Changes to GITM outputs

Small, if at all. Most likely there will not be any change. If outputs *are* changed, the new versions should be more correct.

---

## Summary of changes:


- First, IDK why there are a few commits here that were in a previous pull request. That's weird. Maybe we need to delete branches (or sync them) before continuing, after making a pull request?
- Errors in GITM initializing withing SWMF:
  - HPI (avepower) was zero at the 0th time-step, before being passed anything from SWMF. Fixed in ec6777d.
  - calc_electrodynamics called things incorrectly in initialize.f90 within SWMF. Skipping the call when inside SWMF (`IsFrameWork`) was done in d9ce4e4 & eliminated a lot of error messages.
- Character lengths aren't specified in *most* `intent(in)` variables. Might save some headache later
- isnan() is replaced by ieee_is_nan(), at the request of the Nag compiler.
- Parallel compilation is now doable. 4796620 adds instructions to create a dependency graph.
- Then some style things too, for good measure. 


Nothing too serious, but fixes a lot of headaches (and errors) with SWMF stuff.