### PR TITLE
Indices bug v2

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,6 +40,7 @@ src/libEMPIRICALUA.a
 src/libINDICES.a
 src/libSHARE.a
 src/output.f90
+src/overwrite.f90
 src/planet.f90
 src/set_vertical_bcs.f90
 srcData/UAM.in

--- a/src/calc_euv.f90
+++ b/src/calc_euv.f90
@@ -518,6 +518,10 @@ subroutine calc_scaled_euv
 
     call Set_Euv(iError, CurrentTime, EndTime)
 
+    if (iError /= 0) then
+      call stop_gitm("Stopping in euv_ionization_heat. Error in EUV data. Check times!")
+    endif
+
     do N = 1, Num_WaveLengths_High
       wvavg(N) = (WAVEL(N) + WAVES(N))/2.
     end do
@@ -914,6 +918,7 @@ subroutine Set_Euv(iError, StartTime, EndTime)
   nSeeTimes = iline - 1
 
   if (nSeeTimes > 2) iError = 0
+  if (nSeeTimes < 1) iError = 1
 
 end subroutine Set_Euv
 

--- a/src/calc_euv.f90
+++ b/src/calc_euv.f90
@@ -520,7 +520,7 @@ subroutine calc_scaled_euv
 
     if (iError /= 0) then
       call stop_gitm("Stopping in euv_ionization_heat. Error in EUV data. Check times!")
-    endif
+    end if
 
     do N = 1, Num_WaveLengths_High
       wvavg(N) = (WAVEL(N) + WAVES(N))/2.

--- a/src/read_MHDIMF_Indices_new.f90
+++ b/src/read_MHDIMF_Indices_new.f90
@@ -188,5 +188,10 @@ subroutine read_MHDIMF_Indices_new(iOutputError, StartTime, EndTime)
   nIndices_V(sw_n_) = iSW - 2
   nIndices_V(sw_t_) = iSW - 2
 
+  ! If we have gotten to this point and we have no data, 
+  ! there is something wrong!
+  if (nIndices_V(imf_bz_) < 2) iOutputError = 1
+  if (nIndices_V(sw_v_) < 2) iOutputError = 1
+
 end subroutine read_MHDIMF_Indices_new
 

--- a/src/read_MHDIMF_Indices_new.f90
+++ b/src/read_MHDIMF_Indices_new.f90
@@ -188,7 +188,7 @@ subroutine read_MHDIMF_Indices_new(iOutputError, StartTime, EndTime)
   nIndices_V(sw_n_) = iSW - 2
   nIndices_V(sw_t_) = iSW - 2
 
-  ! If we have gotten to this point and we have no data, 
+  ! If we have gotten to this point and we have no data,
   ! there is something wrong!
   if (nIndices_V(imf_bz_) < 2) iOutputError = 1
   if (nIndices_V(sw_v_) < 2) iOutputError = 1

--- a/src/read_sme.f90
+++ b/src/read_sme.f90
@@ -124,6 +124,10 @@ subroutine read_al_onset_list(iOutputError, StartTime, EndTime)
   nIndices_V(onsetmlat_) = iAE - 1
   nIndices_V(onsetmlt_) = iAE - 1
 
+  ! If we have gotten to this point and we have no data, 
+  ! there is something wrong!
+  if (iAE < 2) iOutputError = 1
+
 end subroutine read_al_onset_list
 
 !==============================================================================
@@ -266,6 +270,10 @@ subroutine read_sme(iOutputError, StartTime, EndTime, doUseAeForHp)
   nIndices_V(ae_) = iAE - 2
   nIndices_V(au_) = iAE - 2
   nIndices_V(al_) = iAE - 2
+
+  ! If we have gotten to this point and we have no data, 
+  ! there is something wrong!
+  if (nIndices_V(ae_) < 2) iOutputError = 1
 
 end subroutine read_sme
 

--- a/src/read_sme.f90
+++ b/src/read_sme.f90
@@ -124,7 +124,7 @@ subroutine read_al_onset_list(iOutputError, StartTime, EndTime)
   nIndices_V(onsetmlat_) = iAE - 1
   nIndices_V(onsetmlt_) = iAE - 1
 
-  ! If we have gotten to this point and we have no data, 
+  ! If we have gotten to this point and we have no data,
   ! there is something wrong!
   if (iAE < 2) iOutputError = 1
 
@@ -271,7 +271,7 @@ subroutine read_sme(iOutputError, StartTime, EndTime, doUseAeForHp)
   nIndices_V(au_) = iAE - 2
   nIndices_V(al_) = iAE - 2
 
-  ! If we have gotten to this point and we have no data, 
+  ! If we have gotten to this point and we have no data,
   ! there is something wrong!
   if (nIndices_V(ae_) < 2) iOutputError = 1
 

--- a/src/set_inputs.f90
+++ b/src/set_inputs.f90
@@ -1837,7 +1837,7 @@ subroutine set_inputs
           else
             UseVariableInputs = .true.
           end if
-        endif
+        end if
 
       case ("#ACE_DATA")
         cTempLines(1) = cLine

--- a/util/DATAREAD/srcIndices/indices_library.f90
+++ b/util/DATAREAD/srcIndices/indices_library.f90
@@ -4,33 +4,33 @@
 ! ---------------------------------------------------
 subroutine check_all_indices(TimeIn, iOutputError)
 
-   use ModIndices
-   implicit none
-   real (Real8_), intent(in)  :: TimeIn
-   integer, intent(out) :: iOutputError
+  use ModIndices
+  implicit none
+  real(Real8_), intent(in)  :: TimeIn
+  integer, intent(out) :: iOutputError
 
-   integer :: iIndex
+  integer :: iIndex
 
-   iOutputError = 0
+  iOutputError = 0
 
-   do iIndex = 1, nIndices
-      ! If there are 0 times, then no error, since there are no values
-      ! If there is 1 time, then it is a constant
-      ! If there are 2 or more times, check for boundaries
-      if (nIndices_V(iIndex) > 1) then
-         if ((IndexTimes_TV(1, iIndex) - TimeIn) > &
-            5.0 * (IndexTimes_TV(2, iIndex) - IndexTimes_TV(1, iIndex))) then
-            iOutputError = 3
-         endif
+  do iIndex = 1, nIndices
+    ! If there are 0 times, then no error, since there are no values
+    ! If there is 1 time, then it is a constant
+    ! If there are 2 or more times, check for boundaries
+    if (nIndices_V(iIndex) > 1) then
+      if ((IndexTimes_TV(1, iIndex) - TimeIn) > &
+          5.0*(IndexTimes_TV(2, iIndex) - IndexTimes_TV(1, iIndex))) then
+        iOutputError = 3
+      end if
 
-         if ((TimeIn - IndexTimes_TV(nIndices_V(iIndex), iIndex)) > &
-            5.0 * (IndexTimes_TV(2, iIndex) - IndexTimes_TV(1, iIndex))) then
-            iOutputError = 3
-         endif
-      endif
-   enddo
+      if ((TimeIn - IndexTimes_TV(nIndices_V(iIndex), iIndex)) > &
+          5.0*(IndexTimes_TV(2, iIndex) - IndexTimes_TV(1, iIndex))) then
+        iOutputError = 3
+      end if
+    end if
+  end do
 
-   return
+  return
 end subroutine check_all_indices
 
 ! ---------------------------------------------------
@@ -215,10 +215,10 @@ subroutine get_index(label_, TimeIn, Interpolate, value, iOutputError)
     value = Indices_TV(1, label_)
     ! We are going to report an error if the delta t is too large (5
     ! * first dt), though:
-    if ((IndexTimes_TV(1,label_) - TimeIn) > &
-         5.0 * (IndexTimes_TV(2, label_) - IndexTimes_TV(1, label_))) then
+    if ((IndexTimes_TV(1, label_) - TimeIn) > &
+        5.0*(IndexTimes_TV(2, label_) - IndexTimes_TV(1, label_))) then
       iOutputError = 3
-    endif    
+    end if
     return
   end if
 
@@ -226,10 +226,10 @@ subroutine get_index(label_, TimeIn, Interpolate, value, iOutputError)
     value = Indices_TV(nIndices_V(label_), label_)
     ! We are going to report an error if the delta t is too large (5
     ! * first dt), though:
-    if ((TimeIn - IndexTimes_TV(nIndices_V(label_),label_)) > &
-         5.0 * (IndexTimes_TV(2, label_) - IndexTimes_TV(1, label_))) then
+    if ((TimeIn - IndexTimes_TV(nIndices_V(label_), label_)) > &
+        5.0*(IndexTimes_TV(2, label_) - IndexTimes_TV(1, label_))) then
       iOutputError = 3
-    endif
+    end if
     return
   end if
 

--- a/util/DATAREAD/srcIndices/indices_library.f90
+++ b/util/DATAREAD/srcIndices/indices_library.f90
@@ -2,6 +2,38 @@
 !  For more information, see http://csem.engin.umich.edu/tools/swmf
 
 ! ---------------------------------------------------
+subroutine check_all_indices(TimeIn, iOutputError)
+
+   use ModIndices
+   implicit none
+   real (Real8_), intent(in)  :: TimeIn
+   integer, intent(out) :: iOutputError
+
+   integer :: iIndex
+
+   iOutputError = 0
+
+   do iIndex = 1, nIndices
+      ! If there are 0 times, then no error, since there are no values
+      ! If there is 1 time, then it is a constant
+      ! If there are 2 or more times, check for boundaries
+      if (nIndices_V(iIndex) > 1) then
+         if ((IndexTimes_TV(1, iIndex) - TimeIn) > &
+            5.0 * (IndexTimes_TV(2, iIndex) - IndexTimes_TV(1, iIndex))) then
+            iOutputError = 3
+         endif
+
+         if ((TimeIn - IndexTimes_TV(nIndices_V(iIndex), iIndex)) > &
+            5.0 * (IndexTimes_TV(2, iIndex) - IndexTimes_TV(1, iIndex))) then
+            iOutputError = 3
+         endif
+      endif
+   enddo
+
+   return
+end subroutine check_all_indices
+
+! ---------------------------------------------------
 
 subroutine indices_set_IMF_Bz_single(BzIn)
 
@@ -181,11 +213,23 @@ subroutine get_index(label_, TimeIn, Interpolate, value, iOutputError)
 
   if (TimeIn <= IndexTimes_TV(1, label_)) then
     value = Indices_TV(1, label_)
+    ! We are going to report an error if the delta t is too large (5
+    ! * first dt), though:
+    if ((IndexTimes_TV(1,label_) - TimeIn) > &
+         5.0 * (IndexTimes_TV(2, label_) - IndexTimes_TV(1, label_))) then
+      iOutputError = 3
+    endif    
     return
   end if
 
   if (TimeIn >= IndexTimes_TV(nIndices_V(label_), label_)) then
     value = Indices_TV(nIndices_V(label_), label_)
+    ! We are going to report an error if the delta t is too large (5
+    ! * first dt), though:
+    if ((TimeIn - IndexTimes_TV(nIndices_V(label_),label_)) > &
+         5.0 * (IndexTimes_TV(2, label_) - IndexTimes_TV(1, label_))) then
+      iOutputError = 3
+    endif
     return
   end if
 


### PR DESCRIPTION
# [BUG/FEAT/DOC/*etc.*] **Description**

The code would happily run if the time requested and the indices did not match up.  The code by default just used the first or last time in the file.

This is not great behavior, since the user probably wasn't aware of this.

Now the code stops if the start time or end time are outside of the times on the indices.  It checks each index individual and reports an error.  It also checks to see if any data was read in for the SME indices, IMF indices, and FISM.

## Justification

The user most likely doesn't want constant values outside of their requested interval.

## Changes to GITM outputs

Shouldn't be any changes, but will stop running if start/end time is outside of indices intervals.

