### PR TITLE
[STY]: Remove spaces in `enddo` and `endif`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -48,11 +48,10 @@ srcGlow/libGLOW.a
 srcGlow/Makefile.DEPEND
 srcInterface/Makefile.DEPEND
 srcSphereAB/libSphere.a
-
-
-# Ignore util and share, and component_(util/share)
-# for SWMF coupling.
-util/
-share/
-component_util/
-component_share/
+util/CRASH/src/Makefile.DEPEND
+util/CRASH/src/Makefile.RULES
+util/DATAREAD/srcIndices/Makefile.DEPEND
+util/EMPIRICAL/srcEE/Makefile.DEPEND
+util/EMPIRICAL/srcIE/Makefile.DEPEND
+util/EMPIRICAL/srcUA/Makefile.RULES
+util/NOMPI/src/Makefile.RULES

--- a/.gitignore
+++ b/.gitignore
@@ -48,6 +48,7 @@ srcGlow/libGLOW.a
 srcGlow/Makefile.DEPEND
 srcInterface/Makefile.DEPEND
 srcSphereAB/libSphere.a
+srcSphereAB/Makefile.DEPEND
 util/CRASH/src/Makefile.DEPEND
 util/CRASH/src/Makefile.RULES
 util/DATAREAD/srcIndices/Makefile.DEPEND

--- a/share/Library/src/CON_axes.f90
+++ b/share/Library/src/CON_axes.f90
@@ -281,7 +281,7 @@ contains
           MagAxisThetaGeo*cRadToDeg, MagAxisPhiGeo*cRadToDeg
         write(*, *) 'DipoleStrengthDefault, DipoleStrengthGeopack=', &
           DipoleStrengthPlanet_I(Earth_), DipoleStrength
-      end if
+      endif
     elseif (.not. UseSetRotAxis) then
       if (UseRealRotAxis .or. UseRealMagAxis) then
         RotAxisTheta = TiltRotation
@@ -292,7 +292,7 @@ contains
           ! This assumes circular orbit that is a crude approximation
           RotAxisPhi = modulo( &
                        cHalfPi - OmegaOrbit*(tStart - TimeEquinox%Time), cTwoPi8)
-        end if
+        endif
         if (DoTestMe) write(*, *) NameSub, &
           ': UseRealRotAxis, UseRealMagAxis, TiltRotation, OmegaOrbit, tStart, tEquinox=', &
           UseRealRotAxis, UseRealMagAxis, TiltRotation*cRadToDeg, OmegaOrbit, tStart, &
@@ -308,15 +308,15 @@ contains
           call CON_stop(NameSub// &
                         ' SWMF_ERROR both rotation and magnetic axes'// &
                         ' are aligned with the other one?!')
-        end if
-      end if
-    end if
+        endif
+      endif
+    endif
 
     if (DoTestMe) then
       write(*, *) 'tStart,TimeEquinox=', tStart, TimeEquinox
       write(*, *) 'RotAxisTheta,RotAxisPhi=', &
         RotAxisTheta*cRadToDeg, RotAxisPhi*cRadToDeg
-    end if
+    endif
 
     ! Using the RotAxisTheta and RotAxisPhi
     ! set the GseGei matrix to convert between GSE and  GEI systems
@@ -331,7 +331,7 @@ contains
         write(*, *) 'MagAxisThetaGeo,MagAxisPhiGeo=', &
           MagAxisThetaGeo*cRadToDeg, MagAxisPhiGeo*cRadToDeg
         write(*, *) 'MagAxisGeo_D=', MagAxis_D
-      end if
+      endif
 
       ! GEO --> GEI
       call set_gei_geo_matrix(0.0)
@@ -351,14 +351,14 @@ contains
         write(*, *) 'MagAxisGse_D=', MagAxis_D
         write(*, *) 'MagAxisTheta,MagAxisPhi=', &
           MagAxisTheta*cRadToDeg, MagAxisPhi*cRadToDeg
-      end if
+      endif
 
     else
       if (.not. UseSetMagAxis) then
         ! Must be aligned with rotational axis
         MagAxisTheta = RotAxisTheta
         MagAxisPhi = RotAxisPhi
-      end if
+      endif
       ! Convert direction to Cartesian coordinates in GSE
       call dir_to_xyz(MagAxisTheta, MagAxisPhi, MagAxis_D)
 
@@ -373,9 +373,9 @@ contains
         write(*, *) 'MagAxisGse_D=', MagAxis_D
         write(*, *) 'MagAxisTheta,MagAxisPhi=', &
           MagAxisTheta*cRadToDeg, MagAxisPhi*cRadToDeg
-      end if
+      endif
 
-    end if
+    endif
 
     if (.not. (UseRealRotAxis .or. UseSetRotAxis) .and. UseRealMagAxis) then
       ! Rotation axis is aligned.
@@ -386,7 +386,7 @@ contains
       ! The "permanent" matrices are also recalculated
       call set_gse_gei_matrix
       call set_gei_geo_matrix(0.0)
-    end if
+    endif
 
     ! Obtain the cartesian components of the rotational axis (in GSE)
     call dir_to_xyz(RotAxisTheta, RotAxisPhi, RotAxis_D)
@@ -403,7 +403,7 @@ contains
     else
       ! Set the magnetic direction in Cartesian GEO coordinates
       call dir_to_xyz(MagAxisThetaGeo, MagAxisPhiGeo, MagAxisGeo_D)
-    end if
+    endif
 
     ! From MagAxisThetaGeo and MagAxisPhiGeo obtain the MAG-GEO matrix
     ! This matrix does not change with simulation time.
@@ -442,7 +442,7 @@ contains
       write(*, *) 'XyzPlanetHgi_D/rSun = ', XyzPlanetHgi_D/rSun
       write(*, *) 'XyzPlanetHgr_D/rSun = ', XyzPlanetHgr_D/rSun
       write(*, *) 'vPlanetHgi_D/(km/s) = ', vPlanetHgi_D/1000.0
-    end if
+    endif
 
     DoInitializeAxes = .false.
 
@@ -518,7 +518,7 @@ contains
         ! Reset dLongitudeHgiDeg to be a valid but negative value
         dLongitudeHgiDeg = dLongitudeHgi*cRadToDeg - 360.0
 
-      end if
+      endif
 
       ! A negative dLongitudeHgr means that the planet should be in
       ! in the -X,Z plane of the rotated HGR system.
@@ -534,7 +534,7 @@ contains
         ! Reset dLongitudeHgrDeg to be a valid but negative value
         dLongitudeHgrDeg = dLongitudeHgr*cRadToDeg - 360.0
 
-      end if
+      endif
 
     end subroutine set_hgi_gse_d_planet
 
@@ -582,7 +582,7 @@ contains
       ! If the planet does not rotate we may take GEI=GEO
       GeiGeo_DD = cUnit_DD
       RETURN
-    end if
+    endif
 
     AlphaEquinox = (TimeSim + tStart - TimeEquinox%Time) &
                    *OmegaPlanet + AngleEquinox
@@ -662,7 +662,7 @@ contains
 
       ! Remember the time
       TimeSimHgr = TimeSim
-    end if
+    endif
 
     ! Check if there is a need to update the magnetic axis
     ! and related transformations
@@ -673,12 +673,12 @@ contains
       ! If DtUpdateB0 is more than 0.001 update if int(time/DtUpdateB0) differ
       if (DtUpdateB0 > 0.001) then
         if (int(TimeSim/DtUpdateB0) == int(TimeSimLast/DtUpdateB0)) RETURN
-      end if
+      endif
 
       ! If DtUpdateB0 is less than 1 msec update unless time is the same
       if (abs(TimeSim - TimeSimLast) < cTiny) RETURN
 
-    end if
+    endif
 
     call CON_set_do_test(NameSub, DoTest, DoTestMe)
 
@@ -687,7 +687,7 @@ contains
         UseAlignedAxes, UseRotation, DoUpdateB0
       write(*, *) NameSub, 'DtUpdateB0,TimeSim,TimeSimLast=', &
         DtUpdateB0, TimeSim, TimeSimLast
-    end if
+    endif
 
     ! Remember the simulation time
     TimeSimLast = TimeSim
@@ -743,7 +743,7 @@ contains
       write(*, *) NameSub, ' new MagAxis_D     =', MagAxis_D
       write(*, *) NameSub, ' new MagAxisTiltGsm=', MagAxisTiltGsm*cRadToDeg
       write(*, *) NameSub, ' new RotAxisGsm_D  =', RotAxisGsm_D
-    end if
+    endif
 
   end subroutine set_axes
 
@@ -811,7 +811,7 @@ contains
     if (TypeCoordIn == TypeCoordOut) then
       Rot_DD = cUnit_DD
       RETURN
-    end if
+    endif
 
     ! Set time dependent information
     call set_axes(TimeSim)
@@ -915,12 +915,12 @@ contains
         if (iFrame /= 1 .and. iFrame /= 2) then
           write(*, *) NameSub, ' ERROR iFrame = ', iFrame
           call CON_stop(NameSub//': invalid value for iFrame = 1 or 2')
-        end if
+        endif
         iFrameOut = iFrame
       else
         ! Default is to provide Omega_D in the output coord. system
         iFrameOut = 1
-      end if
+      endif
     else
       if (NameCoord1(1:1) == 'H') then
         ! For heliocentric coordinate systems set the inertial frame to HGI
@@ -929,22 +929,22 @@ contains
         ! For geocentric systems GSE is assumed to be inertial
         ! Otherwise better use GEI !!!
         NameCoord2 = 'GSE'
-      end if
+      endif
       iFrameOut = 1
-    end if
+    endif
 
     ! Determine the perturbation of time
     if (precision(TimeSim) >= 12) then
       dTimeSim = max(1.0, 1e-10*TimeSim)
     else
       dTimeSim = max(1000.0, 1e-4*TimeSim)
-    end if
+    endif
 
     if (NameCoord1 == NameCoord2) then
       ! Nothing to do
       Omega_D = 0.0
       RETURN
-    end if
+    endif
 
     RotMinus_DD = transform_matrix(TimeSim - dTimeSim, NameCoord1, NameCoord2)
     RotPlus_DD = transform_matrix(TimeSim + dTimeSim, NameCoord1, NameCoord2)
@@ -1014,7 +1014,7 @@ contains
     if (NameCoord1 == NameCoord2) then
       v2_D = v1_D
       RETURN
-    end if
+    endif
 
     if (.not. (TimeSim == TimeSimLast .and. NameCoord1 == NameCoord1Last &
                .and. NameCoord1 == NameCoord2Last)) then
@@ -1050,10 +1050,10 @@ contains
           ! subtract planet speed and flip planet position
           XyzPlanet1_D = -XyzPlanet1_D
           vPlanet1_D = -vPlanet1_D
-        end if
+        endif
 
-      end if
-    end if
+      endif
+    endif
 
     if (IsHelioGeo) then
       ! Velocity with respect to the inertial frame comoving with Frame 1
@@ -1080,7 +1080,7 @@ contains
       ! Transform total velocity to Frame2
       v2_D = matmul(Transform21_DD, v1Total_D)
 
-    end if
+    endif
 
   end function transform_velocity
 
@@ -1107,7 +1107,7 @@ contains
       Epsilon1 = 1e-5
       Epsilon2 = 1e+2
       Epsilon3 = 1e+0
-    end if
+    endif
 
     if (.not. DoInitializeAxes) write(*, *) 'test failed: DoInitializeAxes=', &
       DoInitializeAxes, ' should be true'
@@ -1161,7 +1161,7 @@ contains
       call show_rot_matrix(Rot_DD)
       write(*, *) 'instead of'
       call show_rot_matrix(Result_DD)
-    end if
+    endif
 
     write(*, '(a)') 'Testing show_rot_matrix'
     write(*, '(a)') 'HgiGse_DD(0)='; call show_rot_matrix(HgiGse_DD)

--- a/share/Library/src/CON_geopack.f90
+++ b/share/Library/src/CON_geopack.f90
@@ -86,7 +86,7 @@ contains
     if (iYear < 1901 .or. iYear > 2099) then
       write(*, *) NameSub, ' ERROR: No ephemeris data for the year of ', iYear
       call CON_stop('CON_geopack ERROR')
-    end if
+    endif
     FDAY = dble(IHOUR*3600 + iMIN*60 + ISEC)/86400.E0
     DJ = 365*(IYear - 1900) + (IYear - 1901)/4 + jDAY - 0.5E0 + FDAY
     Century = DJ/36525.0
@@ -179,10 +179,10 @@ contains
           MinYear
         write(*, *) NameSub, ': setting iYear=', MinYear, ' iDay=1'
         DoWarnSmallYear = .false.
-      end if
+      endif
       iYear = MinYear
       iDay = 1
-    end if
+    endif
     if (iYearIn > MaxYear + DnYear) then
       if (DoWarnLargeYear) then
         write(*, *) 'WARNING!!! Update IGRF coefficients in ', NameSub, &
@@ -190,10 +190,10 @@ contains
         write(*, *) NameSub, ': no IGRF coefficients beyond year ', MaxYear
         write(*, *) NameSub, ': setting iYear=', MaxYear + DnYear, ' iDay=365'
         DoWarnLargeYear = .false.
-      end if
+      endif
       iYear = MaxYear + DnYear
       iDay = 365
-    end if
+    endif
 
     ! No need to recalculate if the call uses the same values as last time
     if (iYear == iYearLast .and. iDay == iDayLast) RETURN

--- a/share/Library/src/CON_line_extract.f90
+++ b/share/Library/src/CON_line_extract.f90
@@ -108,7 +108,7 @@ contains
         OldState_VI(:, 1:nPoint)           ! copy old values
       deallocate(OldState_VI)                ! free old storage
       MaxPoint = MaxPointIn                  ! change buffer size
-    end if
+    endif
 
   end subroutine line_extend
 
@@ -132,7 +132,7 @@ contains
     if (nVarIn /= nVar) then
       write(*, *) NameSub, ' ERROR: nVarIn, nVar=', nVarIn, nVar
       call CON_stop(NameSub//' ERROR: incorrect number of variables!')
-    end if
+    endif
 
     if (nPoint >= MaxPoint) call line_extend(nPoint + 100)
     nPoint = nPoint + 1
@@ -176,14 +176,14 @@ contains
       if (iProc == iProcFrom .and. iProc == iProcTo) then
         nPoint_P(iProcFrom) = nPoint
         CYCLE
-      end if
+      endif
 
       if (iProc == iProcFrom) call MPI_SEND(nPoint, &
                                             1, MPI_INTEGER, iProcTo, iTag, iComm, iError)
 
       if (iProc == iProcTo) call MPI_RECV(nPoint_P(iProcFrom), &
                                           1, MPI_INTEGER, iProcFrom, iTag, iComm, Status_I, iError)
-    end do
+    enddo
 
     ! Extend buffer on receiving processor
     if (iProc == iProcTo) call line_extend(sum(nPoint_P) + 100)
@@ -199,7 +199,7 @@ contains
                       iProcTo, iTag, iComm, iError)
         deallocate(State_VI)
         nPoint = 0
-      end if
+      endif
 
       ! Receive ray line data
       if (iProc == iProcTo .and. nPoint_P(iProcFrom) > 0) then
@@ -207,9 +207,9 @@ contains
                       nPoint_P(iProcFrom)*(nVar + 1), MPI_REAL, &
                       iProcFrom, iTag, iComm, Status_I, iError)
         nPoint = nPoint + nPoint_P(iProcFrom)
-      end if
+      endif
 
-    end do
+    enddo
 
     deallocate(nPoint_P)
 
@@ -258,7 +258,7 @@ contains
       nVarOut = nVar
       nPointOUt = nPoint
       RETURN
-    end if
+    endif
 
     ! Check size
     if (nVar /= nVarOut .or. nPoint /= nPointOut) then
@@ -267,7 +267,7 @@ contains
       write(*, *) NameSub, ' ERROR: nPoint, nPointOut=', &
         nPoint, nPointOut
       call CON_stop(NameSub//' ERROR: incorrect array size')
-    end if
+    endif
     if (present(DoSort)) then
       if (DoSort) then
         allocate(iSorted_I(nPoint))
@@ -282,10 +282,10 @@ contains
         deallocate(iSorted_I)
       else
         Line_VI(:, 1:nPoint) = State_VI(:, 1:nPoint)
-      end if
+      endif
     else
       Line_VI(:, 1:nPoint) = State_VI(:, 1:nPoint)
-    end if
+    endif
 
     nPoint = 0
 
@@ -339,7 +339,7 @@ contains
               30.0*iPoint + iProc/))) &
         write(*, *) NameSub, ' line_put failed, iProc=', iProc, &
         ' iPoint=', iPoint, ' State_VI=', State_VI(:, iPoint)
-    end do
+    enddo
 
     if (iProc == 0) write(*, '(a)') 'Testing line_collect'
     call line_collect(MPI_COMM_WORLD, 0)
@@ -359,7 +359,7 @@ contains
         write(*, *) NameSub, ' line_collect failed, iProc=', iProc, &
         ' MaxPoint =', MaxPoint, ' should be 100'
 
-    end if
+    endif
 
     if (iProc == 0) then
       write(*, '(a)') 'Testing line_get on PE 0'
@@ -380,7 +380,7 @@ contains
           Index = 1.0
         else
           Index = 2.0
-        end if
+        endif
         if (Result_VI(0, iPoint) /= Index) &
           write(*, *) NameSub, ' line_get failed at iPoint=', iPoint, &
           ' Index=', Result_VI(0, iPoint), ' should be ', Index
@@ -390,7 +390,7 @@ contains
           Length = iPoint - 1.0
         else
           Length = 2.0*(iPoint - 2*nProc - 1)
-        end if
+        endif
         if (Result_VI(1, iPoint) /= real(Length)) &
           write(*, *) NameSub, ' line_get failed at iPoint=', iPoint, &
           ' Length=', Result_VI(1, iPoint), ' should be ', Length
@@ -402,17 +402,17 @@ contains
             State_V = (/10.0 + iProcFrom, 20.0 + iProcFrom, 30.0 + iProcFrom/)
           else
             State_V = (/40.0 + iProcFrom, 50.0 + iProcFrom, 60.0 + iProcFrom/)
-          end if
+          endif
         else
           iProcFrom = nint(Length/2.0)
           State_V = (/70.0 + iProcFrom, 80.0 + iProcFrom, 90.0 + iProcFrom/)
-        end if
+        endif
         if (any(Result_VI(2:nVar, iPoint) /= State_V)) &
           write(*, *) NameSub, ' line_get failed at iPoint=', iPoint, &
           ' State = ', Result_VI(2:nVar, iPoint), ' should be ', State_V
 
-      end do
-    end if
+      enddo
+    endif
 
     if (iProc == 0) write(*, '(a)') 'Testing line_clean'
     call line_clean

--- a/share/Library/src/CON_planet.f90
+++ b/share/Library/src/CON_planet.f90
@@ -162,7 +162,7 @@ contains
       call CON_stop(NameSub// &
                     ' ERROR: attempt to change planet name from '// &
                     trim(NamePlanet)//' to '//NamePlanetIn)
-    end if
+    endif
 
     NamePlanet = NamePlanetIn
     IsInitialized = .true.
@@ -173,13 +173,13 @@ contains
         IsKnown = .true.
         Planet_ = i
         EXIT
-      end if
-    end do
+      endif
+    enddo
 
     if (.not. IsKnown) then
       Planet_ = NewPlanet_
       NamePlanet = NamePlanetIN
-    end if
+    endif
 
     ! Set all values for the selected planet
     RadiusPlanet = rPlanet_I(Planet_)
@@ -191,12 +191,12 @@ contains
       OmegaRotation = 0.0
     else
       OmegaRotation = cTwoPi/RotationPeriodPlanet_I(Planet_)
-    end if
+    endif
     if (OrbitalPeriodPlanet_I(Planet_) == 0.0) then
       OmegaOrbit = 0.0
     else
       OmegaOrbit = cTwoPi/OrbitalPeriodPlanet_I(Planet_)
-    end if
+    endif
     OmegaPlanet = OmegaRotation + OmegaOrbit
     AngleEquinox = &
       cTwoPi*(iHourEquinoxPlanet_I(Planet_)*3600 + iMinuteEquinoxPlanet_I(Planet_)*60 &
@@ -262,7 +262,7 @@ contains
           RotPeriodPlanet = cTwoPi/OmegaPlanet
         else
           RotPeriodPlanet = 0.0
-        end if
+        endif
         call read_var('TiltRotation', TiltRotation)
         TiltRotation = TiltRotation*cDegToRad
         call read_var('TypeBField', TypeBField)
@@ -290,12 +290,12 @@ contains
           if (TypeBField == 'QUADRUPOLE') then
             call CON_stop(NameSub// &
                           ' ERROR: quadrupole field unimplemented')
-          end if
+          endif
 
           if (TypeBField == 'OCTUPOLE') then
             call CON_stop(NameSub// &
                           ' ERROR: octupole field unimplemented')
-          end if
+          endif
 
         case default
           call CON_stop(NameSub// &
@@ -303,7 +303,7 @@ contains
 
         end select
 
-      end if
+      endif
 
     case ('#IDEALAXES')
       ! This is a short version of setting one axis parallel with Z
@@ -342,7 +342,7 @@ contains
       else
         if (.not. IsMagAxisPrimary) call CON_stop(NameSub// &
                                                   ' ERROR: either rotation or magnetic axis must be primary')
-      end if
+      endif
 
     case ('#MAGNETICAXIS')
 
@@ -365,7 +365,7 @@ contains
       else
         if (.not. IsRotAxisPrimary) call CON_stop(NameSub// &
                                                   ' ERROR: either rotation or magnetic axis must be primary')
-      end if
+      endif
 
     case ('#MAGNETICCENTER')
 
@@ -388,7 +388,7 @@ contains
         call read_var('Rotation period [hours]', RotPeriodPlanet)
         RotPeriodPlanet = RotPeriodPlanet*3600
         OmegaPlanet = cTwoPi/RotPeriodPlanet
-      end if
+      endif
 
     case ('#NONDIPOLE')
 
@@ -401,7 +401,7 @@ contains
       else
         call CON_stop(NameSub// &
                       ' ERROR: nondipole magnetic field unimplemented')
-      end if
+      endif
 
     case ('#DIPOLE')
 
@@ -413,7 +413,7 @@ contains
         TypeBField = "NONE"
       else
         TypeBField = "DIPOLE"
-      end if
+      endif
 
     case ('#UPDATEB0')
 

--- a/share/Library/src/CON_planet_field.f90
+++ b/share/Library/src/CON_planet_field.f90
@@ -95,7 +95,7 @@ contains
     if (TypeBField == 'NONE') then
       b_D = 0
       RETURN
-    end if
+    endif
 
     if (len(TypeCoord) < 3) call CON_stop(NameSub// &
                                           ' SWMF_ERROR: coordinate type should be at least 3 characters,'// &
@@ -106,7 +106,7 @@ contains
       Xyz_D = XyzIn_D
     else
       Xyz_D = XyzIn_D/RadiusPlanet
-    end if
+    endif
 
     Xyz_D = Xyz_D - MagCenter_D
 
@@ -116,7 +116,7 @@ contains
       ! return zero field if very small
       b_D = 0
       RETURN
-    end if
+    endif
 
     ! Update axes
     call set_axes(TimeSim)
@@ -316,7 +316,7 @@ contains
     else
       Xyz_D = XyzIn_D/RadiusPlanet
       rMap = rMapIn/RadiusPlanet
-    end if
+    endif
 
     ! Check if the mapping radius is outside of the planet
     if (rMap < rNormLimit) then
@@ -324,7 +324,7 @@ contains
       write(*, *) NameSub, ' normalized mapping radius rMap=', rMap
       call CON_stop(NameSub// &
                     ' SWMF_ERROR mapping radius is less than planet radius')
-    end if
+    endif
 
     ! Convert input position into MAG or SMG system
     DoConvert = .true.
@@ -363,7 +363,7 @@ contains
       write(*, *) NameSub, ' normalized radius r=', r
       call CON_stop(NameSub// &
                     ' SWMF_ERROR radial distance is less than planet radius')
-    end if
+    endif
 
     ! Check if the mapping radius differs from the radius of input position
     if (abs(r - rMap) < DrNormLimit .and. .not. present(DdirDxyz_DD)) then
@@ -375,11 +375,11 @@ contains
       else
         ! Trivial mapping
         XyzMap_D = XyzIn_D
-      end if
+      endif
       ! The hemisphere has been established already
       RETURN
 
-    end if
+    endif
 
     ! Find the mapped position
     select case (TypeBField)
@@ -414,7 +414,7 @@ contains
         ! Calculate the Z component of the mapped position
         ! Select the same hemisphere as for the input position
         XyzMap_D(3) = iHemisphere*sqrt(rMap2 - XyMap2)
-      end if
+      endif
 
       if (present(DdirDxyz_DD)) then
         ! dTheta/dx = -xMap*(0.5-1.5*z^2/r^2)/(zMap*sqrt(x^2+y^2))
@@ -442,7 +442,7 @@ contains
         ! dDir/dXyzIn = dDir/dXyzSMGMAG . dXyzSMGMAG/dXyzIn
         if (DoConvert) DdirDxyz_DD = matmul(DdirDxyz_DD, Convert_DD)
 
-      end if
+      endif
 
     case default
       call CON_stop(NameSub//' unimplemented TypeBField='//TypeBField)
@@ -456,7 +456,7 @@ contains
     if (index(TypeCoord, "NORM") <= 0) then
       Xyzmap_D = Xyzmap_D*RadiusPlanet
       if (present(DdirDxyz_DD)) DdirDxyz_DD = DdirDxyz_DD/RadiusPlanet
-    end if
+    endif
 
   end subroutine map_planet_field11
 

--- a/share/Library/src/CON_ray_trace.f90
+++ b/share/Library/src/CON_ray_trace.f90
@@ -117,7 +117,7 @@ contains
       Send_P(jProc)%nRay = 0
       Send_P(jProc)%MaxRay = 0
       nullify (Send_P(jProc)%Ray_VI)
-    end do
+    enddo
 
     ! Initialize receive buffer
     allocate(nRayRecv_P(0:nProc - 1))
@@ -148,8 +148,8 @@ contains
       do jProc = 0, nProc - 1
         if (associated(Send_P(jProc)%Ray_VI)) &
           deallocate(Send_P(jProc)%Ray_VI)
-      end do
-    end if
+      enddo
+    endif
     deallocate(Send_P)
 
     ! Deallocate recv buffer
@@ -190,7 +190,7 @@ contains
       iProcTo = iProcStart  ! Send back result to the PE that started tracing
     else
       iProcTo = iProcEnd    ! Send to PE which can continue the tracing
-    end if
+    endif
 
     if (iProcTo < 0) &
       call CON_stop(NameSub//' SWMF_error: PE lookup to be implemented')
@@ -219,13 +219,13 @@ contains
         Send%Ray_VI(RayDir_, iRay) = 1
       else
         Send%Ray_VI(RayDir_, iRay) = -1
-      end if
+      endif
 
       if (DoneRay) then
         Send%Ray_VI(RayDone_, iRay) = 1
       else
         Send%Ray_VI(RayDone_, iRay) = 0
-      end if
+      endif
 
       Send%nRay = iRay
 
@@ -315,7 +315,7 @@ contains
       nRequest = nRequest + 1
       call MPI_irecv(nRayRecv_P(jProc), 1, MPI_INTEGER, jProc, &
                      iTag, iComm, iRequest_I(nRequest), iError)
-    end do
+    enddo
 
     ! Wait for all receive commands to be posted for all processors
     call MPI_barrier(iComm, iError)
@@ -325,7 +325,7 @@ contains
       if (jProc == iProc) CYCLE
       call MPI_rsend(Send_P(jProc)%nRay, 1, MPI_INTEGER, jProc, &
                      iTag, iComm, iError)
-    end do
+    enddo
 
     ! Wait for all messages to be received
     if (nRequest > 0) call MPI_waitall(nRequest, iRequest_I, iStatus_II, iError)
@@ -343,7 +343,7 @@ contains
       Recv%Ray_VI(:, iRay:iRay + nRayRecv_P(iProc) - 1) = &
         Send_P(iProc)%Ray_VI(:, 1:Send_P(iProc)%nRay)
       iRay = iRay + nRayRecv_P(iProc)
-    end if
+    endif
 
     nRequest = 0
     iRequest_I = MPI_REQUEST_NULL
@@ -355,7 +355,7 @@ contains
       call MPI_irecv(Recv%Ray_VI(1, iRay), nRayRecv_P(jProc)*nRayInfo, &
                      MPI_REAL, jProc, iTag, iComm, iRequest_I(nRequest), iError)
       iRay = iRay + nRayRecv_P(jProc)
-    end do
+    enddo
 
     ! Wait for all receive commands to be posted for all processors
     call MPI_barrier(iComm, iError)
@@ -366,7 +366,7 @@ contains
 
       call MPI_rsend(Send_P(jProc)%Ray_VI(1, 1), &
                      Send_P(jProc)%nRay*nRayInfo, MPI_REAL, jProc, iTag, iComm, iError)
-    end do
+    enddo
 
     ! Wait for all messages to be received
     if (nRequest > 0) call MPI_waitall(nRequest, iRequest_I, iStatus_II, iError)
@@ -377,7 +377,7 @@ contains
     ! Reset send buffers
     do jProc = 0, nProc - 1
       Send_P(jProc)%nRay = 0
-    end do
+    enddo
 
     ! Check if all PE-s are done
     DoneAll = DoneMe .and. (Recv%nRay == 0)
@@ -408,7 +408,7 @@ contains
         OldRay_VI(:, 1:Buffer%nRay)              ! copy old values
       deallocate(OldRay_VI)                          ! free old storage
       Buffer%MaxRay = nRayNew                      ! change buffer size
-    end if
+    endif
 
   end subroutine extend_buffer
 
@@ -463,7 +463,7 @@ contains
         iProc, jProc, Send_P(jProc)%MaxRay, &
         Send_P(jProc)%nRay, &
         Send_P(jProc)%Ray_VI(:, 1:Send_P(jProc)%nRay)
-    end do
+    enddo
 
     if (iProc == 0) write(*, '(a)') 'ray_put done'
 
@@ -479,7 +479,7 @@ contains
         'iProc ', iProc, ' received iStart=', iStart_D, &
         ' iProcStart=', iProcStart, ' XyzEnd=', XyzEnd_D, ' Length=', Length, &
         ' Isparallel,DoneRay=', IsParallel, DoneRay
-    end do
+    enddo
 
     if (iProc == 0) write(*, '(a)') 'ray_get done'
 

--- a/share/Library/src/ModCoordTransform.f90
+++ b/share/Library/src/ModCoordTransform.f90
@@ -487,7 +487,7 @@ contains
     else
       SinPhi = 0
       CosPhi = 0
-    end if
+    endif
     !EOC
 
   end subroutine xyz_to_dir34
@@ -891,7 +891,7 @@ contains
       write(*, *) 'Error in ', NameSub, ' for matrix:'
       call show_rot_matrix(a_DD)
       call CON_stop('Singular matrix in '//NameSub)
-    end if
+    endif
 
   end function inverse_matrix
 
@@ -916,7 +916,7 @@ contains
       atan2_check = 0
     else
       atan2_check = atan2(x, y)
-    end if
+    endif
     if (atan2_check < 0.0) atan2_check = atan2_check + cTwoPi
     !EOC
   end function atan2_check

--- a/share/Library/src/ModExactRS.f90
+++ b/share/Library/src/ModExactRS.f90
@@ -62,14 +62,14 @@ contains
       GammaL = GammaLIn
     else
       GammaL = GammaHere
-    end if
+    endif
     CL = sqrt(GammaL*PL/RhoL)
 
     if (present(GammaRIn)) then
       GammaR = GammaRIn
     else
       GammaR = GammaHere
-    end if
+    endif
     CR = sqrt(GammaR*PR/RhoR)
 
     UVac = 2.0*(CL/(GammaL - 1.0) + CR/(GammaR - 1.0))
@@ -93,7 +93,7 @@ contains
       PStar = POld - (FL + FR + UDiff)/(FLD + FRD)
       Change = 2.0*abs((PStar - POld)/(PStar + POld))
       POLD = PStar; iIter = iIter + 1
-    end do
+    enddo
 
     !     Compute velocity in Star Region
 
@@ -119,7 +119,7 @@ contains
         Gamma = GammaIn
       else
         Gamma = GammaHere
-      end if
+      endif
       IF (P .LE. PK) THEN
         !
         !        Rarefaction wave
@@ -138,7 +138,7 @@ contains
         F = (P - PK)*QRT
         FD = (1.0 - 0.5*(P - PK)/BK)*QRT
         WK = 0.50*(GAMMA + 1.0)*BK*QRT
-      END IF
+      ENDIF
     end subroutine pressure_function
     !===============================================!
     subroutine guess_p(PGuess)
@@ -201,7 +201,7 @@ contains
       !
       call simple_wave(S - UnStar, RhoR, UnR - UnStar, PR, CR, GammaRIn)
       Un = Un + UnStar
-    end IF
+    endIF
   contains
     subroutine simple_wave(SRel, RhoK, UnK, PK, CK, GammaIn)
       real, intent(in)::SRel, RhoK, UnK, PK, CK
@@ -213,7 +213,7 @@ contains
         Gamma = GammaIn
       else
         Gamma = GammaHere
-      end if
+      endif
       IF (PStar .LE. PK) THEN
         !
         !           rarefaction
@@ -240,7 +240,7 @@ contains
           C = (CK - G7*(UnK - SRel))/(1.0 + G7)
           Un = SRel - C
           P = PK*(C/CK)**(2.0*Gamma/(Gamma - 1.0))
-        END IF
+        ENDIF
         Rho = RhoK*(P/PK)**(1.0/Gamma)
       ELSE
         !
@@ -253,7 +253,7 @@ contains
               ((Gamma - 1.0)*PStar + PK*(Gamma + 1.0))
         Un = 0.0
         P = PStar
-      END IF
+      ENDIF
     end subroutine simple_wave
   end subroutine exact_rs_sample
 end module ModExactRS

--- a/share/Library/src/ModFreq.f90
+++ b/share/Library/src/ModFreq.f90
@@ -83,7 +83,7 @@ contains
       write(*, *) NameSub, ' ERROR: Dn=', Act%Dn, ' for action ', NameAct
       call CON_stop(NameSub//' Dn must be positive in steady state mode!')
 
-    end if
+    endif
 
   end subroutine check_freq
 
@@ -149,7 +149,7 @@ contains
     if (.not. Act%DoThis) then
       IsTimeTo = .false.
       RETURN
-    end if
+    endif
 
     if (Act%Dn == 0) then
       IsTimeTo = .true.
@@ -161,13 +161,13 @@ contains
           IsTimeTo = tSimulation >= Act%tNext
         elseif (Act%Dn > 0) then
           IsTimeTo = nStep >= Act%nNext
-        end if
+        endif
       else
         if (Act%Dn > 0) then
           IsTimeTo = nStep >= Act%nNext
-        end if
-      end if
-    end if
+        endif
+      endif
+    endif
 
     if (IsTimeTo .and. .not. present(DoCheckOnly)) then
 
@@ -175,14 +175,14 @@ contains
         Act%tNext = Act%tNext + Act%Dt
         if (Act%tNext < tSimulation) &
           Act%tNext = tSimulation + Act%Dt
-      end if
+      endif
 
       if (Act%Dn > 0) then
         Act%nNext = Act%nNext + Act%Dn
         if (Act%nNext <= nStep) &
           Act%nNext = nStep + Act%Dn
-      end if
-    end if
+      endif
+    endif
 
   end function is_time_to
 
@@ -270,12 +270,12 @@ contains
       do iAct = 1, nAct
         t = t + 1.0
         DoAct(iAct) = is_time_to(Act, iAct, t, DoTimeAccurate)
-      end do
+      enddo
       if (IsVerbose) then
         write(*, *) 'DoTimeAccurate=', DoTimeAccurate
         write(*, *) 'Act  =', Act
         write(*, *) 'DoAct=', DoAct
-      end if
+      endif
     end subroutine check_act
 
   end subroutine test_freq

--- a/share/Library/src/ModHdf5Utils_orig.f90
+++ b/share/Library/src/ModHdf5Utils_orig.f90
@@ -200,7 +200,7 @@ contains
       iCommOpen = MPI_COMM_SELF
       iProc = 0
       nProc = 1
-    end if
+    endif
 
     nBlkUsed = NumberOfBlocksUsed
     CellsPerBlock(1:3) = n_D(1:3)
@@ -211,7 +211,7 @@ contains
     if (FileID == -1) then
       write(*, *) "Error: unable to initialize file"
       call stop_hdf5("unable to initialize hdf5 file")
-    end if
+    endif
 
     xMin = 0; yMin = 0; zMin = 0
     if (present(CoordMin)) then
@@ -220,8 +220,8 @@ contains
         yMin = CoordMin(2)
         if (nDimOut == 3) &
           zMin = CoordMin(3)
-      end if
-    end if  ! else make a grid?
+      endif
+    endif  ! else make a grid?
 
     xMax = 0; yMax = 0; zMax = 0
     if (present(CoordMax)) then
@@ -230,8 +230,8 @@ contains
         yMax = CoordMax(2)
         if (nDimOut == 3) &
           zMax = CoordMax(3)
-      end if
-    end if  ! else make a grid
+      endif
+    endif  ! else make a grid
 
     allocate(UnknownNameArray(nVar))
     call split_string(NameUnits, nVar, UnknownNameArray(1:nVar), i)
@@ -255,7 +255,7 @@ contains
                            Rank4RealData=PlotVarBlk(:, :, :, :, iVar), &
                            RealAttribute1=VarMin, RealAttribute2=VarMax, &
                            NameRealAttribute1="minimum", NameRealAttribute2="maximum")
-    end do
+    enddo
     deallocate(UnknownNameArray)
 
     iInteger8 = 2
@@ -265,7 +265,7 @@ contains
     allocate(coordinates(nPlotDim, nBlkUsed))
     do iBlk = 1, nBlkUsed
       coordinates(1:nPlotDim, iBlk) = .5*(XYZMinMax(1, 1:nPlotDim, iBlk) + XYZMinMax(2, 1:nPlotDim, iBlk))
-    end do
+    enddo
     call write_hdf5_data(FileID, "coordinates", 2, &
                          (/nPlotDim, nBlkUsed/), Rank2RealData=coordinates)
 
@@ -277,7 +277,7 @@ contains
       UnknownNameArray(2) = "Z-Axis"
       if (nPlotDim == 3) &
         UnknownNameArray(3) = "Z-Axis"
-    end if
+    endif
     iInteger4 = lNameh5
     call pad_string_with_null(nVar, iInteger4, UnknownNameArray, UnknownNameArray)
     iInteger8 = nPlotDim
@@ -324,7 +324,7 @@ contains
       RealMetaData(iData) = zMin
       iData = iData + 1
       RealMetaData(iData) = zMax
-    end if
+    endif
 
     !-------------------------------------------------------------------
     !write the real Metadata
@@ -372,7 +372,7 @@ contains
     do i = 1, 3
       IntegerMetaData(iData) = 0 ! none of the axis are periodic
       iData = iData + 1
-    end do
+    enddo
 
     integerMetaData(iData) = 1 !Tells VisIt that this is a cut file, which to VisIt means that
     ! there is no morton curve index to be read.
@@ -425,11 +425,11 @@ contains
           DoCollectiveWrite = .true.
         else
           DoCollectiveWrite = .false.
-        end if
+        endif
       else
         DoCollectiveWrite = .false.
-      end if
-    end if
+      endif
+    endif
 
     ! Create the file Collectively.
 
@@ -504,13 +504,13 @@ contains
       allocate(nCount(DatasetRank))
     else
       nBlocksLocal = nDatasetDimension(DatasetRank)
-    end if
+    endif
     if (present(nCellsLocalIn)) then
       nCellsLocal = nCellsLocalIn
       allocate(nCount(1))
     else
       nCellsLocal = nBlocksLocal
-    end if
+    endif
 
     if ((.not. present(nBlocksLocalIn)) .and. (.not. present(nCellsLocalIn))) &
       allocate(nCount(DatasetRank))
@@ -528,7 +528,7 @@ contains
     else if (present(CharacterData)) then
       call h5tcopy_f(H5T_NATIVE_CHARACTER, DataType, iErrorHdf)
       call h5tset_size_f(DataType, nStringChars, iErrorHdf)
-    end if
+    endif
 
     call h5screate_simple_f(DatasetRank, nDatasetDimension, DataSpaceId, iErrorHdf)
     !create the DatasetID
@@ -572,7 +572,7 @@ contains
         call h5dclose_f(DatasetID, iErrorHdf)
         deallocate(nCount)
         return
-      end if
+      endif
     else
       if (present(nOffsetLocal)) then
         if (DatasetRank == 1) then
@@ -583,7 +583,7 @@ contains
           nStart(DatasetRank) = nOffsetLocal
           nCount(1:DatasetRank - 1) = nDatasetDimension(1:DatasetRank - 1)
           nCount(DatasetRank) = nBlocksLocal
-        end if
+        endif
         !create the hyperslab.  This will differ on the different processors
         call h5sselect_hyperslab_f(DataSpaceId, H5S_SELECT_SET_F, nStart, nCount, iErrorHdf)
         !create the memory space
@@ -600,8 +600,8 @@ contains
         call h5sselect_all_f(DataSpaceId, iErrorHdf)
         !         !create the memory space
         call h5screate_simple_f(DatasetRank, nDatasetDimension, MemorySpaceId, iErrorHdf)
-      end if
-    end if
+      endif
+    endif
     if (DataType == H5T_NATIVE_DOUBLE) then
       if (present(Rank1RealData)) then
         call h5dwrite_f(DatasetID, DataType, Rank1RealData, nCount, iErrorHdf, &
@@ -627,7 +627,7 @@ contains
                         xfer_prp=PropertyListID)
         if (iErrorHdf == -1) &
           call stop_hdf5("iErrorHdf in subroutine write_hdf5_data. Error marker 9")
-      end if
+      endif
     else if (DataType == H5T_NATIVE_INTEGER) then
       if (present(Rank1IntegerData)) then
         call h5dwrite_f(DatasetID, DataType, Rank1IntegerData, nCount, iErrorHdf, &
@@ -653,7 +653,7 @@ contains
                         xfer_prp=PropertyListID)
         if (iErrorHdf == -1) &
           call stop_hdf5("iErrorHdf in subroutine write_hdf5_data. Error marker 13")
-      end if
+      endif
     else
       call h5dwrite_f(DatasetID, DataType, CharacterData, nCount, iErrorHdf, &
                       mem_space_id=MemorySpaceId, file_space_id=DataSpaceId, &
@@ -661,7 +661,7 @@ contains
       if (iErrorHdf == -1) &
         call stop_hdf5("iErrorHdf in subroutine write_hdf5_data. Error marker 14")
       call h5tclose_f(DataType, iErrorHdf)
-    end if
+    endif
     call h5sclose_f(MemorySpaceId, iErrorHdf)
     call h5pclose_f(PropertyListID, iErrorHdf)
     call h5sclose_f(DataSpaceId, iErrorHdf)
@@ -695,7 +695,7 @@ contains
                        iAttributeSpaceID, attribute, &
                        iErrorHdf, H5P_DEFAULT_F)
       call h5awrite_f(attribute, H5T_NATIVE_INTEGER, RealAtt, iDimension1D, iErrorHdf)
-    end if
+    endif
     call h5sclose_f(iAttributeSpaceID, iErrorHdf)
     call h5aclose_f(attribute, iErrorHdf)
 
@@ -726,7 +726,7 @@ contains
       nCharsIn = len_trim(StringsOut(iStr))
       do iLen = nCharsIn + 1, nCharNeeded
         StringsOut(iStr) (iLen:iLen) = CHAR(0)
-      end do
-    end do
+      enddo
+    enddo
   end subroutine pad_string_with_null
 end module ModHdf5Utils

--- a/share/Library/src/ModInitialState.f90
+++ b/share/Library/src/ModInitialState.f90
@@ -81,7 +81,7 @@ contains
 
     do iVar = 1, nVar
       call lower_case(NameVar_V(iVar))
-    end do
+    enddo
 
     iVarMaterial0 = -1
     if (present(iVarMaterial1In)) iVarMaterial0 = iVarMaterial1In - 1
@@ -163,11 +163,11 @@ contains
           if (NameStateVar_I(i) == NameVar_V(iVar)) then
             iVar_I(i) = iVar
             CYCLE LOOPSTATE
-          end if
-        end do
+          endif
+        enddo
         call CON_stop(NameSub//': could not match variable name='// &
                       trim(NameStateVar_I(i)))
-      end do LOOPSTATE
+      enddo LOOPSTATE
 
       ! Number of different states in the initial condition
       call read_var('nMaterialState', nMaterialState)
@@ -183,7 +183,7 @@ contains
           NameMaterialState_I(i), MaterialState_VI(iVar_I, i)
         if (iError /= 0) call CON_stop(NameSub// &
                                        ' could not read Name, State from '//trim(String))
-      end do
+      enddo
       deallocate(NameStateVar_I, iVar_I)
 
     case ("#STATEINTERFACE")
@@ -211,12 +211,12 @@ contains
         if (nMaterial > 0) then
           iLevelSegment_SI(1, i) = i_level(NameMaterial1(1:2))
           iLevelSegment_SI(2, i) = i_level(NameMaterial2(1:2))
-        end if
+        endif
 
         StartSegment_DI(:, i) = Start_D
         VectorSegment_DI(:, i) = End_D - Start_D
         LengthSegment_I(i) = sqrt(sum((End_D - Start_D)**2))
-      end do
+      enddo
     case default
       call CON_stop(NameSub//': unknown command='//NameCommand)
     end select
@@ -233,8 +233,8 @@ contains
         if (NameMaterial == NameVar_V(iVar)) then
           i_level = iMaterial
           RETURN
-        end if
-      end do
+        endif
+      enddo
 
       call CON_stop(NameSub// &
                     ' could not match material name='//NameMaterial)
@@ -254,8 +254,8 @@ contains
         if (NameMaterial == NameMaterialState_I(i)) then
           i_state = i
           RETURN
-        end if
-      end do
+        endif
+      enddo
 
       write(*, *) NameSub, ': nMaterialState      = ', nMaterialState
       write(*, *) NameSub, ': NameMaterialState_I = ', NameMaterialState_I
@@ -301,7 +301,7 @@ contains
     if (nMaterial > 0) then
       allocate(dMin_I(nMaterial))
       dMin_I = -huge(1.0)
-    end if
+    endif
 
     ! Check distance from all the material interface segments
     do iSegment = 1, nSegment
@@ -341,7 +341,7 @@ contains
       if (d < dMin) then
         dMin = d
         iState = iStateSegment_SI(iSide, iSegment)
-      end if
+      endif
 
       if (nMaterial > 0) then
         ! Get the levels on the two sides of the segment.
@@ -353,8 +353,8 @@ contains
           ! Set level set function if distance is smaller than earlier
           if (d < abs(dMin_I(iLevel))) dMin_I(iLevel) = d
           if (d < abs(dMin_I(jLevel))) dMin_I(jLevel) = -d
-        end if
-      end if
+        endif
+      endif
 
       if (.not. present(DoTest)) CYCLE
       if (.not. DoTest) CYCLE
@@ -366,13 +366,13 @@ contains
       write(*, *) NameSub, ' Projection, Point_D=', Projection, Point_D
       write(*, *) NameSub, ' d, iLevel, jLevel  =', d, iLevel, jLevel
 
-    end do
+    enddo
 
     State_V = MaterialState_VI(:, iState)
     if (nMaterial > 0) then
       State_V(iVarMaterial0 + 1:iVarMaterial0 + nMaterial) = dMin_I
       deallocate(dMin_I)
-    end if
+    endif
 
   end subroutine get_initial_state
 
@@ -421,7 +421,7 @@ contains
       case default
         call CON_stop(NameSub//': unknown command='//NameCommand)
       end select
-    end do
+    enddo
 
     ! Set the levelset values for all cell centers
     do j = 1, nJ; do i = 1, nI
@@ -440,7 +440,7 @@ contains
         State_VC(nVar, i, j) = maxloc( &
                                State_VC(iMaterial1:iMaterialLast, i, j), DIM=1)
 
-      end do; end do
+      enddo; enddo
 
     if (iProc == 0) call save_plot_file('test_initial_state.out', &
                                         NameVarIn="x y "//NameVar//" level nSegment", &

--- a/share/Library/src/ModInterpolate.f90
+++ b/share/Library/src/ModInterpolate.f90
@@ -96,7 +96,7 @@ contains
       else
         interpolate_scalar = linear_scalar(a_C, &
                                            Min_D(1), Max_D(1), x_D(1), x_I, DoExtrapolate)
-      end if
+      endif
     case (2)
       interpolate_scalar = bilinear_scalar(a_C, &
                                            Min_D(1), Max_D(1), Min_D(2), Max_D(2), &
@@ -141,7 +141,7 @@ contains
       else
         interpolate_vector = linear_vector(a_VC, nVar, &
                                            Min_D(1), Max_D(1), x_D(1), x_I, DoExtrapolate)
-      end if
+      endif
     case (2)
       interpolate_vector = bilinear_vector(a_VC, nVar, &
                                            Min_D(1), Max_D(1), Min_D(2), Max_D(2), &
@@ -196,7 +196,7 @@ contains
       ! Calculate the remaining cell indices and interpolation weights
       i2 = i1 + 1; Dx2 = 1.0 - Dx1
 
-    end if
+    endif
 
     ! Perform interpolation (or extrapolation)
     linear_scalar = (Dx2)*a_I(i1) + Dx1*a_I(i2)
@@ -247,7 +247,7 @@ contains
       ! Calculate the remaining cell indices and interpolation weights
       i2 = i1 + 1; Dx2 = 1.0 - Dx1
 
-    end if
+    endif
 
     ! Perform interpolation (or extrapolation) for multiple variables
     linear_vector = (Dx2)*a_VI(:, i1) + Dx1*a_VI(:, i2)
@@ -305,7 +305,7 @@ contains
       i2 = i1 + 1; Dx2 = 1.0 - Dx1
       j2 = j1 + 1; Dy2 = 1.0 - Dy1
 
-    end if
+    endif
 
     ! Perform interpolation (or extrapolation)
     bilinear_scalar = Dy2*(Dx2*a_II(i1, j1) &
@@ -369,7 +369,7 @@ contains
       i2 = i1 + 1; Dx2 = 1.0 - Dx1
       j2 = j1 + 1; Dy2 = 1.0 - Dy1
 
-    end if
+    endif
 
     ! Perform interpolation (or extrapolation) for multiple variables
     bilinear_vector = Dy2*(Dx2*a_VII(:, i1, j1) &
@@ -439,7 +439,7 @@ contains
       j2 = j1 + 1; Dy2 = 1.0 - Dy1
       k2 = k1 + 1; Dz2 = 1.0 - Dz1
 
-    end if
+    endif
 
     !Perform interpolation (or extrapolation)
     trilinear_scalar = Dz2*(Dy2*(Dx2*a_III(i1, j1, k1) &
@@ -517,7 +517,7 @@ contains
       j2 = j1 + 1; Dy2 = 1.0 - Dy1
       k2 = k1 + 1; Dz2 = 1.0 - Dz1
 
-    end if
+    endif
 
     trilinear_vector = Dz2*(Dy2*(Dx2*a_VIII(:, i1, j1, k1) &
                                  + Dx1*a_VIII(:, i2, j1, k1)) &
@@ -608,7 +608,7 @@ contains
         elseif (.not. DoExtrapolate) then
           ! Use lefttmost cell (first order accurate)
           dCoord = 0.0
-        end if
+        endif
         if (present(IsInside)) IsInside = .false.
       elseif (Coord > MaxCoord) then
         if (.not. (present(DoExtrapolate))) then
@@ -619,11 +619,11 @@ contains
         elseif (.not. DoExtrapolate) then
           ! Use rightmost cell (first order accurate)
           dCoord = 1.0
-        end if
+        endif
         if (present(IsInside)) IsInside = .false.
       else
         if (present(IsInside)) IsInside = .true.
-      end if
+      endif
 
     elseif (Coord_I(MinCoord) < Coord_I(MaxCoord)) then
 
@@ -643,10 +643,10 @@ contains
         else
           iCoord = MinCoord
           dCoord = 0.0
-        end if
+        endif
         if (present(IsInside)) IsInside = .false.
         RETURN
-      end if
+      endif
 
       if (Coord > Coord_I(MaxCoord)) then
         if (.not. (present(DoExtrapolate))) then
@@ -662,10 +662,10 @@ contains
         else
           iCoord = MaxCoord - 1
           dCoord = 1.0
-        end if
+        endif
         if (present(IsInside)) IsInside = .false.
         RETURN
-      end if
+      endif
 
       if (present(IsInside)) IsInside = .true.
 
@@ -680,15 +680,15 @@ contains
           i = min(MaxCoord - 1, i + Di)
         else
           EXIT
-        end if
-      end do
+        endif
+      enddo
       iCoord = i
       if (Coord_I(iCoord + 1) == Coord_I(iCoord)) then
         dCoord = 0.0
       else
         dCoord = (Coord - Coord_I(iCoord)) &
                  /(Coord_I(iCoord + 1) - Coord_I(iCoord))
-      end if
+      endif
     else
 
       ! Monotone decreasing coordinates
@@ -707,10 +707,10 @@ contains
         else
           iCoord = MaxCoord - 1
           dCoord = 1.0
-        end if
+        endif
         if (present(IsInside)) IsInside = .false.
         RETURN
-      end if
+      endif
 
       if (Coord > Coord_I(MinCoord)) then
         if (.not. (present(DoExtrapolate))) then
@@ -726,10 +726,10 @@ contains
         else
           iCoord = MinCoord
           dCoord = 0.0
-        end if
+        endif
         if (present(IsInside)) IsInside = .false.
         RETURN
-      end if
+      endif
 
       if (present(IsInside)) IsInside = .true.
 
@@ -744,16 +744,16 @@ contains
           i = min(MaxCoord - 1, i + Di)
         else
           EXIT
-        end if
-      end do
+        endif
+      enddo
       iCoord = i
       if (Coord_I(iCoord + 1) == Coord_I(iCoord)) then
         dCoord = 0.0
       else
         dCoord = (Coord_I(iCoord) - Coord) &
                  /(Coord_I(iCoord) - Coord_I(iCoord + 1))
-      end if
-    end if
+      endif
+    endif
 
   end subroutine find_cell
   !===========================================================================
@@ -792,7 +792,7 @@ contains
     if (x1 == 0.0 .or. x3 == 0.0) then
       write(*, *) NameSub, ': x_I=', x_I, ' y_I=', y_I
       call CON_stop(NameSub//' error in coordinates')
-    end if
+    endif
 
     ! Calculate slopes
     s1 = y1/x1
@@ -801,7 +801,7 @@ contains
     if (s1*s3 > 0.0) then
       write(*, *) NameSub, ': x_I=', x_I, ' y_I=', y_I
       call CON_stop(NameSub//' error: midpoint is not an extremum')
-    end if
+    endif
 
     ! Find the position where the line connecting
     ! the (x1/2, s1) and (x3/2, s3) points intersects the X axis.
@@ -821,8 +821,8 @@ contains
         Weight2Out_I(3) = 0.0
         Weight2Out_I(1) = xE/x1
         Weight2Out_I(2) = 1.0 - Weight2Out_I(1)
-      end if
-    end if
+      endif
+    endif
 
     if (present(yExtremumOut) .or. present(Weight3Out_I)) then
       ! Find the value of the parabola y = a*(x-xE)**2 + yE at the extremum
@@ -833,7 +833,7 @@ contains
       else
         Ratio = xE**2/(x3 - xE)**2
         yE = Ratio*y3/(Ratio - 1.0)
-      end if
+      endif
       if (present(yExtremumOut)) yExtremumOut = yE + y_I(2)
 
       if (present(Weight3Out_I)) then
@@ -852,8 +852,8 @@ contains
 
         ! For point 2 we use that the sum of weights must be 1
         Weight3Out_I(2) = 1.0 - Weight3Out_I(1) - Weight3Out_I(3)
-      end if
-    end if
+      endif
+    endif
 
   end subroutine fit_parabola
   !===========================================================================
@@ -903,7 +903,7 @@ contains
         write(*, '(a)') 'Testing find_cell for increasing coordinates'
       else
         write(*, '(a)') 'Testing find_cell for decreasing coordinates'
-      end if
+      endif
 
       ! Change number of coordinates to test binary search
       do nCoord = MaxCoord/2, MaxCoord
@@ -931,7 +931,7 @@ contains
               'Test failed for nCoord, Coord=', nCoord, Coord, &
               ', dCoord=', dCoord, ' should be 0.0'
             CYCLE
-          end if
+          endif
           if (iSign*Coord > iSign*Coord_I(nCoord)) then
             if (IsInside) write(*, *) &
               'Test failed for nCoord, Coord=', nCoord, Coord, &
@@ -943,7 +943,7 @@ contains
               'Test failed for nCoord, Coord=', nCoord, Coord, &
               ', dCoord=', dCoord, ' should be 1.0'
             CYCLE
-          end if
+          endif
           if (.not. IsInside) write(*, *) &
             'Test failed for nCoord, Coord=', nCoord, Coord, &
             ', IsInside=F, should be true'
@@ -954,7 +954,7 @@ contains
               ', iCoord=', iCoord, ' should be < ', MinCoord, &
               ' and > ', nCoord - 1
             CYCLE
-          end if
+          endif
 
           if (iSign*Coord_I(iCoord) > iSign*Coord) write(*, *) &
             'Test failed for nCoord, Coord=', nCoord, Coord, &
@@ -971,11 +971,11 @@ contains
             'Test failed for nCoord, Coord=', nCoord, Coord, &
             ', Coord_I(iCoord:iCoord+1)=', Coord_I(iCoord:iCoord + 1), &
             ', but incorrect dCoord = ', dCoord
-        end do
-      end do
+        enddo
+      enddo
       ! Change signs of coordinates to test decreasing order
       Coord_I = -Coord_I
-    end do
+    enddo
 
     !Test for normal conditions.
     write(*, '(a)') 'Testing function linear for uniform grid'

--- a/share/Library/src/ModInterpolateAMR.f90
+++ b/share/Library/src/ModInterpolateAMR.f90
@@ -105,11 +105,11 @@ contains
       else
         Weight_I(1:5) = -1
         RETURN
-      end if
+      endif
     elseif (Alpha5 < 0.0 .or. Alpha5 > 1.0) then
       Weight_I(1:5) = -1
       RETURN
-    end if
+    endif
     XyzP_D = X5_D + (Xyz_D - X5_D)/Alpha5
     !\
     ! Now, Xyz = Alpha5*XyzP + (1-Alpha5)*X5
@@ -161,7 +161,7 @@ contains
     if (y < 0.0 .or. y > 1.0 .or. x < 0.0 .or. x > 1.0) then
       Weight_I(1:4) = -1
       RETURN
-    end if
+    endif
     if (x <= 0.250) then
       !Interpolation in triangle 132, 4th weight is zero
       Weight_I(3) = y; Weight_I(4) = 0
@@ -174,7 +174,7 @@ contains
       !Interpolation in triangle 142, 3rd weight is zero
       Weight_I(3) = 0; Weight_I(4) = y
       Weight_I(1) = 1 - 0.250*y - x; Weight_I(2) = x - 0.750*y
-    end if
+    endif
   end subroutine trapezoid
   !=====================================
   subroutine triangle(X1_D, X2_D, X3_D, XyzP_D, Weight_I)
@@ -282,13 +282,13 @@ contains
                   nGridOut = 4
                   iOrder_I(1:4) = iTetrahedron6_I
                   RETURN
-                end if ! 6
-              end if    ! 5
-            end if       ! 4
-          end if          ! 3
-        end if             ! 2
-      end if                ! 1
-    end if                   ! no tetrahedron
+                endif ! 6
+              endif    ! 5
+            endif       ! 4
+          endif          ! 3
+        endif             ! 2
+      endif                ! 1
+    endif                   ! no tetrahedron
     if (present(iRectangular1_I)) then
       call interpolate_pyramid(Rectangular_, &
                                XyzGrid_DI(:, iRectangular1_I(1)), &
@@ -322,10 +322,10 @@ contains
             nGridOut = 5
             iOrder_I(1:5) = iRectangular3_I
             RETURN
-          end if          ! 3
-        end if             ! 2
-      end if                ! 1
-    end if                   ! no rectangular
+          endif          ! 3
+        endif             ! 2
+      endif                ! 1
+    endif                   ! no rectangular
     if (present(iTrapezoidal1_I)) then
       call interpolate_pyramid(Trapezoidal_, &
                                XyzGrid_DI(:, iTrapezoidal1_I(1)), &
@@ -348,9 +348,9 @@ contains
           nGridOut = 5
           iOrder_I(1:5) = iTrapezoidal2_I
           RETURN
-        end if             ! 2
-      end if                ! 1
-    end if                   ! no trapezoid
+        endif             ! 2
+      endif                ! 1
+    endif                   ! no trapezoid
   end subroutine interpolate_pyramids
   !======================
   subroutine interpolate_on_parallel_rays( &
@@ -438,7 +438,7 @@ contains
           !\
           ! Exit if for triangles with positive AlphaUp and nGridOut = 3
           !/
-        end if
+        endif
       elseif (present(iUTriangle2_I)) then
         X1_D = XyzGrid_DI(:, iUTriangle2_I(1))
         X2_D = XyzGrid_DI(:, iUTriangle2_I(2))
@@ -469,7 +469,7 @@ contains
             !\
             ! Exit if for triangles with positive AlphaUp
             !/
-          end if
+          endif
         elseif (present(iUTriangle3_I)) then
           X1_D = XyzGrid_DI(:, iUTriangle3_I(1))
           X2_D = XyzGrid_DI(:, iUTriangle3_I(2))
@@ -502,7 +502,7 @@ contains
               ! Exit if for triangles with positive AlphaUp
               !/
 
-            end if
+            endif
           elseif (present(iUTriangle4_I)) then
             X1_D = XyzGrid_DI(:, iUTriangle4_I(1))
             X2_D = XyzGrid_DI(:, iUTriangle4_I(2))
@@ -534,12 +534,12 @@ contains
                 !\
                 ! Exit if for triangles with positive AlphaUp
                 !/
-              end if
-            end if
-          end if       !4
-        end if          !3
-      end if             !2
-    end if                !1
+              endif
+            endif
+          endif       !4
+        endif          !3
+      endif             !2
+    endif                !1
     if (nGridOutUp < 1) then
       if (present(iURectangle1_I)) then
         X1_D = XyzGrid_DI(:, iURectangle1_I(1))
@@ -572,7 +572,7 @@ contains
             !\
             ! Exit if for rectangles with positive AlphaUp
             !/
-          end if
+          endif
         elseif (present(iURectangle2_I)) then
           X1_D = XyzGrid_DI(:, iURectangle2_I(1))
           X2_D = XyzGrid_DI(:, iURectangle2_I(2))
@@ -604,7 +604,7 @@ contains
               !/
               iOrder_I(1:4) = iURectangle2_I
               nGridOutUp = 4
-            end if
+            endif
           elseif (present(iURectangle3_I)) then
             X1_D = XyzGrid_DI(:, iURectangle3_I(1))
             X2_D = XyzGrid_DI(:, iURectangle3_I(2))
@@ -637,12 +637,12 @@ contains
                 !/
                 iOrder_I(1:4) = iURectangle3_I
                 nGridOutUp = 4
-              end if
-            end if
-          end if     !3
-        end if        !2
-      end if           !1
-    end if
+              endif
+            endif
+          endif     !3
+        endif        !2
+      endif           !1
+    endif
     if (nGridOutUp < 1) then
       if (present(iUTrapezoid1_I)) then
         X1_D = XyzGrid_DI(:, iUTrapezoid1_I(1))
@@ -675,10 +675,10 @@ contains
             !/
             iOrder_I(1:4) = iUTrapezoid1_I
             nGridOutUp = 4
-          end if
-        end if
-      end if
-    end if
+          endif
+        endif
+      endif
+    endif
     !\
     !If no intersection point with upper boundary is found
     !/
@@ -721,7 +721,7 @@ contains
           !/
           iOrder_I(1:3) = iDTriangle1_I
           nGridOutDown = 3
-        end if
+        endif
       elseif (present(iDTriangle2_I)) then
         X1_D = XyzGrid_DI(:, iDTriangle2_I(1))
         X2_D = XyzGrid_DI(:, iDTriangle2_I(2))
@@ -754,7 +754,7 @@ contains
             !/
             iOrder_I(1:3) = iDTriangle2_I
             nGridOutDown = 3
-          end if
+          endif
         elseif (present(iDTriangle3_I)) then
           X1_D = XyzGrid_DI(:, iDTriangle3_I(1))
           X2_D = XyzGrid_DI(:, iDTriangle3_I(2))
@@ -787,7 +787,7 @@ contains
               !/
               iOrder_I(1:3) = iDTriangle3_I
               nGridOutDown = 3
-            end if
+            endif
           elseif (present(iDTriangle4_I)) then
             X1_D = XyzGrid_DI(:, iDTriangle4_I(1))
             X2_D = XyzGrid_DI(:, iDTriangle4_I(2))
@@ -820,7 +820,7 @@ contains
                 !/
                 iOrder_I(1:3) = iDTriangle4_I
                 nGridOutDown = 3
-              end if
+              endif
             elseif (present(iDTriangle5_I)) then
               X1_D = XyzGrid_DI(:, iDTriangle5_I(1))
               X2_D = XyzGrid_DI(:, iDTriangle5_I(2))
@@ -855,7 +855,7 @@ contains
                   !/
                   iOrder_I(1:3) = iDTriangle5_I
                   nGridOutDown = 3
-                end if
+                endif
               elseif (present(iDTriangle6_I)) then
                 X1_D = XyzGrid_DI(:, iDTriangle6_I(1))
                 X2_D = XyzGrid_DI(:, iDTriangle6_I(2))
@@ -891,14 +891,14 @@ contains
                     !/
                     iOrder_I(1:3) = iDTriangle6_I
                     nGridOutDown = 3
-                  end if
-                end if
-              end if !6
-            end if    !5
-          end if       !4
-        end if          !3
-      end if             !2
-    end if                !1
+                  endif
+                endif
+              endif !6
+            endif    !5
+          endif       !4
+        endif          !3
+      endif             !2
+    endif                !1
     if (nGridOutDown < 1) then
       if (present(iDRectangle1_I)) then
         if (present(iDTriangle1_I)) then
@@ -911,7 +911,7 @@ contains
           Weight_I(1:4) = 0
           iOrder_I(5:4 + nGridOutUp) = iOrder_I(1:nGridOutUp)
           iOrder_I(1:4) = 0
-        end if
+        endif
         X1_D = XyzGrid_DI(:, iDRectangle1_I(1))
         X2_D = XyzGrid_DI(:, iDRectangle1_I(2))
         X3_D = XyzGrid_DI(:, iDRectangle1_I(3))
@@ -943,10 +943,10 @@ contains
             !/
             iOrder_I(1:4) = iDRectangle1_I
             nGridOutDown = 4
-          end if
-        end if
-      end if
-    end if           !1
+          endif
+        endif
+      endif
+    endif           !1
     if (nGridOutDown < 1) then
       if (present(iDTrapezoid1_I)) then
         if (.not. present(iDRectangle1_I)) then
@@ -960,8 +960,8 @@ contains
             Weight_I(1:4) = 0
             iOrder_I(5:4 + nGridOutUp) = iOrder_I(1:nGridOutUp)
             iOrder_I(1:4) = 0
-          end if
-        end if
+          endif
+        endif
         X1_D = XyzGrid_DI(:, iDTrapezoid1_I(1))
         X2_D = XyzGrid_DI(:, iDTrapezoid1_I(2))
         X3_D = XyzGrid_DI(:, iDTrapezoid1_I(3))
@@ -993,7 +993,7 @@ contains
             !/
             iOrder_I(1:4) = iDTrapezoid1_I
             nGridOutDown = 4
-          end if
+          endif
         elseif (present(iDTrapezoid2_I)) then
           X1_D = XyzGrid_DI(:, iDTrapezoid2_I(1))
           X2_D = XyzGrid_DI(:, iDTrapezoid2_I(2))
@@ -1026,11 +1026,11 @@ contains
               !/
               iOrder_I(1:4) = iDTrapezoid2_I
               nGridOutDown = 4
-            end if
-          end if
-        end if
-      end if           !1
-    end if
+            endif
+          endif
+        endif
+      endif           !1
+    endif
     !\
     !If no intersection point with the down subface is found
     !/
@@ -1240,7 +1240,7 @@ contains
         iLevel_I(iGrid) = mod(iMisc, 2)
         iMisc = (iMisc - iLevel_I(iGrid))/2
         iGrid = iGrid + 1
-      end do
+      enddo
       !\
       ! Sort out faces 6 cases, 8 totally, 248 left
       !/
@@ -1257,8 +1257,8 @@ contains
           iSortStencil3_II(Dir_, iCase) = iDir !2*iDir
           iSortStencil3_II(Case_, iCase) = Face_
           CYCLE CASE
-        end if
-      end do
+        endif
+      enddo
       !\
       ! Sort out edges 30 cases, 38 totally, 218 left
       !/
@@ -1269,8 +1269,8 @@ contains
           iSortStencil3_II(Dir_, iCase) = iDir
           iSortStencil3_II(Case_, iCase) = Edge_
           CYCLE CASE
-        end if
-      end do
+        endif
+      enddo
       !\
       ! Find configurations which split into five tetrahedra
       !   26 cases 64 totally 192 left
@@ -1282,8 +1282,8 @@ contains
           iSortStencil3_II(Grid_, iCase) = iGrid
           iSortStencil3_II(Case_, iCase) = FiveTetrahedra_
           CYCLE CASE
-        end if
-      end do
+        endif
+      enddo
       select case (count(iLevel_I == Fine_))
       case (1)                          ! 8 cases 72 totally 184 left
         iLoc = maxloc(iLevel_I, DIM=1)
@@ -1312,9 +1312,9 @@ contains
               iSortStencil3_II(Grid_, iCase) = iLoc
               iSortStencil3_II(Case_, iCase) = FineFaceDiag_
               CYCLE CASE
-            end if
-          end do
-        end if
+            endif
+          enddo
+        endif
       case (6)                       ! 4 cases 100 totally 156 left
         iLoc = minloc(iLevel_I, DIM=1)
         if (iLevel_I(iMainDiag_I(iLoc)) == Coarse_) then
@@ -1329,9 +1329,9 @@ contains
               iSortStencil3_II(Grid_, iCase) = iLoc
               iSortStencil3_II(Case_, iCase) = CoarseFaceDiag_
               CYCLE CASE
-            end if
-          end do
-        end if
+            endif
+          enddo
+        endif
       case (3)          !         24 cases  136 totally 120 left
         do iGrid = 1, nGrid
           if (iLevel_I(iGrid) == Fine_) then
@@ -1342,8 +1342,8 @@ contains
                   iSortStencil3_II(Grid_, iCase) = iGrid
                   iSortStencil3_II(Case_, iCase) = FineEdgePlusOne_
                   CYCLE CASE
-                end if
-              end do
+                endif
+              enddo
             else            ! 24 cases 160 totally 96 left
               do iDir = 1, nDim
                 if (all(iLevel_I(iFace_IDI(1:3, iDir, iGrid)) == Fine_)) then
@@ -1351,11 +1351,11 @@ contains
                   iSortStencil3_II(Grid_, iCase) = iGrid
                   iSortStencil3_II(Case_, iCase) = ThreeFineOnFace_
                   CYCLE CASE
-                end if
-              end do
-            end if
-          end if
-        end do
+                endif
+              enddo
+            endif
+          endif
+        enddo
       case (5)          !         24 cases 184 totally 72 left
         do iGrid = 1, nGrid
           if (iLevel_I(iGrid) /= Coarse_) CYCLE
@@ -1366,9 +1366,9 @@ contains
                 iSortStencil3_II(Grid_, iCase) = iGrid
                 iSortStencil3_II(Case_, iCase) = CoarseEdgePlusOne_
                 CYCLE CASE
-              end if
-            end do
-          end if
+              endif
+            enddo
+          endif
           !                     24 cases 208 totally 48 left
           do iDir = 1, nDim
             if (all(iLevel_I(iFace_IDI(1:3, iDir, iGrid)) == Coarse_)) then
@@ -1376,9 +1376,9 @@ contains
               iSortStencil3_II(Grid_, iCase) = iGrid
               iSortStencil3_II(Case_, iCase) = ThreeCoarseOnFace_
               CYCLE CASE
-            end if
-          end do
-        end do
+            endif
+          enddo
+        enddo
       case (4)
         do iGrid = 1, nGrid
           if (iLevel_I(iGrid) == Coarse_) then
@@ -1391,7 +1391,7 @@ contains
                 iSortStencil3_II(Case_, iCase) = &
                   ThreeCoarseOnFacePlusOne_
                 CYCLE CASE
-              end if
+              endif
               !
               !\
               ! 24 cases 256 totally 0 left
@@ -1404,12 +1404,12 @@ contains
                 iSortStencil3_II(Grid_, iCase) = iGrid
                 iSortStencil3_II(Case_, iCase) = CoarseChain_
                 CYCLE CASE
-              end if
-            end do
-          end if
-        end do
+              endif
+            enddo
+          endif
+        enddo
       end select
-    end do CASE
+    enddo CASE
     iSortStencil3_II(Grid_:Dir_, Transition2Edge_:TransitionJunction_) = 1
     iSortStencil3_II(Case_, Transition2Edge_:TransitionJunction_) = &
       (/Transition2Edge_, Transition2Corner_, TransitionJunction_/)
@@ -1429,7 +1429,7 @@ contains
         iLevel_I(iGrid) = mod(iMisc, 2)
         iMisc = (iMisc - iLevel_I(iGrid))/2
         iGrid = iGrid + 1
-      end do
+      enddo
       !\
       ! Sort out faces 4 cases, 6 totally, 10 left
       !/
@@ -1446,8 +1446,8 @@ contains
           iSortStencil2_II(Dir_, iCase) = iDir !2*iDir
           iSortStencil2_II(Case_, iCase) = Trapezoid_
           CYCLE CASE2
-        end if
-      end do
+        endif
+      enddo
       select case (count(iLevel_I(1:4) == Fine_))
       case (1)                          ! 4 cases 10 totally 6 left
         iLoc = maxloc(iLevel_I, DIM=1)
@@ -1467,7 +1467,7 @@ contains
         iSortStencil2_II(Grid_, iCase) = iLoc
         iSortStencil2_II(Case_, iCase) = Rhombus_
       end select
-    end do CASE2
+    enddo CASE2
   end subroutine init_sort_stencil
   !============================
   integer function i_case(iLevel_I)
@@ -1481,7 +1481,7 @@ contains
     i_case = iLevel_I(nGrid)
     do iGrid = nGrid - 1, 1, -1
       i_case = i_case + i_case + iLevel_I(iGrid)
-    end do
+    enddo
   end function i_case
   !============================
 end module ModCubeGeometry
@@ -1797,7 +1797,7 @@ contains
                                           iURectangle1_I=(/5, 6, 7, 8/), &
                                           iDTriangle1_I=(/2, 3, 5/), &
                                           iDTriangle2_I=(/2, 3, 8/))
-      end if
+      endif
     case (FineEdgePlusOne_)
       !       ^
       !iDir-axis
@@ -2115,13 +2115,13 @@ contains
     if (nDim == 3) then
       Weight_I(5:8) = Weight_I(1:4)*Dimless_D(3)
       Weight_I(1:4) = Weight_I(1:4)*(1 - Dimless_D(3))
-    end if
+    endif
     if (present(IsOut_I)) then
       if (any(IsOut_I)) then
         where (IsOut_I) Weight_I = 0
         Weight_I = Weight_I/sum(Weight_I)
-      end if
-    end if
+      endif
+    endif
   end subroutine interpolate_uniform
   !=================================
   subroutine check_transition2(Xyz_D, dXyzInv_D, XyzGrid_DI, iLevel_I, &
@@ -2189,7 +2189,7 @@ contains
                                             iSide_IDI(:, 3 - iDim, 1)) == Fine_)) iDiscr_D(iDim) = -1
       if (Dimless_D(iDim) >= 0.750 .and. any(iLevel_I( &
                                              iOppositeSide_IDI(:, 3 - iDim, 1)) == Fine_)) iDiscr_D(iDim) = 1
-    end do
+    enddo
     iGrid = iGridDir_III(1, iDiscr_D(1), iDiscr_D(2))
     XyzAvr_D = 0.50*(XyzGrid_DI(:, 1) + XyzGrid_DI(:, 4))
     if (iGrid == 0) then
@@ -2198,7 +2198,7 @@ contains
       !/
       XyzStencil_D = XyzAvr_D
       RETURN
-    end if
+    endif
     !\
     !Xyz point is in the transition domain
     !/
@@ -2213,12 +2213,12 @@ contains
                              XyzGrid_DI(:, iSide_IDI(2, 3 - iDim, iGrid)))
         Distance_D(iDim) = &
           sum(((Xyz_D - XyzAvr_DD(:, iDim))*DxyzInv_D)**2)
-      end do
+      enddo
       iDir = minloc(Distance_D(1:2), DIM=1)
       !\
       !else Xyz point is close to a single refined face
       !/
-    end if
+    endif
     iCase = Transition2Edge_
     !\
     ! Displace the stencil center toward the face center
@@ -2319,8 +2319,8 @@ contains
           Weight_I(iGrid + 1) = (Xyz_D(iDir) - XyzGrid_DI(iDir, iGrid))/ &
                                 (XyzGrid_DI(iDir, iGrid + 1) - XyzGrid_DI(iDir, iGrid))
           Weight_I(iGrid) = 1 - Weight_I(iGrid + 1)
-        end if
-      end do
+        endif
+      enddo
       !\
       ! Apply weight for interpolation along another axis
       !/
@@ -2377,7 +2377,7 @@ contains
         call triangle(X1_D, X2_D, X3_D)
         iOrder_I = (/iOrder_I(iTriangle2_I(1)), iOrder_I(iTriangle2_I(2)), &
                      iOrder_I(iTriangle2_I(3)), iOrder_I(10 - sum(iTriangle2_I))/)
-      end if
+      endif
     end subroutine triangles
     !============
     subroutine triangle(X1_D, X2_D, X3_D)
@@ -2391,7 +2391,7 @@ contains
         Weight_I(2) = cross_product(X3_D - X1_D, Xyz_D - X1_D)/ &
                       cross_product(X3_D - X1_D, X2_D - X1_D)
         Weight_I(1) = 1 - Weight_I(2) - Weight_I(3)
-      end if
+      endif
     end subroutine triangle
   end subroutine interpolate_amr2
   !==============================
@@ -2479,13 +2479,13 @@ contains
                                             iFace_IDI(:, iDim, 1)) == Fine_)) iDiscr_D(iDim) = -1
       if (Dimless_D(iDim) >= 0.750 .and. any(iLevel_I( &
                                              iOppositeFace_IDI(:, iDim, 1)) == Fine_)) iDiscr_D(iDim) = 1
-    end do
+    enddo
     if (IsEdge) iDiscr_D(iDirEdge) = 0
     iGrid = iGridDir_IIII(1, iDiscr_D(1), iDiscr_D(2), iDiscr_D(nDim))
     if (iGrid == 0) then
       IsCorner = .not. IsEdge
       RETURN
-    end if
+    endif
     !\
     !Xyz point is in the transition or transition junction domain
     !/
@@ -2546,7 +2546,7 @@ contains
                                               iFace_IDI(4, 1 + mod(iDir + iDim, 3), iGrid)))
           Distance_D(1 + iDim) = &
             sum(((Xyz_D - XyzAvr_DD(:, 1 + iDim))*DxyzInv_D)**2)
-        end do
+        enddo
         iDim = minloc(Distance_D(1:2), DIM=1)
         iDir = 1 + mod(iDir + iDim - 1, 3)
         iCase = Transition2Corner_
@@ -2558,7 +2558,7 @@ contains
         XyzStencil_D(1 + mod(iDir, 3)) = XyzAvr_D(1 + mod(iDir, 3))
         XyzStencil_D(1 + mod(iDir + 1, 3)) = &
           XyzAvr_D(1 + mod(iDir + 1, 3))
-      end if
+      endif
     else
       !\
       ! Xyz point is close to three refined planes
@@ -2576,7 +2576,7 @@ contains
                                XyzGrid_DI(:, iFace_IDI(4, iDim, iGrid)))
           Distance_D(iDim) = &
             sum(((Xyz_D - XyzAvr_DD(:, iDim))*DxyzInv_D)**2)
-        end do
+        enddo
         iDir = minloc(Distance_D, DIM=1)
         iCase = Transition2Corner_
         iSortStencil3_II(Grid_, Transition2Corner_) = iGrid
@@ -2605,7 +2605,7 @@ contains
                                (iLevel_I(iEdge_ID(iGrid, iDim)) + 1)
           Distance_D(iDim) = &
             sum(((Xyz_D - XyzAvr_DD(:, iDim))*DxyzInv_D)**2)
-        end do
+        enddo
         iDir = minloc(Distance_D, DIM=1)
         iCase = TransitionJunction_
         iSortStencil3_II(Grid_, TransitionJunction_) = iGrid
@@ -2665,14 +2665,14 @@ contains
         else
           IsCorner = .true.
           XyzStencil_D = XyzAvr_D
-        end if
+        endif
       end select
-    end if
+    endif
     if (IsEdge) then
       iCase = Transition2Edge_
       iSortStencil3_II(Dir_, iCase) = iDirEdge
       XyzStencil_D(iDirEdge) = Xyz_D(iDirEdge)
-    end if
+    endif
   end subroutine check_transition3
   !============================
   subroutine interpolate_amr3( &
@@ -2790,7 +2790,7 @@ contains
       !/
       if (.not. iSortStencil3_II(Case_, iCase) == Face_) &
         iCase = iCaseExtended
-    end if
+    endif
     iGrid = iSortStencil3_II(Grid_, iCase)
     iDir = iSortStencil3_II(Dir_, iCase)
     iCase = iSortStencil3_II(Case_, iCase)
@@ -2826,7 +2826,7 @@ contains
                                  (XyzGrid_DI(x_:y_, iGrid + 3) - XyzGrid_DI(x_:y_, iGrid)), &
                                  Weight_I=Weight_I(iGrid:iGrid + 3), &
                                  IsOut_I=IsOut_I(iOrder_I(iGrid:iGrid + 3)))
-      end do
+      enddo
       !\
       ! Apply weight for interolation along z
       !/
@@ -2881,8 +2881,8 @@ contains
         else
           Weight_I(3 + iGrid) = Weight_I(iGrid)*AuxCoarse
           Weight_I(iGrid) = Weight_I(iGrid)*(1 - AuxCoarse)
-        end if
-      end do
+        endif
+      enddo
     case (TransitionJunction_)
       !\
       ! Check corner transition junction
@@ -2914,7 +2914,7 @@ contains
         iGrid = 2
       else
         iGrid = 3
-      end if
+      endif
       if (iLevel_I(iOrder_I(iGrid)) == Coarse_) then
         call interpolate_on_parallel_rays(Dir_D=0.50*( &
                                           XyzGrid_DI(:, 8) + XyzGrid_DI(:, 5)) - XyzGrid_DI(:, 1), &
@@ -2923,7 +2923,7 @@ contains
       else
         call interpolate_pyramids(iRectangular1_I=(/5, 6, 7, 8, 1/), &
                                   iRectangular2_I=(/iGrid, 4, iGrid + 4, 8, 1/))
-      end if
+      endif
       IsCorner = nGridOut <= 3
     case (Transition2Corner_)
       !\
@@ -2960,8 +2960,8 @@ contains
             iOrder_I((/iGrid + 4, nFine + 4/))
           XyzGrid_DI(:, (/nFine + 4, iGrid + 4/)) = &
             XyzGrid_DI(:, (/iGrid + 4, nFine + 4/))
-        end if
-      end do
+        endif
+      enddo
       nCoarse = nGridOut2 - nFine
       !\
       ! Two exceptions result from our desire to use whenever possible
@@ -3020,7 +3020,7 @@ contains
                                           iUTriangle1_I=(/1, 2, 5/))
         IsCorner = nGridOut < 1
         RETURN
-      end if
+      endif
       !\
       ! Otherwise use parallel-rays procedure with rays parallel to
       ! iDir, that is in the direction toward the corner. We employ the
@@ -3041,7 +3041,7 @@ contains
         AuxFine = 0.0
       else
         AuxFine = abs(dXyzUp)/(abs(dXyzUp) + abs(dXyzDown))
-      end if
+      endif
       !\
       ! Remove points, apply weights for fine points.
       !/
@@ -3440,8 +3440,8 @@ contains
         iShift_D(iDim) = 1 - iShift_D(iDim)
         iSliceMin_D(iDim) = iShift_D(iDim)
         iSliceMax_D(iDim) = iShift_D(iDim)
-      end if
-    end do
+      endif
+    enddo
     ! get the final result
     iGridRef = 1 + sum(iShift_D*iPowerOf2_D(1:nDim))
   end subroutine get_reference_block
@@ -3538,13 +3538,13 @@ contains
       iCellOut_II(:, 1) = floor(Dimless_D + 0.50)
       do iGrid = 2, nGrid
         iCellOut_II(:, iGrid) = iCellOut_II(:, 1) + iShift_DI(1:nDim, iGrid)
-      end do
+      enddo
       ! find interpolation weights
       Dimless_D = Dimless_D + 0.50 - iCellOut_II(:, 1)
       call interpolate_uniform(nDim, Dimless_D, Weight_I)
       call sort_out
       RETURN
-    end if
+    endif
 
     ! point is close to the block's boundary,
     ! iDiscr_D is an indicator of these boundaries: -1 or 0 or 1
@@ -3573,7 +3573,7 @@ contains
       iCellOut_II(:, 1) = floor(Dimless_D + 0.50)
       do iGrid = 2, nGrid
         iCellOut_II(:, iGrid) = iCellOut_II(:, 1) + iShift_DI(1:nDim, iGrid)
-      end do
+      enddo
       !\
       ! find interpolation weights. Dimensionless coordinate with
       ! respect to the stencil corner:
@@ -3583,7 +3583,7 @@ contains
       if (present(IsSecondOrder)) IsSecondOrder = .not. any(IsOut_I)
       call sort_out
       RETURN
-    end if
+    endif
 
     ! recompute iDiscr_D: certain configurations are not covered, e.g.
     !  __ __ _____ _____ _____
@@ -3684,7 +3684,7 @@ contains
             sum(iDiscr_D(1:nDim)*iPowerOf2_D(1:nDim)) + iGridBasic
         else
           iGridSeenFrom = iGridBasic
-        end if
+        endif
         nSubgrid_I(iGrid) = iPowerOf2_D(1 + nDim - &
                                         iLog2NDimOverNSubgrid_II(iGrid, iGridSeenFrom))
         do iOrder = 1, nSubgrid_I(iGrid)
@@ -3693,9 +3693,9 @@ contains
                                           + iShift_DI(1:nDim, iSubGrid)
           iCellIndexes_DII(:, iOrder, iGrid) = &
             nint(XyzGrid_DII(:, iOrder, iGrid) + 0.50)
-        end do
-      end if
-    end do
+        enddo
+      endif
+    enddo
 
     ! call interpolation routine
     call interpolate_extended_stencil( &
@@ -3723,7 +3723,7 @@ contains
       if (all(Weight_I >= cTol2)) then
         nCellOut = nGrid
         RETURN
-      end if
+      endif
       !\
       ! sort out zero weights
       !/
@@ -3733,7 +3733,7 @@ contains
         nCellOut = nCellOut + 1
         iCellOut_II(:, nCellOut) = iCellOut_II(:, iGrid)
         Weight_I(nCellOut) = Weight_I(iGrid)
-      end do
+      enddo
     end subroutine sort_out
   end subroutine interpolate_amr_gc
   !============================================================================
@@ -3931,7 +3931,7 @@ contains
       UseGhostCellLocal = UseGhostCell
     else
       UseGhostCellLocal = .false.
-    end if
+    endif
     if (present(IsSecondOrder)) IsSecondOrder = .false.
     !\
     ! Implemented version:
@@ -3955,7 +3955,7 @@ contains
       !/
       nGridOut = -1
       RETURN
-    end if
+    endif
     !\
     ! Now Xyz_D is given  with respect to the main block corner
     !/
@@ -3966,7 +3966,7 @@ contains
     if (nGridOut > 0) then
       if (present(IsSecondOrder)) IsSecondOrder = .true.
       RETURN
-    end if
+    endif
     call get_other_blocks(iGridOutOfBlock)
     !\
     ! recalculate grid cells indexes for ghost cells
@@ -4045,9 +4045,9 @@ contains
           iIndexes_II(1:nDim, nGridOut) = iCellIndexes_DII(:, 1, 1) + &
                                           iShift_DI(1:nDim, iGrid)
           Weight_I(nGridOut) = Weight_I(iGrid)
-        end do
+        enddo
         RETURN  !All interpolation is done, ready to exit
-      end if
+      endif
       XyzGrid_DII(:, 0, 1) = DxyzBasic_D*(iCellIndexes_DII(:, 1, 1) - 0.50)
       do iGrid = 2, nGrid
         iShift_D = iShift_DI(1:nDim, iGrid)
@@ -4056,7 +4056,7 @@ contains
         !\
         !This grid point is out of block, mark it
         !/
-      end do
+      enddo
       !\
       ! now XyzMisc_D = (Xyz_D-XyzGrid_DII(:,0,1))/Dxyz satisfies
       ! inequalities: XyzMisc_D >= 0 and XyzMisc_D < 1. Strengthen
@@ -4085,7 +4085,7 @@ contains
           iCellIndexes_DII(:, 1, 1) + iShift_D
         iBlock_I(iGrid) = iBlockBasic
         iProc_I(iGrid) = iProcBasic
-      end do
+      enddo
 
       iGridOutOfBlock = maxval(iOrder_I(1:nGrid), MASK=iProc_I == -1)
 
@@ -4136,10 +4136,10 @@ contains
             iGridOutOfBlock = iGrid
             call get_other_blocks(iGridOutOfBlock)
             RETURN
-          end if
-        end do
+          endif
+        enddo
         RETURN
-      end if
+      endif
       iLevel = 1 - floor(Dxyz_D(1)*DXyzInv_D(1) + cTol)
       !\                     ^
       ! For expression above | equal to 2 , 1, 0.5 correspondingly
@@ -4226,7 +4226,7 @@ contains
         XyzGrid_DII(:, 1, iGrid) = XyzGrid_DII(:, 0, iGrid)
         iLevelSubGrid_I(iGrid) = Coarse_
         nSubgrid_I(iGrid) = 1
-      end do
+      enddo
       iGridOutOfBlock = -1
       if (any(iProc_I == -1)) &
         iGridOutOfBlock = maxval(iOrder_I(1:nGrid), MASK=iProc_I == -1)
@@ -4311,7 +4311,7 @@ contains
             sum(iDiscr1_D(1:nDim)*iPowerOf2_D(1:nDim)) + iGridBasic
         else
           iGridSeenFrom = iGridBasic
-        end if
+        endif
         nSubgrid_I(iGrid) = iPowerOf2_D(1 + nDim - &
                                         iLog2NDimOverNSubgrid_II(iGrid, iGridSeenFrom))
         !iLog2NDimOverNSubgrid_II(iGrid,iGridBasic))
@@ -4321,8 +4321,8 @@ contains
           XyzGrid_DII(:, iOrderSubgrid, iGrid) = &
             XyzGrid_DII(:, 0, iGrid) + DxyzFine_D*(iShift_D - 0.50)
           iCellIndexes_DII(:, iOrderSubgrid, iGrid) = iCellIndexes_D + iShift_D
-        end do
-      end do
+        enddo
+      enddo
       iGridOutOfBlock = -1
       if (any(iProc_I == -1)) &
         iGridOutOfBlock = maxval(iOrder_I(1:nGrid), MASK=iProc_I == -1)
@@ -4455,7 +4455,7 @@ contains
               sum(iDiscr1_D(1:nDim)*iPowerOf2_D(1:nDim)) + iGridBasic
           else
             iGridSeenFrom = iGridBasic
-          end if
+          endif
           nSubgrid_I(iGrid) = iPowerOf2_D(1 + nDim - &
                                           iLog2NDimOverNSubgrid_II(iGrid, iGridSeenFrom))
           do iOrder = 1, nSubgrid_I(iGrid)
@@ -4468,9 +4468,9 @@ contains
               XyzGrid_DII(:, 0, iGrid) + Dxyz_D*(iShift_D - 0.50)
             iCellIndexes_DII(:, iOrder, iGrid) = &
               iCellIndexes_D + iShift_D
-          end do
-        end if
-      end do
+          enddo
+        endif
+      enddo
       !\
       ! Done with all previously found fine blocks. Now proceed to
       ! the coarse block
@@ -4511,11 +4511,11 @@ contains
           iShift_D = iShift_DI(1:nDim, iGrid) - iShift_DI(1:nDim, iGridPhys)
           iCellIndexes_DII(:, 1, iGrid) = &
             iCellIndexes_DII(:, 1, iGridPhys) + iShift_D
-        end do
+        enddo
         iBlock_I(1:nGrid) = iBlock_I(iGridPhys)
         iProc_I(1:nGrid) = iProc_I(iGridPhys)
         RETURN
-      end if
+      endif
       do iGrid = 1, nGrid
         !\
         ! Nothing to do, if this part of the extended stencil consists
@@ -4546,9 +4546,9 @@ contains
                                                  iCellIndexes_DII(:, nSubgrid_I(iGridPhys), iGridPhys) + &
                                                  iCellIndexes_DII(:, iOrder, iGrid) - &
                                                  iCellIndexes_DII(:, nSubgrid_I(iGrid), iGrid)
-          end do
-        end if
-      end do
+          enddo
+        endif
+      enddo
     end subroutine get_ghost_cell_indexes
   end subroutine interpolate_amr
   !=================================
@@ -4697,10 +4697,10 @@ contains
         iIndexes_II(nIndexes, nGridOut) = iBlock_I(iGrid)
         iIndexes_II(1:nCellId, nGridOut) = iCellIndexes_DII(:, 1, iGrid)
         Weight_I(nGridOut) = Weight_I(iGrid)
-      end do
+      enddo
       if (present(IsSecondOrder)) IsSecondOrder = .not. IsNearBoundary
       RETURN
-    end if
+    endif
     !\
     !Start non-uniform grid
     !/
@@ -4709,7 +4709,7 @@ contains
     else
       nSubgrid_I = 1
       where (iLevelSubgrid_I == Fine_ .and. .not. IsOut_I) nSubgrid_I = nGrid
-    end if
+    endif
     if (IsNearBoundary) call prolong_beyond_boundary
 
     if (DoInit) call init_sort_stencil
@@ -4738,7 +4738,7 @@ contains
         call interpolate_amr3( &
           Xyz_D, XyzGrid_DI, iLevel_I, IsOut_I, iCaseExtended, &
           nGridOut, Weight_I, iOrder_I, IsCorner)
-      end if
+      endif
       if (IsCorner) then
         !\
         ! This is not necessarily esleif,
@@ -4750,7 +4750,7 @@ contains
         call generate_corner_stencil
         call resolution_corner(Xyz_D, XyzGrid_DI, iLevel_I, &
                                nGridOut, Weight_I, iOrder_I)
-      end if
+      endif
     end select
     !\
     ! Eliminate repeating grid points and points with zero weight
@@ -4788,10 +4788,10 @@ contains
             do iGrid = 1, 4
               call prolong(iFace_IDI(iGrid, iDir, iLoc), &
                            iOppositeFace_IDI(iGrid, iDir, iLoc))
-            end do
+            enddo
             RETURN
-          end if
-        end do
+          endif
+        enddo
       case (2)
         ! Analogous to the previous case, but nDim = 2
         !\
@@ -4808,10 +4808,10 @@ contains
             do iGrid = 1, 2
               call prolong(iSide_IDI(iGrid, iDir, iLoc), &
                            iOppositeSide_IDI(iGrid, iDir, iLoc))
-            end do
+            enddo
             RETURN
-          end if
-        end do
+          endif
+        enddo
       case (6)
         !\
         ! Three-dimensional case, only two grid vertexes are
@@ -4827,10 +4827,10 @@ contains
                            iFace_IDI(iGrid, iDir, iLoc))
               call prolong(iEdge_ID(iLoc, iDir), &
                            iOppositeFace_IDI(iGrid, iDir, iLoc))
-            end do
+            enddo
             RETURN
-          end if
-        end do
+          endif
+        enddo
       end select
     end subroutine prolong_beyond_boundary
     !======================
@@ -4864,8 +4864,8 @@ contains
                                                  XyzGrid_DII(:, 0, iGridGhost) - 2*NormalToFace_D* &
                                                  sum(NormalToFace_D*DeltaXyzRef_D)/ &
                                                  sum(NormalToFace_D**2)
-        end do
-      end if
+        enddo
+      endif
     end subroutine prolong
 
     !==================
@@ -4891,9 +4891,9 @@ contains
             XyzGrid_DI(:, iGrid) = XyzGrid_DII(:, 9 - iGrid, iGrid)
             iIndexes_II(1:nCellId, iGrid) = &
               iCellIndexes_DII(:, 9 - iGrid, iGrid)
-          end if
-        end if
-      end do
+          endif
+        endif
+      enddo
     end subroutine generate_corner_stencil
     !==================
     subroutine generate_basic_stencil(XyzStencil_D)
@@ -4931,8 +4931,8 @@ contains
             XyzStencil_D < XyzGrid_DII(:, iSubGrid, iGrid)
           Distance_I(iPoint) = sum( &
                                ((XyzStencil_D - XyzGrid_DII(:, iSubGrid, iGrid))*dXyzInv_D)**2)
-        end do
-      end do
+        enddo
+      enddo
       nExtendedStencil = iPoint
       do iGrid = 1, nGrid
         do iPoint = 1, nExtendedStencil
@@ -4942,7 +4942,7 @@ contains
           !/
           IsMask_I(iPoint) = all( &
                              IsBelowExtended_DI(:, iPoint) .eqv. IsBelow_DI(1:nDim, iGrid))
-        end do
+        enddo
         !\
         !Among the candidates chose the closest one
         !/
@@ -4958,7 +4958,7 @@ contains
           iCellIndexes_DII(:, iSubGrid_I(iPoint), iGrid_I(iPoint))
         iLevel_I(iGrid) = iLevelSubgrid_I(iGrid_I(iPoint))
         IsOut_I(iGrid) = IsOutSaved_I(iGrid_I(iPoint))
-      end do
+      enddo
     end subroutine generate_basic_stencil
     !==================
     subroutine sort_out
@@ -4984,12 +4984,12 @@ contains
           if (iOrder_I(iLoc) == iOrder_I(iGrid)) then
             Weight_I(iLoc) = Weight_I(iLoc) + Weight_I(iGrid)
             CYCLE ALL
-          end if
-        end do
+          endif
+        enddo
         nGridOut = nGridOut + 1
         iOrder_I(nGridOut) = iOrder_I(iGrid)
         Weight_I(nGridOut) = Weight_I(iGrid)
-      end do ALL
+      enddo ALL
     end subroutine sort_out
   end subroutine interpolate_extended_stencil
 end module ModInterpolateAMR

--- a/share/Library/src/ModInterpolateCellAMR.f90
+++ b/share/Library/src/ModInterpolateCellAMR.f90
@@ -109,7 +109,7 @@ contains
       DXyzInvInput_D = 0.50*DXyzInv_D
     else
       DXyzInvInput_D = DXyzInv_D
-    end if
+    endif
     !\
     ! call interpolation routine
     !/
@@ -271,7 +271,7 @@ contains
       do iGrid = 1, nGrid
         XyzGridCoarse_DII(:, 0, iGrid) = XyzCoarseCenter_D + &
                                          DXyz_D*(2*iShift_DI(1:nDim, iGrid) - 1)
-      end do
+      enddo
       !\
       ! Store an info about the coarse cell
       !/
@@ -294,7 +294,7 @@ contains
         XyzGridCoarse_DII(:, iGrid, iGridCoarse) = &
           XyzGridCoarse_DII(:, 0, iGridCoarse) + &
           DXyz_D*(-0.50 + iShift_DI(1:nDim, iGrid))
-      end do
+      enddo
 
       iDiscrSubGrid_D = nint(0.50 + SIGN(0.50, XyzCell_D &
                                          - XyzGridCoarse_DII(:, 0, iGridCoarse)))
@@ -302,7 +302,7 @@ contains
       iCellIdCoarse_III(:, iSubGrid, iGridCoarse) = &
         iCellId_I
       IsOutCoarse_I(iGridCoarse) = .false.
-    end if
+    endif
     !\
     !Construct an ordered list of neighbors
     !/
@@ -333,7 +333,7 @@ contains
             NameSub//': neighbor is inside the central cell')
           if (any(iDiscr_D > 1 .or. iDiscr_D < -1)) call CON_stop( &
             NameSub//': neighbor does not contact the central cell')
-        end if
+        endif
         !\
         !Initialize the grid coordinates, if needed
         !/
@@ -364,8 +364,8 @@ contains
               XyzGridCoarse_DII(:, iGrid, iGridCoarse) = &
                 XyzGridCoarse_DII(:, 0, iGridCoarse) + &
                 DXyz_D*(-0.50 + iShift_DI(1:nDim, iGrid))
-            end do
-          end if
+            enddo
+          endif
           iDiscrSubGrid_D = nint(0.50 + SIGN(0.50, XyzNeighbor_DI(:, iNeighbor) &
                                              - XyzGridCoarse_DII(:, 0, iGridCoarse)))
           iSubGrid = sum(iDiscrSubGrid_D*iPowerOf2_D(1:nDim)) + 1
@@ -373,7 +373,7 @@ contains
             iCellId_II(:, iNeighbor)
           IsOutCoarse_I(iGridCoarse) = &
             IsOutCoarse_I(iGridCoarse) .or. IsOut_I(iNeighbor)
-        end if
+        endif
       case (1)
         iDiscr_D(1:nDim) = &
           floor((XyzNeighbor_DI(:, iNeighbor) - XyzCorner_D)*DXyzInv_D)
@@ -385,7 +385,7 @@ contains
             NameSub//': neighbor is inside the central cell')
           if (any(iDiscr_D > 1 .or. iDiscr_D < -1)) call CON_stop( &
             NameSub//': neighbor does not contact the central cell')
-        end if
+        endif
         if (DoRefineGrid_III(iDiscr_D(1), iDiscr_D(2), iDiscr_D(3))) then
           DoRefineGrid_III(iDiscr_D(1), iDiscr_D(2), iDiscr_D(3)) = .false.
           !\
@@ -398,8 +398,8 @@ contains
             XyzGrid_DIIII(:, iGrid, iDiscr_D(1), iDiscr_D(2), iDiscr_D(3)) = &
               XyzGrid_DIIII(:, 0, iDiscr_D(1), iDiscr_D(2), iDiscr_D(3)) + &
               DXyz_D*0.50*(-0.50 + iShift_DI(1:nDim, iGrid))
-          end do
-        end if
+          enddo
+        endif
         !\
         ! Put the neighbor info into the ordered list
         !/
@@ -437,9 +437,9 @@ contains
           if (DoTest) then
             if (all(iDiscr_D == 0)) call CON_stop( &
               NameSub//': neighbor is inside the central cell')
-          end if
+          endif
           iLevel_III(iDiscr_D(1), iDiscr_D(2), iDiscr_D(3)) = -1
-        end do
+        enddo
         if (iNeighbor == iCoarseNeighbor) CYCLE
         !\
         !Store the coarse cell information in coarse extended stencil
@@ -452,7 +452,7 @@ contains
         iLevelCoarse_I(iGridCoarse) = -1
         IsOutCoarse_I(iGridCoarse) = IsOut_I(iNeighbor)
       end select
-    end do
+    enddo
     !\
     !Form output arrays
     !/
@@ -484,8 +484,8 @@ contains
 
         iCellId_IIII(:, :, :, iGrid) = iCellIdCoarse_III
         XyzGrid_DIII(:, :, :, iGrid) = XyzGridCoarse_DII
-      end if
-    end do
+      endif
+    enddo
   end subroutine order_connectivity_list
   !
 end module ModInterpolateCellAMR

--- a/share/Library/src/ModIoUnit.f90
+++ b/share/Library/src/ModIoUnit.f90
@@ -81,8 +81,8 @@ contains
       if (IsExisting .and. .not. IsOpened .and. iError == 0) then
         iUnitMax = max(iUnitMax, iUnit)
         return
-      end if
-    end do
+      endif
+    enddo
 
     iUnit = -1
 
@@ -112,9 +112,9 @@ contains
         else
           ! Close file again
           close(iUnit)
-        end if
-      end if
-    end do
+        endif
+      endif
+    enddo
 
   end subroutine io_unit_clean
   !==========================================================================
@@ -159,7 +159,7 @@ contains
       close(iUnit1, STATUS='delete')
       inquire(file='ascii', exist=IsExisting)
       if (IsExisting) write(*, *) 'failed to delete file "ascii"'
-    end if
+    endif
 
     inquire(file='binary', exist=IsExisting)
     if (.not. IsExisting) then
@@ -170,7 +170,7 @@ contains
       close(iUnit2, STATUS='delete')
       inquire(file='binary', exist=IsExisting)
       if (IsExisting) write(*, *) 'failed to delete file "binary"'
-    end if
+    endif
 
     inquire(file='empty_ascii', exist=IsExisting)
     if (IsExisting) then
@@ -180,7 +180,7 @@ contains
       close(iUnit3, STATUS='delete')
       inquire(file='empty_ascii', exist=IsExisting)
       if (IsExisting) write(*, *) 'failed to delete file "empty_ascii"'
-    end if
+    endif
 
     inquire(file='empty_binary', exist=IsExisting)
     if (IsExisting) then
@@ -190,7 +190,7 @@ contains
       close(iUnit4, STATUS='delete')
       inquire(file='empty_binary', exist=IsExisting)
       if (IsExisting) write(*, *) 'failed to delete file "empty_binary"'
-    end if
+    endif
 
   end subroutine io_unit_test
 

--- a/share/Library/src/ModLinearAdvection.f90
+++ b/share/Library/src/ModLinearAdvection.f90
@@ -47,7 +47,7 @@ contains
       BetaLim = BetaIn
     else
       BetaLim = 2.0
-    end if
+    endif
 
     if (present(IsNegativeEnergy)) IsNegativeEnergy = .false.
 
@@ -64,8 +64,8 @@ contains
       else
         write(*, *) 'F_I:', F_I
         call CON_stop('Error in '//NameSub)
-      end if
-    end if
+      endif
+    endif
 
     !One stage second order upwind scheme
 
@@ -81,7 +81,7 @@ contains
         ! f_(i+1/2):
         FSemiintUp_I(iX) = F_I(iX) + &
                            0.50*(1.0 - CFL_I(iX))*df_lim(F_I(iX - 1:iX + 1))
-      end do
+      enddo
       ! f_(i-1/2):
       FSemiintDown_I(1:nX) = FSemiintUp_I(0:nX - 1)
 
@@ -89,14 +89,14 @@ contains
       if (present(UseConservativeBC)) then
         FSemiintDown_I(1) = 0.0
         FSemiintUp_I(nX) = 0.0
-      end if
+      endif
 
       !\
       ! Update the solution from f^(n) to f^(n+1):
       !/
       F_I(1:nX) = F_I(1:nX) + CFL_I(1:nX)* &
                   (FSemiintDown_I(1:nX) - FSemiintUp_I(1:nX))
-    end do
+    enddo
 
     FInOut_I(1 - nGCLeft:nX + nGCRight) = F_I(1 - nGCLeft:nX + nGCRight)
     if (any(FInOut_I(1:nX) < 0.0)) then
@@ -107,8 +107,8 @@ contains
         return
       else
         call CON_stop('Error in '//NameSub)
-      end if
-    end if
+      endif
+    endif
   end subroutine advance_lin_advection_plus
 
   !===========advance_lin_advection==========================================!
@@ -154,7 +154,7 @@ contains
       BetaLim = BetaIn
     else
       BetaLim = 2.0
-    end if
+    endif
     if (present(IsNegativeEnergy)) IsNegativeEnergy = .false.
 
     nStep = 1 + int(maxval(CFLIn_I)); CFL_I(1:nX) = CFLIn_I/real(nStep)
@@ -172,8 +172,8 @@ contains
       else
         write(*, *) 'F_I:', F_I
         call CON_stop('Error in '//NameSub)
-      end if
-    end if
+      endif
+    endif
 
     !One stage second order upwind scheme
 
@@ -186,7 +186,7 @@ contains
         ! f_(i-1/2):
         FSemiintDown_I(iX) = F_I(iX) &
                              - 0.50*(1.0 - CFL_I(iX))*df_lim(F_I(iX - 1:iX + 1))
-      end do
+      enddo
       ! f_(i+1/2):
       FSemiintUp_I(1:nX) = FSemiintDown_I(2:nX + 1)
 
@@ -194,12 +194,12 @@ contains
       if (present(UseConservativeBC)) then
         FSemiintDown_I(1) = 0.0
         FSemiintUp_I(nX) = 0.0
-      end if
+      endif
       !\
       ! Update the solution from f^(n) to f^(n+1):
       !/
       F_I(1:nX) = F_I(1:nX) - CFL_I(1:nX)*(FSemiintDown_I(1:nX) - FSemiintUp_I(1:nX))
-    end do
+    enddo
 
     FInOut_I(1:nX) = F_I(1:nX)
 
@@ -211,8 +211,8 @@ contains
         return
       else
         call CON_stop('Error in '//NameSub)
-      end if
-    end if
+      endif
+    endif
     !------------------------------------ DONE --------------------------------!
   end subroutine advance_lin_advection_minus
   !============================================================================!
@@ -242,7 +242,7 @@ contains
       call advance_lin_advection_minus(CFL, nCell, nGCLeft, nGCRight, Fminus_I, &
                                        2.0, .true., IsNegativeEnergy)
 
-    end do
+    enddo
 
     ! write sln to file
     ! Deafault output file name
@@ -259,7 +259,7 @@ contains
     write(UNITTMP_, '(a,i3.3,a,i5.5,a)') 'Zone I= ', nCell, ' F=point'
     do iCell = 1, nCell
       write(UNITTMP_, '(i3.3,e14.6,e14.6)') iCell, Fplus_I(iCell), Fminus_I(iCell)
-    end do
+    enddo
     close(UNITTMP_)
 
   end subroutine test_linear_advection

--- a/share/Library/src/ModLinearSolver.f90
+++ b/share/Library/src/ModLinearSolver.f90
@@ -197,7 +197,7 @@ contains
       epsmac = 0.0000000000000001
     else
       epsmac = 0.00000001
-    end if
+    endif
 
     its = 0
     !-------------------------------------------------------------
@@ -214,7 +214,7 @@ contains
       else
         ! Save a matvec when starting from zero initial condition
         Krylov_II(:, 1) = Rhs
-      end if
+      endif
       !-------------------------------------------------------------
       ro = sqrt(dot_product_mpi(Krylov_II(:, 1), Krylov_II(:, 1), iComm))
       if (ro == 0.0) then
@@ -222,12 +222,12 @@ contains
           info = 3
         else
           info = 0
-        end if
+        endif
         Tol = ro
         Iter = its
         deallocate(Krylov_II, hh, c, s, rs)
         RETURN
-      end if
+      endif
 
       ! set Tol1 for stopping criterion
       if (its == 0) then
@@ -242,11 +242,11 @@ contains
             if (DoTest) print *, 'GMRES: nothing to do. info = ', info
             deallocate(Krylov_II, hh, c, s, rs)
             RETURN
-          end if
+          endif
         else
           Tol1 = Tol*ro
-        end if
-      end if
+        endif
+      endif
 
       coeff = 1.0/ro
       Krylov_II(:, 1) = coeff*Krylov_II(:, 1)
@@ -269,14 +269,14 @@ contains
           t = dot_product_mpi(Krylov_II(:, j), Krylov_II(:, i1), iComm)
           hh(j, i) = t
           Krylov_II(:, i1) = Krylov_II(:, i1) - t*Krylov_II(:, j)
-        end do
+        enddo
         t = sqrt(dot_product_mpi(Krylov_II(:, i1), Krylov_II(:, i1), iComm))
 
         hh(i1, i) = t
         if (t /= 0.0) then
           t = 1.0/t
           Krylov_II(:, i1) = t*Krylov_II(:, i1)
-        end if
+        endif
         !--------done with modified gram schmidt and arnoldi step
 
         !-------- now  update factorization of hh
@@ -287,7 +287,7 @@ contains
           t = hh(k1, i)
           hh(k1, i) = c(k1)*t + s(k1)*hh(k, i)
           hh(k, i) = -s(k1)*t + c(k1)*hh(k, i)
-        end do
+        enddo
         gam = sqrt(hh(i, i)**2 + hh(i1, i)**2)
         if (gam == 0.0) gam = epsmac
         !-----------#  determine next plane rotation  #-------------------
@@ -305,9 +305,9 @@ contains
           case ('abs')
             write(*, *) its, ' matvecs, ', ' ||rn|| =', ro
           end select
-        end if
+        endif
         if (i >= nKrylov .or. (ro <= Tol1)) exit KRYLOVLOOP
-      end do KRYLOVLOOP
+      enddo KRYLOVLOOP
 
       !
       ! now compute solution. first solve upper triangular system.
@@ -320,20 +320,20 @@ contains
           tmp = rs(j)
           do k = j - 1, 1, -1
             rs(k) = rs(k) - tmp*hh(k, j)
-          end do
-        end if
-      end do
+          enddo
+        endif
+      enddo
 
       ! done with back substitution..
       ! now form linear combination to get solution
       do j = 1, i
         t = rs(j)
         Sol = Sol + t*Krylov_II(:, j)
-      end do
+      enddo
 
       ! exit from outer loop if converged or too many iterations
       if (ro <= Tol1 .or. its >= Iter) exit RESTARTLOOP
-    end do RESTARTLOOP
+    enddo RESTARTLOOP
 
     Iter = its
     Tol = Tol/Tol1*ro ! (relative) tolerance achieved
@@ -343,7 +343,7 @@ contains
       info = 2
     else
       info = -2
-    end if
+    endif
 
     ! Deallocate arrays that used to be automatic
     deallocate(Krylov_II, hh, c, s, rs)
@@ -474,7 +474,7 @@ contains
       assumedzero = 0.0000000000000001
     else
       assumedzero = 0.00000001
-    end if
+    endif
 
     !
     !     --- Initialize first residual
@@ -488,7 +488,7 @@ contains
       bicg_r = rhs - bicg_r
     else
       bicg_r = rhs
-    end if
+    endif
 
     qx = 0.0
     bicg_u = 0.0
@@ -547,10 +547,10 @@ contains
       if (nonzero) then
         qx = qx0
         deallocate(qx0)
-      end if
+      endif
 
       RETURN
-    end if
+    endif
 
     do while (GoOn)
       !
@@ -568,9 +568,9 @@ contains
         if (nonzero) then
           qx = qx + qx0
           deallocate(qx0)
-        end if
+        endif
         RETURN
-      end if
+      endif
       beta = alpha*(rho1/rho0)
       rho0 = rho1
       bicg_u = bicg_r - beta*bicg_u
@@ -590,9 +590,9 @@ contains
         if (nonzero) then
           qx = qx + qx0
           deallocate(qx0)
-        end if
+        endif
         RETURN
-      end if
+      endif
 
       alpha = rho1/sigma
 
@@ -686,7 +686,7 @@ contains
         if (DoTest) print *, nmv, ' matvecs, max(rn) =', rnrmMax
       end select
 
-    end do
+    enddo
     !
     !     =========================
     !     --- End of iterations ---
@@ -696,7 +696,7 @@ contains
     if (nonzero) then
       qx = qx + qx0
       deallocate(qx0)
-    end if
+    endif
 
     select case (typestop)
     case ('rel')
@@ -800,7 +800,7 @@ contains
       Rhs_I = Rhs_I - ADotVec_I
     else
       Sol_I = 0.0
-    end if
+    endif
 
     Vec_I = 0.0
 
@@ -812,13 +812,13 @@ contains
       rDotR0 = dot_product_mpi(Rhs_I, PrecRhs_I, iComm)
     else
       rDotR0 = dot_product_mpi(Rhs_I, Rhs_I, iComm)
-    end if
+    endif
 
     if (TypeStop == 'abs') then
       rDotRMax = Tol**2
     else
       rDotRMax = Tol**2*max(rDotR0, 1e-99)
-    end if
+    endif
 
     if (DoTest) write(*, *) 'CG rDotR0, rDotRMax=', rDotR0, rDotRMax
 
@@ -835,7 +835,7 @@ contains
         Vec_I = Vec_I + Alpha*PrecRhs_I
       else
         Vec_I = Vec_I + Alpha*Rhs_I
-      end if
+      endif
 
       UsePDotADotP = .false.
 
@@ -847,7 +847,7 @@ contains
         UsePDotADotP = .false.
       else
         pDotADotP = dot_product_mpi(Vec_I, aDotVec_I, iComm)
-      end if
+      endif
       Beta = 1.0/pDotADotP
 
       Rhs_I = Rhs_I - Beta*aDotVec_I
@@ -861,10 +861,10 @@ contains
         rDotR = dot_product_mpi(Rhs_I, PrecRhs_I, iComm)
       else
         rDotR = dot_product_mpi(Rhs_I, Rhs_I, iComm)
-      end if
+      endif
       if (DoTest) write(*, *) 'CG nIter, rDotR=', nIter, rDotR
 
-    end do
+    enddo
 
     ! Deallocate the temporary vectors
     deallocate(Vec_I, aDotVec_I)
@@ -875,7 +875,7 @@ contains
       Tol = sqrt(rDotR)
     else
       Tol = sqrt(rDotR/max(rDotR0, 1e-99))
-    end if
+    endif
 
     ! Set the error flag
     if (rDotR0 < rDotRMax) then
@@ -887,7 +887,7 @@ contains
       iError = 2
     else
       iError = -2
-    end if
+    endif
 
   end subroutine cg
 
@@ -935,17 +935,17 @@ contains
       Maximum = 0.0
       do i = 1, n
         Maximum = max(Maximum, abs(a_I(i)*b_I(i)))
-      end do
+      enddo
       if (present(iComm)) then
         if (iComm /= MPI_COMM_SELF) then
           call MPI_COMM_SIZE(iComm, nProc, iError)
           if (nProc > 1) call MPI_allreduce( &
             MPI_IN_PLACE, Maximum, 1, MPI_REAL, MPI_MAX, iComm, iError)
-        end if
-      end if
+        endif
+      endif
       ! Formulate an integer power of 2 near Ratio*Maximum
       Limit = 2.0**exponent(Ratio*Maximum)
-    end if
+    endif
 
     SumPart_I = 0.0
     do i = 1, n
@@ -953,15 +953,15 @@ contains
       Part_I(1) = modulo(a, Limit)
       Part_I(2) = a - Part_I(1)
       SumPart_I = SumPart_I + Part_I
-    end do
+    enddo
 
     if (present(iComm)) then
       if (iComm /= MPI_COMM_SELF) then
         call MPI_allreduce(SumPart_I, SumAllPart_I, nPart, MPI_REAL, &
                            MPI_SUM, iComm, iError)
         SumPart_I = SumAllPart_I
-      end if
-    end if
+      endif
+    endif
 
     accurate_dot_product = sum(SumPart_I)
 
@@ -980,14 +980,14 @@ contains
     if (UseAccurateSum) then
       dot_product_mpi = accurate_dot_product(a_I, b_I, iComm=iComm)
       RETURN
-    end if
+    endif
 
     DotProduct = dot_product(a_I, b_I)
 
     if (iComm == MPI_COMM_SELF) then
       dot_product_mpi = DotProduct
       RETURN
-    end if
+    endif
     call MPI_allreduce(DotProduct, DotProductMpi, 1, MPI_REAL, MPI_SUM, &
                        iComm, iError)
     dot_product_mpi = DotProductMpi
@@ -1008,7 +1008,7 @@ contains
     if (iComm == MPI_COMM_SELF) then
       maxval_abs_mpi = MaxvalAbs
       RETURN
-    end if
+    endif
 
     call MPI_allreduce(MaxvalAbs, MaxvalAbsMpi, 1, MPI_REAL, MPI_MAX, &
                        iComm, iError)
@@ -1184,9 +1184,9 @@ contains
         if (present(f2)) then
           allocate(f2Orig_VVI(n, n, nBlock))
           f2Orig_VVI = f2
-        end if
-      end if
-    end if
+        endif
+      endif
+    endif
 
     do j = 1, nBlock
 
@@ -1201,7 +1201,7 @@ contains
                                    e1(:, :, j), N, f1(:, :, j - M1), n, 1.0, dd, n)
         if (j > m2) call BLAS_gemm('n', 'n', n, n, n, -1.0, &
                                    e2(:, :, j), N, f2(:, :, j - M2), n, 1.0, dd, n)
-      end if
+      endif
       if (iPrecond <= Mbilu_) then
         ! Relaxed Gustafsson modification for MBILU
 
@@ -1215,7 +1215,7 @@ contains
                          e2(:, :, j), N, f(:, :, j - M2), N, 1.0, dd, N)
           call BLAS_GEMM('n', 'n', N, N, N, PrecondParam, &
                          e2(:, :, j), N, f1(:, :, j - M2), N, 1.0, dd, N)
-        end if
+        endif
         if (j > M1) call BLAS_GEMM('n', 'n', N, N, N, PrecondParam, &
                                    e1(:, :, j), N, f(:, :, j - M1), N, 1.0, dd, N)
         if (j > M1 .and. j - M1 <= nBlock - M2) &
@@ -1227,7 +1227,7 @@ contains
         if (j > 1 .and. j - 1 <= nBlock - M1) &
           call BLAS_GEMM('n', 'n', N, N, N, PrecondParam, &
                          e(:, :, j), N, f1(:, :, j - 1), N, 1.0, dd, N)
-      end if
+      endif
 
       ! Invert the diagonal block by first factorizing then solving D.D'=I
       call LAPACK_getrf(n, n, dd, n, pivot, info)
@@ -1235,7 +1235,7 @@ contains
       d(:, :, j) = 0.0
       do i = 1, N
         d(i, i, j) = 1.0
-      end do
+      enddo
       ! Solve the problem, returns D^-1 into d(j)
       call LAPACK_getrs('n', n, n, dd, n, pivot, d(:, :, j), n, info)
 
@@ -1249,19 +1249,19 @@ contains
         dd = f(:, :, j)
         call BLAS_gemm('n', 'n', n, n, n, 1.0, d(:, :, j), n, dd, n, 0.0, &
                        f(:, :, j), n)
-      end if
+      endif
       if (j + M1 <= nBlock) then
         dd = f1(:, :, j)
         call BLAS_gemm('n', 'n', n, n, n, 1.0, d(:, :, j), n, dd, n, 0.0, &
                        f1(:, :, j), n)
-      end if
+      endif
       if (j + M2 <= nBlock) then
         dd = f2(:, :, j)
         call BLAS_gemm('n', 'n', n, n, n, 1.0, d(:, :, j), n, dd, n, 0.0, &
                        f2(:, :, j), n)
-      end if
+      endif
 
-    end do
+    enddo
 
     if (iPrecond == Dilu_) then
       ! DILU prec requires original diagonal blocks in U, so restore it
@@ -1273,9 +1273,9 @@ contains
         if (present(f2)) then
           f2 = f2Orig_VVI
           deallocate(f2Orig_VVI)
-        end if
-      end if
-    end if
+        endif
+      endif
+    endif
 
     ! Deallocate arrays
     deallocate(dd, pivot)
@@ -1343,7 +1343,7 @@ contains
     if (n == 1) then
       call upper_hepta_scalar(inverse, nblock, M1, M2, x, f, f1, f2)
       RETURN
-    end if
+    endif
     if (n <= 20) then
       ! F90 VERSION
       if (inverse) then
@@ -1359,8 +1359,8 @@ contains
                       - matmul(f1(:, :, j), x(:, j + M1))
           else
             x(:, j) = x(:, j) - matmul(f(:, :, j), x(:, j + 1))
-          end if
-        end do
+          endif
+        enddo
       else
         !  x := U.x = x + F.x(j+1) + F1.x(j+M1) + F2.x(j+M2)
         do j = 1, nblock - 1
@@ -1373,9 +1373,9 @@ contains
                       + matmul(f1(:, :, j), x(:, j + M1))
           else
             x(:, j) = x(:, j) + matmul(f(:, :, j), x(:, j + 1))
-          end if
-        end do
-      end if
+          endif
+        enddo
+      endif
     else
       ! BLAS VERSION
       if (inverse) then
@@ -1387,7 +1387,7 @@ contains
                                                f1(:, :, j), n, x(:, j + M1), 1, 1.0, x(:, j), 1)
           if (j + M2 <= nblock) CALL BLAS_gemv('n', n, n, -1.0, &
                                                f2(:, :, j), n, x(:, j + M2), 1, 1.0, x(:, j), 1)
-        end do
+        enddo
       else
         !  x := U.x = x + F.x(j+1) + F1.x(j+M1) + F2.x(j+M2)
         do j = 1, nblock - 1
@@ -1397,9 +1397,9 @@ contains
             'n', n, n, 1.0, f1(:, :, j), n, x(:, j + M1), 1, 1.0, x(:, j), 1)
           if (j + M2 <= nblock) call BLAS_gemv( &
             'n', n, n, 1.0, f2(:, :, j), n, x(:, j + M2), 1, 1.0, x(:, j), 1)
-        end do
-      end if
-    end if
+        enddo
+      endif
+    endif
 
     !call timing_stop('Uhepta')
 
@@ -1466,7 +1466,7 @@ contains
     if (n == 1) then
       call lower_hepta_scalar(nblock, M1, M2, x, d, e, e1, e2)
       RETURN
-    end if
+    endif
     ! Allocate arrays that used to be automatic
     allocate(work(N))
     if (n <= 20) then
@@ -1485,9 +1485,9 @@ contains
         else if (j > 1) then
           work = work &
                  - matmul(e(:, :, j), x(:, j - 1))
-        end if
+        endif
         x(:, j) = matmul(d(:, :, j), work)
-      end do
+      enddo
     else
       ! BLAS VERSION
       do j = 1, nblock
@@ -1501,8 +1501,8 @@ contains
           'n', n, n, -1.0, e2(:, :, j), n, x(:, j - M2), 1, 1.0, work, 1)
         call BLAS_copy(n, work, 1, x(:, j), 1)
 
-      end do
-    end if
+      enddo
+    endif
     deallocate(work)
 
     !call timing_stop('Lhepta')
@@ -1540,8 +1540,8 @@ contains
           x(j) = x(j) - f(j)*x(j + 1) - f1(j)*x(j + M1)
         else
           x(j) = x(j) - f(j)*x(j + 1)
-        end if
-      end do
+        endif
+      enddo
     else
       !  x := U.x = x + F.x(j+1) + F1.x(j+M1) + F2.x(j+M2)
       do j = 1, nblock - 1
@@ -1551,9 +1551,9 @@ contains
           x(j) = x(j) + f(j)*x(j + 1) + f1(j)*x(j + M1)
         else
           x(j) = x(j) + f(j)*x(j + 1)
-        end if
-      end do
-    end if
+        endif
+      enddo
+    endif
 
   end subroutine upper_hepta_scalar
 
@@ -1587,9 +1587,9 @@ contains
         work1 = work1 - e(j)*x(j - 1) - e1(j)*x(j - M1)
       else if (j > 1) then
         work1 = work1 - e(j)*x(j - 1)
-      end if
+      endif
       x(j) = d(j)*work1
-    end do
+    enddo
 
   end subroutine lower_hepta_scalar
 
@@ -1624,18 +1624,18 @@ contains
         do i = 1, n
           x_V(i) = x_V(i) - e(i, i, j)*x(i, j - 1) - e1(i, i, j)*x(i, j - M1) &
                    - e2(i, i, j)*x(i, j - M2)
-        end do
+        enddo
       else if (j > M1) then
         do i = 1, n
           x_V(i) = x_V(i) - e(i, i, j)*x(i, j - 1) - e1(i, i, j)*x(i, j - M1)
-        end do
+        enddo
       else if (j > 1) then
         do i = 1, n
           x_V(i) = x_V(i) - e(i, i, j)*x(i, j - 1)
-        end do
-      end if
+        enddo
+      endif
       x(:, j) = matmul(d(:, :, j), x_V)
-    end do
+    enddo
 
     !  x' := U^{-1}.x = x - D^-1 [F.x'(j+1) - F1.x'(j+M1) - F2.x'(j+M2)]
     do j = nBlock - 1, 1, -1
@@ -1643,19 +1643,19 @@ contains
         do i = 1, n
           x_V(i) = f(i, i, j)*x(i, j + 1) + f1(i, i, j)*x(i, j + M1) &
                    + f2(i, i, j)*x(i, j + M2)
-        end do
+        enddo
       else if (j + M1 <= nBlock) then
         do i = 1, n
           x_V(i) = f(i, i, j)*x(i, j + 1) + f1(i, i, j)*x(i, j + M1)
-        end do
+        enddo
       else
         do i = 1, n
           x_V(i) = f(i, i, j)*x(i, j + 1)
-        end do
-      end if
+        enddo
+      endif
       x(:, j) = x(:, j) - matmul(d(:, :, j), x_V)
 
-    end do
+    enddo
     deallocate(x_V)
 
   end subroutine multiply_dilu
@@ -1676,7 +1676,7 @@ contains
     !------------------------------------------------------------------------
     do iBlock = 1, nBlock
       x_VB(:, iBlock) = matmul(d_VVB(:, :, iBlock), x_VB(:, iBlock))
-    end do
+    enddo
 
   end subroutine multiply_block_jacobi
   !============================================================================
@@ -1752,7 +1752,7 @@ contains
     if (nDim < 1 .or. nDim > 3) then
       write(*, *) 'ERROR in ', NameSub, ' nDim=', nDim
       call CON_stop(NameSub//': invalid value for nDim')
-    end if
+    endif
 
     select case (TypePrecond)
     case ('BLOCKJACOBI')
@@ -1809,7 +1809,7 @@ contains
                       a_II(1, 3), a_II(1, 5), a_II(1, 7))
         end select
 
-      end if
+      endif
     case default
       call CON_stop(NameSub//': unknown value for TypePrecond='//TypePrecond)
     end select
@@ -1851,7 +1851,7 @@ contains
     if (nDim < 1 .or. nDim > 3) then
       write(*, *) 'ERROR in ', NameSub, ' nDim=', nDim
       call CON_stop(NameSub//': invalid value for nDim')
-    end if
+    endif
 
     select case (TypePrecond)
     case ('DILU')
@@ -1874,7 +1874,7 @@ contains
           call Lhepta(nI*nJ*nK, nVar, nI, nI*nJ, x_I, &
                       a_II(1, 1), a_II(1, 2), a_II(1, 4), a_II(1, 6))
         end select
-      end if
+      endif
       ! Multiply with U^-1 from the LU decomposition
       select case (nDim)
       case (1)
@@ -1931,7 +1931,7 @@ contains
         Param%TypePrecond, Param%TypePrecondSide, &
         nVar, nDim, nI, nJ, nK, Jac_VVCIB(1, 1, 1, 1, 1, 1, iBlock), &
         x_I(nVarIJK*(iBlock - 1) + 1))
-    end do
+    enddo
 
   end subroutine precond_left_multiblock
 
@@ -1970,7 +1970,7 @@ contains
         Param%TypePrecond, Param%TypePrecondSide, &
         nVar, nDim, nI, nJ, nK, Jac_VVCIB(1, 1, 1, 1, 1, 1, iBlock), &
         x_I(nVarIJK*(iBlock - 1) + 1))
-    end do
+    enddo
 
   end subroutine precond_right_multiblock
 
@@ -2105,9 +2105,9 @@ contains
               do iVar = 1, nVar
                 n = n + 1
                 JacobiPrec_I(n) = 1.0/Jac_VVCIB(iVar, iVar, i, j, k, 1, iBlock)
-              end do
-            end do; end do; end do; end do
-        end if
+              enddo
+            enddo; enddo; enddo; enddo
+        endif
         if (Param%TypeKrylov /= 'CG') &
           Rhs_I(1:nImpl) = JacobiPrec_I(1:nImpl)*Rhs_I(1:nImpl)
       else
@@ -2138,10 +2138,10 @@ contains
             call multiply_initial_guess( &
             nVar, nDim, nI, nJ, nK, Jac_VVCIB(1, 1, 1, 1, 1, 1, iBlock), &
             x_I(n))
-        end do
+        enddo
 
-      end if
-    end if
+      endif
+    endif
 
     ! Initialize stopping conditions. Solver will return actual values.
     Param%nMatVec = Param%MaxMatvec
@@ -2177,7 +2177,7 @@ contains
                 Param%Error, Param%TypeStop, Param%nMatvec, &
                 Param%iError, DoTest, iComm, &
                 preconditioner=cg_precond)
-      end if
+      endif
     case default
       call CON_stop(NameSub//': Unknown TypeKrylov='//Param%TypeKrylov)
     end select
@@ -2258,7 +2258,7 @@ contains
     ! Calculate the norm for the variables
     do iVar = 1, nVar
       Norm_V(iVar) = sqrt(sum(State_GV(1:nCell, iVar)**2)/nCell)
-    end do
+    enddo
 
     if (DoTestMe) write(*, *) 'Norm_V=', Norm_V, ' Eps=', Eps
 
@@ -2269,7 +2269,7 @@ contains
         StateEps_GV = State_GV
         do i = iStencil, nCell, 3
           StateEps_GV(i, jVar) = StateEps_GV(i, jVar) + Eps*Norm_V(jVar)
-        end do
+        enddo
         call update_boundary(nCell, nVar, StateEps_GV)
         if (DoTestMe) call save_plot(iStep, Time, nCell, nVar, StateEps_GV)
         call calc_residual(1, DtExpl, nCell, nVar, StateEps_GV, ResidEps_CV)
@@ -2281,24 +2281,24 @@ contains
           do iVar = 1, nVar
             Matrix_VVCI(iVar, jVar, i, iDiag) = &
               Coeff*(ResidEps_CV(i, iVar) - ResidOrig_CV(i, iVar))
-          end do
-        end do
+          enddo
+        enddo
 
-      end do
-    end do
+      enddo
+    enddo
 
     if (DoTestMe) then
       write(*, '(a,/,3(3f5.1,/))') 'Matrix(:,:,2,1)=', Matrix_VVCI(:, :, 2, 1)
       write(*, '(a,/,3(3f5.1,/))') 'Matrix(:,:,2,2)=', Matrix_VVCI(:, :, 2, 2)
       write(*, '(a,/,3(3f5.1,/))') 'Matrix(:,:,2,3)=', Matrix_VVCI(:, :, 2, 3)
-    end if
+    endif
 
     ! Add the diagonal part J = I - delta t*dR/dU
     do i = 1, nCell
       do iVar = 1, nVar
         Matrix_VVCI(iVar, iVar, i, 1) = Matrix_VVCI(iVar, iVar, i, 1) + 1.0
-      end do
-    end do
+      enddo
+    enddo
 
     ! L-U decomposition using block ILU (exact in 1D)
     call get_precond_matrix(real(bilu_), nVar, 1, nCell, 1, 1, Matrix_VVCI)
@@ -2309,8 +2309,8 @@ contains
       do iVar = 1, nVar
         iX = iX + 1
         x_I(iX) = RightHand_CV(i, iVar)
-      end do
-    end do
+      enddo
+    enddo
 
     ! x --> U^{-1}.L^{-1}.rhs = A^{-1}.rhs
     call multiply_left_precond('BILU', 'left', nVar, 1, nCell, 1, 1, &
@@ -2322,8 +2322,8 @@ contains
       do iVar = 1, nVar
         iX = iX + 1
         State_GV(i, iVar) = State_GV(i, iVar) + x_I(iX)
-      end do
-    end do
+      enddo
+    enddo
 
     call update_boundary(nCell, nVar, State_GV)
 
@@ -2350,7 +2350,7 @@ contains
     write(UNITTMP_, '(a79)') 'x rho rhou p gamma'
     do i = 1, nCell
       write(UNITTMP_, '(100es18.10))') float(i), State_GV(i, rho_:p_)
-    end do
+    enddo
 
   end subroutine save_plot
 
@@ -2377,7 +2377,7 @@ contains
       Resid_CV(i, p_) = -Dt*Inv2Dx* &
                         (uRight*State_GV(i + 1, p_) - uLeft*State_GV(i - 1, p_) &
                          + (Gamma - 1)*State_GV(i, p_)*(uRight - uLeft))
-    end do
+    enddo
   end subroutine calc_resid_test
 
   !=======================================================================
@@ -2440,8 +2440,8 @@ contains
         write(*, *) 'iStep, Max error=', iStep, &
           maxval(abs(StateOld_GV(1:nCell, :) + Resid_CV - State_GV(1:nCell, :)))
         call save_plot(iStep, Time, nCell, nVar, State_GV)
-      end if
-    end do
+      endif
+    enddo
     close(UNITTMP_)
 
   end subroutine test_linear_solver

--- a/share/Library/src/ModLookupTable.f90
+++ b/share/Library/src/ModLookupTable.f90
@@ -154,10 +154,10 @@ contains
       if (nTable > MaxTable) then
         write(*, *) NameSub, ' MaxTable =', MaxTable
         call CON_stop(NameSub//': number of tables exceeded MaxTable')
-      end if
+      endif
 
       iTable = nTable
-    end if
+    endif
 
     ! For sake of more concise source code, use a pointer to the table
     Ptr => Table_I(iTable)
@@ -180,7 +180,7 @@ contains
     if (Ptr%NameCommand == "load") then
       call load_lookup_table(iTable)
       RETURN
-    end if
+    endif
 
     ! Save size of table and index ranges
     Ptr%nIndex = size(nIndex_I)
@@ -199,13 +199,13 @@ contains
       if (nParam > 0) allocate(Ptr%Param_I(nParam))
     else
       Ptr%nParam = 0
-    end if
+    endif
 
     if (present(StringDescription)) then
       Ptr%StringDescription = StringDescription
     else
       Ptr%StringDescription = NameTable
-    end if
+    endif
 
     Ptr%NameVar = NameVar
 
@@ -285,10 +285,10 @@ contains
         if (nTable > MaxTable) then
           write(*, *) NameSub, ' MaxTable =', MaxTable
           call CON_stop(NameSub//': number of tables exceeded MaxTable')
-        end if
+        endif
 
         iTable = nTable
-      end if
+      endif
 
       ! For sake of more concise source code, use a pointer to the table
       Ptr => Table_I(iTable)
@@ -320,8 +320,8 @@ contains
             DoReadTableParam = .false.
           else
             NameCommand = "save"
-          end if
-        end if
+          endif
+        endif
 
         ! The table parameters have to be the same for all tables
         if (DoReadTableParam) then
@@ -331,17 +331,17 @@ contains
           allocate(TableParam_I(nTableParam))
           do iTableParam = 1, nTableParam
             call read_var('TableParam', TableParam_I(iTableParam))
-          end do
-        end if
+          enddo
+        endif
 
-      end if
+      endif
 
       if (NameCommand /= "para") Ptr%NameCommand = NameCommand
 
       if (NameCommand == "load" .or. NameCommand == "save") then
         Ptr%NameFile = NameFile_I(iTableName)
         Ptr%TypeFile = TypeFile
-      end if
+      endif
 
       ! Load table on all processors
       if (NameCommand == "load") call load_lookup_table(iTable)
@@ -354,9 +354,9 @@ contains
         Ptr%Param_I = TableParam_I
         if (NameCommand == "load" .or. NameCommand == "para") &
           Ptr%NameVar = trim(Ptr%NameVar)//' '//trim(NameParam)
-      end if
+      endif
 
-    end do
+    enddo
 
     if (DoReadTableParam) deallocate(TableParam_I)
 
@@ -389,8 +389,8 @@ contains
       if (Ptr%IsLogIndex_I(iIndex)) then
         Ptr%IndexMin_I(iIndex) = log10(Ptr%IndexMin_I(iIndex))
         Ptr%IndexMax_I(iIndex) = log10(Ptr%IndexMax_I(iIndex))
-      end if
-    end do
+      endif
+    enddo
     ! Calculate increments
     Ptr%dIndex_I = (Ptr%IndexMax_I - Ptr%IndexMin_I)/(Ptr%nIndex_I - 1)
 
@@ -413,7 +413,7 @@ contains
         nString = 1
         Name_I(1) = Name
         RETURN
-      end if
+      endif
 
       call split_string(Name(iBracePosition1 + 1:iBracePosition2 - 1), &
                         MaxTableName, Name_I, nString)
@@ -421,15 +421,15 @@ contains
       if (iBracePosition1 > 1) then
         do iString = 1, nString
           Name_I(iString) = Name(1:iBracePosition1 - 1)//trim(Name_I(iString))
-        end do
-      end if
+        enddo
+      endif
 
       if (iBracePosition2 < len_trim(Name)) then
         do iString = 1, nString
           Name_I(iString) = trim(Name_I(iString))// &
                             Name(iBracePosition2 + 1:len_trim(Name))
-        end do
-      end if
+        enddo
+      endif
 
     end subroutine check_braces
 
@@ -450,8 +450,8 @@ contains
       if (Table_I(iTable)%NameTable == Name) then
         i_lookup_table = iTable
         RETURN
-      end if
-    end do
+      endif
+    enddo
     i_lookup_table = -1
 
   end function i_lookup_table
@@ -496,7 +496,7 @@ contains
       if (allocated(Ptr%Param_I)) deallocate(Ptr%Param_I)
       allocate(Ptr%Param_I(Ptr%nParam))
       Ptr%Param_I = TableParam_I(1:Ptr%nParam)
-    end if
+    endif
 
     ! Figure out which index is logarithmic
     call split_string(Ptr%NameVar, MaxVar, NameVar_I, nVar)
@@ -568,7 +568,7 @@ contains
     else
       iProc = 0
       nProc = 1
-    end if
+    endif
 
     if (iProc == 0) write(*, '(3a)') NameSub, ' is creating table ', Ptr%NameTable
 
@@ -582,7 +582,7 @@ contains
       Index1 = Index1Min + (i1 - 1)*dIndex1
       if (IsLog1) Index1 = 10**Index1
       call calc_table_var(iTable, Index1, Value_VC(:, i1))
-    end do
+    enddo
 
     ! Collect (or copy) result into table
     if (nProc > 1) then
@@ -590,7 +590,7 @@ contains
                          MPI_REAL, MPI_SUM, iComm, iError)
     else
       Ptr%Value_VC(:, :, 1, 1) = Value_VC
-    end if
+    endif
 
     deallocate(Value_VC)
 
@@ -617,8 +617,8 @@ contains
           CoordMinIn_D=Ptr%IndexMin_I, &
           CoordMaxIn_D=Ptr%IndexMax_I, &
           VarIn_VIII=Ptr%Value_VC)
-      end if
-    end if
+      endif
+    endif
 
     ! Make sure that all processors are done
     if (nProc > 1) call MPI_barrier(iComm, iError)
@@ -684,7 +684,7 @@ contains
     else
       iProc = 0
       nProc = 1
-    end if
+    endif
 
     if (iProc == 0) write(*, '(3a)') NameSub, ' is creating table ', Ptr%NameTable
 
@@ -701,8 +701,8 @@ contains
         Index1 = Index1Min + (i1 - 1)*dIndex1
         if (IsLog1) Index1 = 10**Index1
         call calc_table_var(iTable, Index1, Index2, Value_VC(:, i1, i2))
-      end do
-    end do
+      enddo
+    enddo
 
     ! Collect (or copy) result into table
     if (nProc > 1) then
@@ -710,7 +710,7 @@ contains
                          MPI_REAL, MPI_SUM, iComm, iError)
     else
       Ptr%Value_VC(:, :, :, 1) = Value_VC
-    end if
+    endif
 
     deallocate(Value_VC)
 
@@ -737,8 +737,8 @@ contains
           CoordMinIn_D=Ptr%IndexMin_I, &
           CoordMaxIn_D=Ptr%IndexMax_I, &
           VarIn_VIII=Ptr%Value_VC)
-      end if
-    end if
+      endif
+    endif
 
     ! Make sure that all processors are done
     if (nProc > 1) call MPI_barrier(iComm, iError)
@@ -810,7 +810,7 @@ contains
     else
       iProc = 0
       nProc = 1
-    end if
+    endif
 
     if (iProc == 0) write(*, '(3a)') NameSub, ' is creating table ', Ptr%NameTable
 
@@ -834,9 +834,9 @@ contains
           if (IsLog1) Index1 = 10**Index1
           call calc_table_var(iTable, Index1, Index2, Index3, &
                               Value_VC(:, i1, i2, i3))
-        end do
-      end do
-    end do
+        enddo
+      enddo
+    enddo
 
     ! Collect (or copy) result into table
     if (nProc > 1) then
@@ -844,7 +844,7 @@ contains
                          MPI_REAL, MPI_SUM, iComm, iError)
     else
       Ptr%Value_VC = Value_VC
-    end if
+    endif
 
     deallocate(Value_VC)
 
@@ -871,8 +871,8 @@ contains
           CoordMinIn_D=Ptr%IndexMin_I, &
           CoordMaxIn_D=Ptr%IndexMax_I, &
           VarIn_VIII=Ptr%Value_VC)
-      end if
-    end if
+      endif
+    endif
 
     ! Make sure that all processors are done
     if (nProc > 1) call MPI_barrier(iComm, iError)
@@ -1119,7 +1119,7 @@ contains
     if (present(Arg1Out)) then
       Arg1Out = (i1 - 1 + Dx1)*Ptr%dIndex_I(1) + Ptr%IndexMin_I(1)
       if (Ptr%IsLogIndex_I(1)) Arg1Out = 10**Arg1Out
-    end if
+    endif
 
   end subroutine interpolate_with_known_val
   !===========================================================================
@@ -1165,8 +1165,8 @@ contains
         Param_I(1:Ptr%nParam) = Ptr%Param_I
       else
         Param_I = Ptr%Param_I(1:size(Param_I))
-      end if
-    end if
+      endif
+    endif
     if (present(Param)) then
       ! return one parameter, the first one by default
       iParam = 1
@@ -1175,8 +1175,8 @@ contains
         Param = -777.77
       else
         Param = Ptr%Param_I(iParam)
-      end if
-    end if
+      endif
+    endif
 
   end subroutine get_lookup_table
 
@@ -1216,12 +1216,12 @@ contains
     if (iTable /= -1) then
       write(*, *) 'iTable = ', iTable, ' should be -1'
       call CON_stop(NameSub)
-    end if
+    endif
     iTable = i_lookup_table("RhoE")
     if (iTable /= 1) then
       write(*, *) 'iTable = ', iTable, ' should be 1'
       call CON_stop(NameSub)
-    end if
+    endif
     Ptr => Table_I(1)
 
     if (iProc == 0) write(*, *) 'testing get_lookup_table'
@@ -1230,20 +1230,20 @@ contains
     if (nIndex /= 2) then
       write(*, *) 'nIndex=', nIndex, ' is different from 2'
       call CON_stop(NameSub)
-    end if
+    endif
     if (nParam /= 3) then
       write(*, *) 'nParam=', nParam, ' is different from 3'
       call CON_stop(NameSub)
-    end if
+    endif
     ValueGood_I = (/54.0, 4.0, -4.0/)
     if (any(Value_I /= ValueGood_I)) then
       write(*, *) 'Param_I=', Value_I, ' is different from ', ValueGood_I
       call CON_stop(NameSub)
-    end if
+    endif
     if (Arg /= ValueGood_I(2)) then
       write(*, *) 'Param=', Arg, ' is different from ', ValueGood_I(2)
       call CON_stop(NameSub)
-    end if
+    endif
 
     if (iProc == 0) write(*, *) 'testing make_lookup_table'
     call make_lookup_table(iTable, eos_rho_e, MPI_COMM_WORLD)
@@ -1257,7 +1257,7 @@ contains
       write(*, *) 'Value_I=', Value_I, ' is different from ValueGood_I=', &
         ValueGood_I
       call CON_stop(NameSub)
-    end if
+    endif
 
     if (iProc == 0) write(*, *) 'testing load_lookup_table'
 
@@ -1273,7 +1273,7 @@ contains
     if (iTable /= 2) then
       write(*, *) 'iTable = ', iTable, ' should be 2'
       call CON_stop(NameSub)
-    end if
+    endif
     Ptr2 => Table_I(iTable)
     call compare_tables
 
@@ -1283,7 +1283,7 @@ contains
       write(*, *) 'Value_I=', Value_I, ' is different from ValueGood_I=', &
         ValueGood_I
       call CON_stop(NameSub)
-    end if
+    endif
 
     ! Test with the condition that Value_I(3)=3.0 and find first argument Arg
     call interpolate_lookup_table(2, 3, 3.0, 2.0, Value_I, Arg)
@@ -1291,7 +1291,7 @@ contains
       write(*, *) 'Value_I=', Value_I, ' Arg =', Arg, &
         ' are different from ValueGood_I=', ValueGood_I, ' ArgGood = 1.0'
       call CON_stop(NameSub)
-    end if
+    endif
 
     ! Test 1D lookup table
     if (iProc == 0) write(*, *) 'testing 1D lookup table'
@@ -1311,7 +1311,7 @@ contains
     if (iTable /= 3) then
       write(*, *) 'iTable = ', iTable, ' should be 3'
       call CON_stop(NameSub)
-    end if
+    endif
     Ptr => Table_I(iTable)
 
     if (iProc == 0) write(*, *) 'testing make_lookup_table_1d'
@@ -1324,7 +1324,7 @@ contains
     if (abs(Value - ValueGood) > 1e-5) then
       write(*, *) 'Value=', Value, ' is different from ValueGood=', ValueGood
       call CON_stop(NameSub)
-    end if
+    endif
 
     if (iProc == 0) write(*, *) 'testing 1D load_lookup_table'
 
@@ -1340,7 +1340,7 @@ contains
     if (iTable /= 4) then
       write(*, *) 'iTable = ', iTable, ' should be 4'
       call CON_stop(NameSub)
-    end if
+    endif
     Ptr2 => Table_I(iTable)
     call compare_tables
 
@@ -1349,7 +1349,7 @@ contains
     if (abs(Value - ValueGood) > 1e-5) then
       write(*, *) 'Value=', Value, ' is different from ValueGood=', ValueGood
       call CON_stop(NameSub)
-    end if
+    endif
 
     ! Test 3D lookup table
     if (iProc == 0) write(*, *) 'testing 3D lookup table'
@@ -1368,7 +1368,7 @@ contains
     if (iTable /= 5) then
       write(*, *) 'iTable = ', iTable, ' should be 5'
       call CON_stop(NameSub)
-    end if
+    endif
     Ptr => Table_I(iTable)
 
     if (iProc == 0) write(*, *) 'testing make_lookup_table_3d'
@@ -1382,7 +1382,7 @@ contains
       write(*, *) 'Value_I=', Value_I, ' is different from ValueGood_I=', &
         ValueGood_I
       call CON_stop(NameSub)
-    end if
+    endif
 
     if (iProc == 0) write(*, *) 'testing 3D load_lookup_table'
 
@@ -1398,7 +1398,7 @@ contains
     if (iTable /= 6) then
       write(*, *) 'iTable = ', iTable, ' should be 6'
       call CON_stop(NameSub)
-    end if
+    endif
     Ptr2 => Table_I(iTable)
     call compare_tables
 
@@ -1408,7 +1408,7 @@ contains
     if (abs(Value - ValueGood) > 1e-5) then
       write(*, *) 'Value=', Value, ' is different from ValueGood=', ValueGood
       call CON_stop(NameSub)
-    end if
+    endif
 
   contains
 
@@ -1426,41 +1426,41 @@ contains
       if (Ptr2%nValue /= Ptr%nValue) then
         write(*, *) 'nValue=', Ptr2%nValue, ' is different from ', Ptr%nValue
         call CON_stop(NameSub)
-      end if
+      endif
       if (Ptr2%nIndex /= Ptr%nIndex) then
         write(*, *) 'nIndex=', Ptr2%nIndex, ' is different from ', Ptr%nIndex
         call CON_stop(NameSub)
-      end if
+      endif
       if (any(abs(Ptr2%IndexMin_I - Ptr%IndexMin_I) > 1e-5)) then
         write(*, *) 'IndexMin_I=', Ptr2%IndexMin_I, ' is different from ', &
           Ptr%IndexMin_I
         call CON_stop(NameSub)
-      end if
+      endif
       if (any(abs(Ptr2%IndexMax_I - Ptr%IndexMax_I) > 1e-5)) then
         write(*, *) 'IndexMax_I=', Ptr2%IndexMax_I, ' is different from ', &
           Ptr%IndexMax_I
         call CON_stop(NameSub)
-      end if
+      endif
       if (any(abs(Ptr2%dIndex_I - Ptr%dIndex_I) > 1e-6)) then
         write(*, *) 'dIndex_I=', Ptr2%dIndex_I, ' is different from ', &
           Ptr%dIndex_I
         call CON_stop(NameSub)
-      end if
+      endif
       if (any(Ptr2%IsLogIndex_I .neqv. Ptr%IsLogIndex_I)) then
         write(*, *) 'IsLogIndex_I=', Ptr2%IsLogIndex_I, ' is different from ', &
           Ptr%IsLogIndex_I
         call CON_stop(NameSub)
-      end if
+      endif
       if (Ptr2%nParam /= Ptr%nParam) then
         write(*, *) 'nParam=', Ptr2%nParam, ' is different from ', Ptr%nParam
         call CON_stop(NameSub)
-      end if
+      endif
       if (Ptr%nParam > 0) then
         if (any(Ptr2%Param_I /= Ptr%Param_I)) then
           write(*, *) 'Param_I=', Ptr2%Param_I, ' is different from ', Ptr%Param_I
           call CON_stop(NameSub)
-        end if
-      end if
+        endif
+      endif
 
     end subroutine compare_tables
 

--- a/share/Library/src/ModMpi.f90
+++ b/share/Library/src/ModMpi.f90
@@ -71,7 +71,7 @@ contains
     else
       call MPI_reduce(Buffer_I, Recv_I, nSize, MPI_REAL, iOp, &
                       iRoot, iComm, iError)
-    end if
+    endif
 
   end subroutine mpi_reduce_real_array
   !============================================================================
@@ -95,7 +95,7 @@ contains
     else
       call MPI_reduce(Value, Recv, 1, MPI_REAL, iOp, &
                       iRoot, iComm, iError)
-    end if
+    endif
 
   end subroutine mpi_reduce_real_scalar
   !============================================================================
@@ -120,7 +120,7 @@ contains
     else
       call MPI_reduce(iBuffer_I, iRecv_I, nSize, MPI_INTEGER, &
                       iOp, iRoot, iComm, iError)
-    end if
+    endif
 
   end subroutine mpi_reduce_integer_array
   !============================================================================
@@ -143,7 +143,7 @@ contains
     else
       call MPI_reduce(iValue, iRecv, 1, MPI_INTEGER, &
                       iOp, iRoot, iComm, iError)
-    end if
+    endif
 
   end subroutine mpi_reduce_integer_scalar
 

--- a/share/Library/src/ModPlanetConst.f90
+++ b/share/Library/src/ModPlanetConst.f90
@@ -338,7 +338,7 @@ contains
     ! make all the planet names upper case
     do i = NoPlanet_, MaxPlanet + 1
       call upper_case(NamePlanet_I(i))  ! make all the names upper case
-    end do
+    enddo
 
   end subroutine init_planet_const
 

--- a/share/Library/src/ModPlotFile.f90
+++ b/share/Library/src/ModPlotFile.f90
@@ -148,7 +148,7 @@ contains
       Param_I = ParamIn_I
     else
       nParam = 0
-    end if
+    endif
     ! Figure out grid dimensions and number of variables. Default is 1.
     n_D = 1
     if (present(VarIn_I)) then
@@ -185,7 +185,7 @@ contains
     else
       call CON_stop(NameSub// &
                     ': none of the VarIn_* variables are present')
-    end if
+    endif
     ! Extract information
     nVar = n_D(0)
     n1 = n_D(1)
@@ -201,8 +201,8 @@ contains
         n_D(1:3) = (/n2, n3, 1/)
       elseif (n2 == 1) then
         n_D(1:3) = (/n1, n3, 1/)
-      end if
-    end if
+      endif
+    endif
     IsCartesian = .true.
     if (present(IsCartesianIn)) IsCartesian = IsCartesianIn
 
@@ -220,14 +220,14 @@ contains
       NameVar = 'x1'
       do i = 2, nDim
         write(NameVar, "(a, i1)") trim(NameVar)//' x', i
-      end do
+      enddo
       do i = 1, nVar
         write(NameVar, "(a, i2.2)") trim(NameVar)//' v', i
-      end do
+      enddo
       do i = 1, nParam
         write(NameVar, "(a, i2.2)") trim(NameVar)//' p', i
-      end do
-    end if
+      enddo
+    endif
 
     ! Create a variable name array
     allocate(NameVar_I(nDim + nVar + nParam))
@@ -240,7 +240,7 @@ contains
         nDim, nVar, nParam, nDim + nVar + nParam
       call CON_stop(NameSub// &
                     ': number of names in NameVar does not match nDim+nVar+nParam !')
-    end if
+    endif
 
     ! Allocate arrays with a shape that is convenient for saving data
     if (TypeFile == 'hdf5') then
@@ -259,9 +259,9 @@ contains
               IsSplitSuccessfull = .true.
             else
               IsSplitSuccessfull = .false.
-            end if
+            endif
             if (IsSplitSuccessfull) exit
-          end do
+          enddo
           if (.not. IsSplitSuccessfull) then
             do j = 3, 2, -1
               ResultMod = mod(n_D(i), j)
@@ -269,25 +269,25 @@ contains
                 IsSplitSuccessfull = .true.
               else
                 IsSplitSuccessfull = .false.
-              end if
+              endif
               if (IsSplitSuccessfull) exit
-            end do
-          end if
+            enddo
+          endif
 
           if (IsSplitSuccessfull) then
             nCellsPerBlock(i) = j
           else
             nCellsPerBlock(i) = n_D(i)
-          end if
+          endif
         else
           nCellsPerBlock(i) = 1
-        end if
-      end do
+        endif
+      enddo
 
       do i = 1, nDim
         nBlocksXYZ(i) = n_D(i)/nCellsPerBlock(i)
         iBlockDxDyDz(i) = (CoordMaxIn_D(i) - CoordMinIn_D(i))/nBlocksXYZ(i)
-      end do
+      enddo
       nBlocks = product(nBlocksXYZ(1:nDim))
 
       allocate(VarHdf5Output(nCellsPerBlock(1), nCellsPerBlock(2), &
@@ -321,8 +321,8 @@ contains
                 VarHdf5Output(i, j, 1, iBlk, 1:nVar) = VarIn_IIV(iG, jG, 1:nVar)
               elseif (present(VarIn_IIIV)) then
                 VarHdf5Output(i, j, k, iBlk, 1:nVar) = VarIn_IIIV(iG, jG, kG, 1:nVar)
-              end if
-            end do; end do; end do; 
+              endif
+            enddo; enddo; enddo; 
           do n = 1, nDim
             if (n == 1) then
               MinimumBlockIjk(n, iBlk) = (ii - 1)*nCellsPerBlock(n)
@@ -336,10 +336,10 @@ contains
               MinimumBlockIjk(n, iBlk) = (kk - 1)*nCellsPerBlock(n)
               XYZMinMax(1, n, iBlk) = iBlockDxDyDz(n)*(kk - 1) + CoordMinIn_D(n)
               XYZMinMax(2, n, iBlk) = iBlockDxDyDz(n)*kk + CoordMinIn_D(n)
-            end if
-          end do
+            endif
+          enddo
 
-        end do; end do; end do; 
+        enddo; enddo; enddo; 
     else
       allocate(Coord_ID(n1*n2*n3, nDim), Var_IV(n1*n2*n3, nVar))
       ! Fill in the Coord_ID coordinate array using the available information
@@ -352,7 +352,7 @@ contains
               i_D = (/i, j, k/)
               Coord = CoordMinIn_D(iDim) + (i_D(iDim) - 1)* &
                       ((CoordMaxIn_D(iDim) - CoordMinIn_D(iDim))/max(1, n_D(iDim) - 1))
-            end if
+            endif
             if (present(CoordIn_I)) Coord = CoordIn_I(i)
             if (present(CoordIn_DII)) Coord = CoordIn_DII(iDim, i, j)
             if (present(CoordIn_DIII)) Coord = CoordIn_DIII(iDim, i, j, k)
@@ -360,8 +360,8 @@ contains
             if (present(Coord2In_I) .and. iDim == 2) Coord = Coord2In_I(j)
             if (present(Coord3In_I) .and. iDim == 3) Coord = Coord3In_I(k)
             Coord_ID(n, iDim) = Coord
-          end do; end do; end do; 
-      end do
+          enddo; enddo; enddo; 
+      enddo
 
       ! Check if all coordinates were set
       if (any(Coord_ID == huge(1.0))) call CON_stop(NameSub// &
@@ -382,13 +382,13 @@ contains
             if (present(VarIn_IV)) Var_IV(n, iVar) = VarIn_IV(i, iVar)
             if (present(VarIn_IIV)) Var_IV(n, iVar) = VarIn_IIV(i, j, iVar)
             if (present(VarIn_IIIV)) Var_IV(n, iVar) = VarIn_IIIV(i, j, k, iVar)
-          end do; end do; end do; 
-      end do
+          enddo; enddo; enddo; 
+      enddo
 
       ! Check if all variables were set
       if (any(Var_IV == huge(1.0))) call CON_stop(NameSub// &
                                                   ' variables were not defined')
-    end if
+    endif
 
     select case (TypeFile)
     case ('hdf5')
@@ -398,8 +398,8 @@ contains
         NameUnits = ''
         do iVar = 1, nVar
           NameUnits = NameUnits//'normalized '
-        end do
-      end if
+        enddo
+      endif
       call save_hdf5_file(NameFile, TypePosition, TypeStatus, StringHeader, &
                           nStep, nBlocks, Time, nDim, nParam, nVar, &
                           nCellsPerBlock(1:nDim), NameVar_I(nDim + 1:nDim + nVar), NameUnits, &
@@ -419,7 +419,7 @@ contains
       else
         call join_string(NameVar_I(1:nDim + nVar), NameVar, '", "')
         write(UnitTmp_, "(a)") '"'//trim(NameVar)//'"'
-      end if
+      endif
       write(UnitTmp_, '(a,i6,a,i6,a,i6,a)') &
         'ZONE T="STRUCTURED GRID", I=', &
         n1, ', J=', n2, ', K=', n3, ', F=POINT'
@@ -428,7 +428,7 @@ contains
       do i = 1, nParam
         write(UnitTmp_, '(a,es18.10,a)') &
           'AUXDATA '//trim(NameVar_I(nDim + nVar + i))//'="', Param_I(i), '"'
-      end do
+      enddo
 
       ! write out coordinates and variables line by line
       n = 0
@@ -438,7 +438,7 @@ contains
           if (n1 > 1) write(UnitTmp_, "(i8)", ADVANCE="NO") i
           n = n + 1
           write(UnitTmp_, "(100es18.10)") Coord_ID(n, :), Var_IV(n, :)
-        end do; end do; end do
+        enddo; enddo; enddo
 
       call close_file
     case ('formatted', 'ascii')
@@ -457,7 +457,7 @@ contains
       do k = 1, n3; do j = 1, n2; do i = 1, n1
           n = n + 1
           write(UnitTmp_, "(100es18.10)") Coord_ID(n, :), Var_IV(n, :)
-        end do; end do; end do
+        enddo; enddo; enddo
       call close_file
     case ('real8')
       call open_file(FILE=NameFile, FORM='unformatted', &
@@ -472,7 +472,7 @@ contains
       ! for very large Var_IV array
       do iVar = 1, nVar
         write(UnitTmp_) Var_IV(:, iVar)
-      end do
+      enddo
       call close_file
     case ('real4')
       call open_file(FILE=NameFile, FORM='unformatted', &
@@ -486,7 +486,7 @@ contains
         Param4_I = Param_I
         write(UnitTmp_) Param4_I
         deallocate(Param4_I)
-      end if
+      endif
       write(UnitTmp_) NameVar
       ! Copy into single precision arrays to avoid compiler issues.
       allocate(Coord4_ID(n1*n2*n3, nDim))
@@ -497,7 +497,7 @@ contains
       do iVar = 1, nVar
         Var4_I = Var_IV(:, iVar)
         write(UnitTmp_) Var4_I
-      end do
+      enddo
       deallocate(Var4_I)
       call close_file
     case default
@@ -606,7 +606,7 @@ contains
       write(*, *) NameSub, ': the number of variables is ', nVar, &
         ' (larger than 1) in file ', NameFile
       call CON_stop(NameSub//' called with scalar variable argument')
-    end if
+    endif
 
     ! If data is read, next header needs to be read
     DoReadHeader = .true.
@@ -619,13 +619,13 @@ contains
       do k = 1, n3; do j = 1, n2; do i = 1, n1
           n = n + 1
           read(iUnit, *, ERR=77, END=77) Coord_ID(n, :), Var_IV(n, :)
-        end do; end do; end do
+        enddo; enddo; enddo
 
     case ('real8')
       read(iUnit, ERR=77, END=77) Coord_ID
       do iVar = 1, nVar
         read(iUnit, ERR=77, END=77) Var_IV(:, iVar)
-      end do
+      enddo
 
     case ('real4')
       allocate(Coord4_ID(n1*n2*n3, nDim), Var4_IV(n1*n2*n3, nVar))
@@ -633,7 +633,7 @@ contains
       Coord_ID = Coord4_ID
       do iVar = 1, nVar
         read(iUnit, ERR=77, END=77) Var4_IV(:, iVar)
-      end do
+      enddo
       Var_IV = Var4_IV
       deallocate(Coord4_ID, Var4_IV)
     end select
@@ -660,8 +660,8 @@ contains
             Coord2Out_I(j) = Coord
           if (present(Coord3Out_I) .and. iDim == 3 .and. i == 1 .and. j == 1) &
             Coord3Out_I(k) = Coord
-        end do; end do; end do
-    end do
+        enddo; enddo; enddo
+    enddo
 
     ! Fill in output variable arrays
     do iVar = 1, nVar
@@ -678,8 +678,8 @@ contains
           if (present(VarOut_IIV)) VarOut_IIV(i, j, iVar) = Var_IV(n, iVar)
           if (present(VarOut_IIIV)) VarOut_IIIV(i, j, k, iVar) = Var_IV(n, iVar)
 
-        end do; end do; end do
-    end do
+        enddo; enddo; enddo
+    enddo
 
     deallocate(Coord_ID, Var_IV)
 
@@ -708,7 +708,7 @@ contains
         if (nParam > 0) then
           allocate(Param_I(nParam))
           read(iUnit, *, ERR=77, END=77) Param_I
-        end if
+        endif
         read(iUnit, '(a)', ERR=77, END=77) NameVar
       case ('real8')
         open(iUnit, file=NameFile, status='old', form='unformatted', ERR=66)
@@ -719,7 +719,7 @@ contains
         if (nParam > 0) then
           allocate(Param_I(nParam))
           read(iUnit, ERR=77, END=77) Param_I
-        end if
+        endif
         read(iUnit, ERR=77, END=77) NameVar
       case ('real4')
         open(iUnit, file=NameFile, status='old', form='unformatted', ERR=66)
@@ -734,7 +734,7 @@ contains
           read(iUnit, ERR=77, END=77) Param4_I
           Param_I = Param4_I
           deallocate(Param4_I)
-        end if
+        endif
         read(iUnit, ERR=77, END=77) NameVar
       case default
         call CON_stop(NameSub//' unknown TypeFile ='//trim(TypeFile))
@@ -757,7 +757,7 @@ contains
       if (present(nOut_D)) then
         nOut_D = 1
         nOut_D(1:nDim) = n_D(1:nDim)
-      end if
+      endif
       if (present(IsCartesianOut)) IsCartesianOut = IsCartesian
       if (present(ParamOut_I) .and. nParam > 0) &
         ParamOut_I(1:nParam) = Param_I
@@ -861,8 +861,8 @@ contains
           VarIn_VII(:, i, j) = (/0.1, 0.0, 0.0, 0.125/)
           VarIn_IIV(i, j, :) = (/0.1, 0.0, 0.0, 0.125/)
           VarIn_VIII(:, i, 1, j) = (/0.1, 0.0, 0.0, 0.125/)
-        end if
-      end do; end do
+        endif
+      enddo; enddo
 
     ! Test ascii, real8 and real4 files
     do iTest = 1, nTest
@@ -876,7 +876,7 @@ contains
         Eps = 1e-5
       else
         Eps = 1e-12
-      end if
+      endif
 
       ! Test saving it
       select case (iTest)
@@ -975,108 +975,108 @@ contains
                             CoordMaxOut_D=CoordMaxOut_D, &
                             VarOut_VII=VarOut_VII)
 
-      end if
+      endif
 
       if (nStepOut /= nStepIn) then
         write(*, *) 'nStepIn=', nStepIn, ' nStepOut=', nStepOut
         call CON_stop(NameSub)
-      end if
+      endif
 
       if (abs(TimeOut - TimeIn) > Eps) then
         write(*, *) 'TimeIn=', TimeIn, ' TimeOut=', TimeOut
         call CON_stop(NameSub)
-      end if
+      endif
 
       if (nDimOut /= nDimIn) then
         write(*, *) 'nDimIn=', nDimIn, ' nDimOut=', nDimOut
         call CON_stop(NameSub)
-      end if
+      endif
 
       if (nParamOut /= nParamIn) then
         write(*, *) 'nParamIn=', nParamIn, ' nParamOut=', nParamOut
         call CON_stop(NameSub)
-      end if
+      endif
 
       if (nVarOut /= nVarIn) then
         write(*, *) 'nVarIn=', nVarIn, ' nVarOut=', nVarOut
         call CON_stop(NameSub)
-      end if
+      endif
 
       if (any(abs(ParamOut_I(1:nParamIn) - ParamIn_I) > Eps)) then
         write(*, *) 'ParamIn=', ParamIn_I, ' ParamOut=', ParamOut_I(1:nParamIn)
         call CON_stop(NameSub)
-      end if
+      endif
 
       if (IsCartesianOut .neqv. IsCartesianIn) then
         write(*, *) 'IsCartesianIn, Out=', IsCartesianIn, IsCartesianOut
         call CON_stop(NameSub)
-      end if
+      endif
 
       if (NameVarOut /= NameVarIn) then
         write(*, *) 'NameVarIn=', NameVarIn, ' NameVarOut=', NameVarOut
         call CON_stop(NameSub)
-      end if
+      endif
 
       !To simplify, replace the 3D input array with 2D
       if (iTest > 6) then
         CoordIn_DII = CoordIn_DIII(:, :, 1, :)
         VarIn_VII = VarIn_VIII(:, :, 1, :)
-      end if
+      endif
       do j = 1, n2In; do i = 1, n1In
           if (any(abs(CoordIn_DII(:, i, j) - CoordOut_DII(:, i, j)) > Eps)) then
             write(*, *) 'i,j=', i, j
             write(*, *) 'CoordIn =', CoordIn_DII(:, i, j)
             write(*, *) 'CoordOut=', CoordOut_DII(:, i, j)
             call CON_stop(NameSub)
-          end if
+          endif
           if (abs(CoordIn_DII(1, i, j) - Coord1Out_I(i)) > Eps) then
             write(*, *) 'i,j=', i, j
             write(*, *) 'CoordIn(1)=', CoordIn_DII(1, i, j)
             write(*, *) 'Coord1Out =', Coord1Out_I(i)
             call CON_stop(NameSub)
-          end if
+          endif
           if (abs(CoordIn_DII(2, i, j) - Coord2Out_I(j)) > Eps) then
             write(*, *) 'i,j=', i, j
             write(*, *) 'CoordIn(2)=', CoordIn_DII(2, i, j)
             write(*, *) 'Coord2Out =', Coord2Out_I(j)
             call CON_stop(NameSub)
-          end if
+          endif
           if (any(abs(VarIn_VII(:, i, j) - VarOut_VII(:, i, j)) > Eps)) then
             write(*, *) 'i,j=', i, j
             write(*, *) 'VarIn =', VarIn_VII(:, i, j)
             write(*, *) 'VarOut=', VarOut_VII(:, i, j)
             call CON_stop(NameSub)
-          end if
+          endif
           if (any(abs(VarIn_IIV(i, j, :) - VarOut_VII(:, i, j)) > Eps)) then
             write(*, *) 'i,j=', i, j
             write(*, *) 'VarIn =', VarIn_IIV(i, j, :)
             write(*, *) 'VarOut=', VarOut_VII(:, i, j)
             call CON_stop(NameSub)
-          end if
-        end do; end do
+          endif
+        enddo; enddo
 
       if (abs(CoordMinOut_D(1) - minval(CoordIn_DII(1, :, :))) > Eps) then
         write(*, *) 'CoordMinOut_D(1)     =', CoordMinOut_D(1)
         write(*, *) 'minval(CoordIn_DII(1)=', minval(CoordIn_DII(1, :, :))
         call CON_stop(NameSub)
-      end if
+      endif
       if (abs(CoordMinOut_D(2) - minval(CoordIn_DII(2, :, :))) > Eps) then
         write(*, *) 'CoordMinOut_D(2)     =', CoordMinOut_D(2)
         write(*, *) 'minval(CoordIn_DII(2)=', minval(CoordIn_DII(2, :, :))
         call CON_stop(NameSub)
-      end if
+      endif
       if (abs(CoordMaxOut_D(1) - maxval(CoordIn_DII(1, :, :))) > Eps) then
         write(*, *) 'CoordMaxOut_D(1)     =', CoordMaxOut_D(1)
         write(*, *) 'maxval(CoordIn_DII(1)=', maxval(CoordIn_DII(1, :, :))
         call CON_stop(NameSub)
-      end if
+      endif
       if (abs(CoordMaxOut_D(2) - maxval(CoordIn_DII(2, :, :))) > Eps) then
         write(*, *) 'CoordMaxOut_D(2)     =', CoordMaxOut_D(2)
         write(*, *) 'maxval(CoordIn_DII(2)=', maxval(CoordIn_DII(2, :, :))
         call CON_stop(NameSub)
-      end if
+      endif
 
-    end do
+    enddo
 
     ! Test using defaults for 2D input array
     NameFile = 'test_plot_file16.out'
@@ -1099,7 +1099,7 @@ contains
       write(*, *) 'n1In, n2In=', n1In, n2In
       write(*, *) 'nOut_D    =', nOut_D
       call CON_stop(NameSub)
-    end if
+    endif
 
     ! Test using defaults for 3D input array
     NameFile = 'test_plot_file17.out'
@@ -1124,7 +1124,7 @@ contains
       write(*, *) 'n1In, n2In=', n1In, n2In
       write(*, *) 'nOut_D    =', nOut_D
       call CON_stop(NameSub)
-    end if
+    endif
 
     ! Now that we have the dimensions, we could allocate coordinate and
     ! variable arrays and read them

--- a/share/Library/src/ModProcessVarName.f90
+++ b/share/Library/src/ModProcessVarName.f90
@@ -256,8 +256,8 @@ contains
           NameVar_V(iName) = NameVarExtraStandardized_I(iVar)
           IsFoundVar = .true.
           CYCLE NAMELOOP
-        end if
-      end do
+        endif
+      enddo
 
       ! check dictionary ( loop over density, momentum. pressure, energy)
       do iVar = 1, nVarPerSubstance
@@ -267,8 +267,8 @@ contains
           nDistinctSubstanceVar_I(iVar) = &
             nDistinctSubstanceVar_I(iVar) + 1
           CYCLE NAMELOOP
-        end if
-      end do
+        endif
+      enddo
 
       ! variable name may correspond to numbered wave/material
       ! These names are created  in BATSRUS:MH_set_parameters
@@ -277,13 +277,13 @@ contains
         nWave = nWave + 1
         IsFoundVar = .true.
         CYCLE NAMELOOP
-      end if
+      endif
 
       if (lge(NameVarIn, 'm1') .and. lle(NameVarIn, 'm9')) then
         nMaterial = nMaterial + 1
         IsFoundVar = .true.
         CYCLE NAMELOOP
-      end if
+      endif
 
       if (.not. IsFoundVar) then
         write(*, *) 'ERROR: Var name not in dictionary: ', NameVarIn
@@ -292,9 +292,9 @@ contains
         !write(*,*) SubstanceStandardName_II
         write(*, *) ''
         call CON_stop(NameSub//': unknown variable '//NameVarIn)
-      end if
+      endif
 
-    end do NAMELOOP
+    enddo NAMELOOP
 
     nDensity = nDistinctSubstanceVar_I(Rho_)
     nSpeed = nDistinctSubstanceVar_I(RhoUx_)
@@ -328,10 +328,10 @@ contains
               NameVar_V(iName) = &
                 SubstanceStandardName_II(iSubstanceFound, iVar)
               RETURN
-            end if
-          end if
-        end do
-      end do
+            endif
+          endif
+        enddo
+      enddo
     end subroutine find_substance_replace_name
 
   end subroutine process_var_list
@@ -349,8 +349,8 @@ contains
         SubstanceStandardName_II(iSubstance, iVar) = &
           ''//trim(NameSubstance_I(iSubstance))//NameSubstanceVar_I(iVar)
 
-      end do
-    end do
+      enddo
+    enddo
 
   end subroutine create_standard_name
   ! =========================================================================
@@ -377,7 +377,7 @@ contains
     do iSubstance = 1, nSubstance
       Dictionary_III(iSubstance, Energy_, 2) = &
         ''//trim(NameSubstance_I(iSubstance))//'e'
-    end do
+    enddo
 
     ! main plasma fluid
     Dictionary_III(Main_, RhoUx_, 2) = 'rhoux'

--- a/share/Library/src/ModRandomNumber.f90
+++ b/share/Library/src/ModRandomNumber.f90
@@ -80,7 +80,7 @@ contains
       iRandom = random_integer(6, iSeed1, iSeed2, iSeed3)
       Average = Average + iRandom
       Average2 = Average2 + iRandom**2
-    end do
+    enddo
     Average = Average/nSample
     Average2 = Average2/nSample
     StdDev = sqrt((Average2 - Average**2))
@@ -102,7 +102,7 @@ contains
       Random = random_real(iSeed)
       Average = Average + Random
       Average2 = Average2 + Random**2
-    end do
+    enddo
     Average = Average/nSample
     Average2 = Average2/nSample
     StdDev = sqrt((Average2 - Average**2))

--- a/share/Library/src/ModReadParam.f90
+++ b/share/Library/src/ModReadParam.f90
@@ -246,7 +246,7 @@ contains
       iComm = iCommIn
     else
       iComm = MPI_COMM_WORLD
-    end if
+    endif
 
     ! If no file name is given, read from STDIN
     DoReadStdIn = .not. present(NameFile)
@@ -258,7 +258,7 @@ contains
     else
       call MPI_comm_rank(iComm, iProc, iError)
       call MPI_comm_size(iComm, nProc, iError)
-    end if
+    endif
 
     ! Read all input file(s) into memory and broadcast
     if (iProc == 0) then
@@ -273,7 +273,7 @@ contains
                                          trim(NameFile)//" cannot be found")
         iUnit_I(iFile) = io_unit_new()
         call open_file(iUnit_I(iFile), FILE=NameFile, STATUS="old")
-      end if
+      endif
       do
         read(iUnit_I(iFile), '(a)', ERR=100, END=100) StringLine
         NameCommand = StringLine
@@ -302,16 +302,16 @@ contains
               call CON_stop("Correct input")
             else
               call CON_stop("Correct "//trim(NameFile))
-            end if
-          end if
+            endif
+          endif
           if (DoInclude) then
             StringLine = NameRestartFile
           else
             StringLine = ' ' ! remove #RESTART command
-          end if
+          endif
         else
           DoInclude = .false.
-        end if
+        endif
         if (DoInclude) then
           iFile = iFile + 1
           if (iFile > MaxNestedFile) call CON_stop(NameSub// &
@@ -330,7 +330,7 @@ contains
                                              " SWMF_ERROR: too many lines of input")
           StringLine_I(nLine) = StringLine
           CYCLE
-        end if
+        endif
 
 100     continue
         call close_file(iUnit_I(iFile))
@@ -341,11 +341,11 @@ contains
         else
           ! The base file ended, stop reading
           EXIT
-        end if
-      end do
+        endif
+      enddo
       if (nLine == 0) call CON_stop(NameSub// &
                                     " SWMF_ERROR: no lines of input read")
-    end if
+    endif
 
     if (nProc > 1) then
       ! Broadcast the number of lines and the text itself to all processors
@@ -359,7 +359,7 @@ contains
 
       if (iError > 0) call CON_stop(NameSub// &
                                     " MPI_ERROR: text could not be broadcast")
-    end if
+    endif
 
     if (iProc == 0) write(*, '(a,i4,a)') NameSub// &
       ': read and broadcast nLine=', nLine, ' lines of text'
@@ -384,7 +384,7 @@ contains
       iSessionNew = iSessionIn
     else
       iSessionNew = 1
-    end if
+    endif
 
     if (iSessionNew > MaxSession) call CON_stop(NameSub// &
                                                 " ERROR: too many sessions in input")
@@ -398,7 +398,7 @@ contains
       NameComp = NameCompIn
     else
       NameComp = ''
-    end if
+    endif
 
     ! Set iLine to 0 for session 1 only (multi-session uses previous value)
     if (iSession == 1) iLine = 0
@@ -408,17 +408,17 @@ contains
       nLine = nLineIn
     else
       nLine = size(StringLine_I)
-    end if
+    endif
     if (present(iIoUnitIn)) then
       iIoUnit = iIoUnitIn
     else
       iIoUnit = StdOut_
-    end if
+    endif
     if (iIoUnit == StdOut_ .and. len_trim(NameComp) > 0) then
       StringPrefix = NameComp//': '
     else
       StringPrefix = ''
-    end if
+    endif
 
   end subroutine read_init
 
@@ -458,7 +458,7 @@ contains
     else
       if (present(StringLineOut)) StringLineOut = ''
       read_line = .false.
-    end if
+    endif
 
   end function read_line
 
@@ -484,7 +484,7 @@ contains
       if (DoEcho) then
         write(iIoUnit, '(a)') trim(StringPrefix)
         write(iIoUnit, '(a)') trim(StringPrefix)//trim(StringLine)
-      end if
+      endif
 
       ! Remove anything after a space or TAB
       i = index(StringLine, ' '); if (i > 0) StringLine(i:len(StringLine)) = ' '
@@ -501,7 +501,7 @@ contains
     else
       NameCommand = ''
       read_command = .false.
-    end if
+    endif
 
   end function read_command
 
@@ -526,8 +526,8 @@ contains
       else
         call CON_stop( &
           'Unexpected end of text after line='//StringLine)
-      end if
-    end if
+      endif
+    endif
     StringLine = StringLine_I(iLine)
 
     ! Get rid of leading spaces
@@ -541,9 +541,9 @@ contains
         i = min(i, j)      ! Both TAB and 3 spaces found, take the closer one
       else
         i = max(i, j)      ! Take the one that was found (if any)
-      end if
+      endif
       if (i > 0) StringParam(i:lStringLine) = ' '
-    end if
+    endif
 
     if (len_trim(StringParam) == 0) call read_error('missing', Name, iError)
 
@@ -591,7 +591,7 @@ contains
       write(*, '(a,i3)') 'Error in component '//NameComp//' in session', iSession
       call CON_stop('Error reading '//Type//' variable '//Name// &
                     ' from line='//StringLine)
-    end if
+    endif
 
   end subroutine read_error
 
@@ -636,10 +636,10 @@ contains
 
     if (present(IsLowerCase)) then
       if (IsLowerCase) call lower_case(StringVar)
-    end if
+    endif
     if (present(IsUpperCase)) then
       if (IsUpperCase) call upper_case(StringVar)
-    end if
+    endif
 
   end subroutine read_var_c
 
@@ -731,7 +731,7 @@ contains
       if (iReadError /= 0) call read_error('denominator', Name, iError)
       if (Denominator == 0.0) call read_error('zero denominator', Name, iError)
       RealTmp = Numerator/Denominator
-    end if
+    endif
     if (DoEcho) call read_echo(Name)
     RealVar = RealTmp
 
@@ -816,8 +816,8 @@ contains
       if (NameCommand == NameCommand_II(i, j)) then
         i_line_command = iLineCommand_II(i, j)
         RETURN
-      end if
-    end do
+      endif
+    enddo
 
     ! Could not find command, return -1
     i_line_command = -1

--- a/share/Library/src/ModSort.f90
+++ b/share/Library/src/ModSort.f90
@@ -38,7 +38,7 @@ contains
     !-------------------------------------------------------------------
     do j = 1, n
       indx(j) = j
-    end do
+    enddo
     jstack = 0
     l = 1
     ir = n
@@ -49,10 +49,10 @@ contains
         do i = j - 1, 1, -1
           if (arr(indx(i)) .le. a) goto 2
           indx(i + 1) = indx(i)
-        end do
+        enddo
         i = 0
 2       indx(i + 1) = indxt
-      end do
+      enddo
       if (jstack .eq. 0) return
       ir = istack(jstack)
       l = istack(jstack - 1)
@@ -66,17 +66,17 @@ contains
         itemp = indx(l + 1)
         indx(l + 1) = indx(ir)
         indx(ir) = itemp
-      end if
+      endif
       if (arr(indx(l)) > arr(indx(ir))) then
         itemp = indx(l)
         indx(l) = indx(ir)
         indx(ir) = itemp
-      end if
+      endif
       if (arr(indx(l + 1)) > arr(indx(l))) then
         itemp = indx(l + 1)
         indx(l + 1) = indx(l)
         indx(l) = itemp
-      end if
+      endif
       i = l + 1
       j = ir
       indxt = indx(l)
@@ -103,8 +103,8 @@ contains
         istack(jstack) = j - 1
         istack(jstack - 1) = l
         l = i
-      end if
-    end if
+      endif
+    endif
     goto 1
 
   end subroutine sort_quick
@@ -133,7 +133,7 @@ contains
     !-------------------------------------------------------------------
     do j = 1, n
       iSort_I(j) = j
-    end do
+    enddo
     jstack = 0
     l = 1
     ir = n
@@ -143,10 +143,10 @@ contains
         do i = j - 1, 1, -1
           if (.not. is_larger(iSort_I(i), indxt)) goto 2
           iSort_I(i + 1) = iSort_I(i)
-        end do
+        enddo
         i = 0
 2       iSort_I(i + 1) = indxt
-      end do
+      enddo
       if (jstack .eq. 0) return
       ir = istack(jstack)
       l = istack(jstack - 1)
@@ -160,17 +160,17 @@ contains
         itemp = iSort_I(l + 1)
         iSort_I(l + 1) = iSort_I(ir)
         iSort_I(ir) = itemp
-      end if
+      endif
       if (is_larger(iSort_I(l), iSort_I(ir))) then
         itemp = iSort_I(l)
         iSort_I(l) = iSort_I(ir)
         iSort_I(ir) = itemp
-      end if
+      endif
       if (is_larger(iSort_I(l + 1), iSort_I(l))) then
         itemp = iSort_I(l + 1)
         iSort_I(l + 1) = iSort_I(l)
         iSort_I(l) = itemp
-      end if
+      endif
       i = l + 1
       j = ir
       indxt = iSort_I(l)
@@ -196,8 +196,8 @@ contains
         istack(jstack) = j - 1
         istack(jstack - 1) = l
         l = i
-      end if
-    end if
+      endif
+    endif
     goto 1
 
   end subroutine sort_quick_func
@@ -221,7 +221,7 @@ contains
     do i = n, 1, -1
       if (i_I(i) < 0) write(*, *) 'This avoids ifort 12 optimization error!'
       SortSum = SortSum + a_I(i_I(i))
-    end do
+    enddo
     sort_sum = SortSum
     deallocate(i_I)
 
@@ -250,7 +250,7 @@ contains
       else
         write(*, '(a)') 'Testing sort_quick_func'
         call sort_quick_func(n, is_larger_test, i_I)
-      end if
+      endif
       b_I = a_I(i_I)
 
       IsError = .false.
@@ -259,15 +259,15 @@ contains
           write(*, *) 'Error at index i=', i, ': sorted b_I(i-1)=', b_I(i - 1), &
             ' should not exceed b_I(i)=', b_I(i)
           IsError = .true.
-        end if
-      end do
+        endif
+      enddo
 
       if (IsError) then
         write(*, '(a,5f5.0)') 'original array =', a_I
         write(*, '(a,5i5)') 'sorted index   =', i_I
         write(*, '(a,5f5.0)') 'sorted array   =', b_I
-      end if
-    end do
+      endif
+    enddo
 
     write(*, '(a)') 'Testing sort_sum'
     a_I = (/1.e-6, 1.e-7, 1.e10, -3.e9, -7.e9/)

--- a/share/Library/src/ModSpice_orig.f90
+++ b/share/Library/src/ModSpice_orig.f90
@@ -40,14 +40,14 @@ contains
     if (.not. DoInitialize) then
       write(*, *) NameSub, ' WARNING: has been initialized'
       RETURN
-    end if
+    endif
 
     tStartSpice = tStart + DtSpiceSwmf
 
     NameDir = 'Param/Spice/'
     if (present(NameDirIn)) then
       if (NameDirIn /= '') NameDir = trim(adjustl(NameDirIn))//'/'
-    end if
+    endif
 
     CALL FURNSH(trim(adjustl(NameDir))//'naif0010.tls')
     CALL FURNSH(trim(adjustl(NameDir))//'pck00010.tpc')

--- a/share/Library/src/ModTimeConvert.f90
+++ b/share/Library/src/ModTimeConvert.f90
@@ -135,7 +135,7 @@ contains
     if (.not. is_valid_int_time(Time)) then
       write(*, *) NameSub, ': invalid Time = ', Time
       call CON_stop(NameSub//' ERROR invalid time')
-    end if
+    endif
 
     write(Time%String, '(i4.4,5(i2.2))') &
       Time%iYear, Time%iMonth, Time%iDay, &
@@ -195,7 +195,7 @@ contains
     if (.not. is_valid_int_time(Time)) then
       write(*, *) NameSub, ': invalid Time = ', Time
       call CON_stop(NameSub//' ERROR invalid time')
-    end if
+    endif
 
     Time%Time = &
       ((Time%iYear - iYearBase)*365 + n_leap_day(Time%iYear) + &
@@ -236,7 +236,7 @@ contains
       !write(*,*)'iDay=', iDay
       if (iDay >= 0) EXIT
       iYear = iYear - 1
-    end do
+    enddo
     !write(*,*) 'iYear, nLeapYear, is_leap_year, iDay=',&
     !     iYear,nLeapYear, is_leap_year(iYear),iDay
 
@@ -259,7 +259,7 @@ contains
     do while (iDay >= nDayInMonth_I(iMonth))
       iDay = iDay - nDayInMonth_I(iMonth)
       iMonth = iMonth + 1
-    end do
+    enddo
 
     Time%iYear = iYear
     Time%iMonth = iMonth
@@ -311,7 +311,7 @@ contains
       nDayInMonth_I(2) = 29
     else
       nDayInMonth_I(2) = 28
-    end if
+    endif
     !EOC
   end subroutine fix_february
 
@@ -446,10 +446,10 @@ contains
               write(*, *) 'TimeStart  =', TimeStart%String
               write(*, *) 'TimeConvert=', TimeConvert%String
               stop
-            end if
-          end do
-        end do
-      end do
+            endif
+          enddo
+        enddo
+      enddo
     end subroutine check_all_days
 
   end subroutine test_time

--- a/share/Library/src/ModTriangulate.f90
+++ b/share/Library/src/ModTriangulate.f90
@@ -55,10 +55,10 @@ contains
           ! Split along jCell--kCell diagonal
           iNodeTriangle_II(:, nTriangle + 1) = (/jCell, kCell, iCell/)
           iNodeTriangle_II(:, nTriangle + 2) = (/jCell, lCell, kCell/)
-        end if
+        endif
         nTriangle = nTriangle + 2
 
-      end do; end do
+      enddo; enddo
 
   end subroutine mesh_triangulation
   !============================================================================
@@ -169,14 +169,14 @@ contains
             do j = jMin, jMax; do i = iMin, iMax
                 n = nTriangle_C(i, j)
                 iTriangle_IC(n, i, j) = iTriangle
-              end do; end do
-          end do
+              enddo; enddo
+          enddo
           if (iLoop == 1) then
             n = maxval(nTriangle_C)
             allocate(iTriangle_IC(n, nX, nY))
-          end if
-        end do
-      end if
+          endif
+        enddo
+      endif
 
       i = max(1, min(nX, floor(DxInv*(CoordIn_D(1) - xMin)) + 1))
       j = max(1, min(nY, floor(DyInv*(CoordIn_D(2) - yMin)) + 1))
@@ -184,20 +184,20 @@ contains
       do n = 1, nTriangle_C(i, j)
         iTriangle = iTriangle_IC(n, i, j)
         if (is_inside_triangle()) RETURN
-      end do
+      enddo
 
     else
       do iTriangle = 1, nTriangle
         if (is_inside_triangle()) RETURN
-      end do
-    end if
+      enddo
+    endif
 
     ! If no triangle contains the CoordIn_D point and IsTriangleFound is
     ! present then return a false value
     if (present(IsTriangleFound)) then
       IsTriangleFound = .false.
       RETURN
-    end if
+    endif
 
     ! If IsTriangleFound is not present then set iNode1 to the closest node
     iNode1 = minloc((XyNode_DI(x_, :) - CoordIn_D(x_))**2 &
@@ -214,7 +214,7 @@ contains
       Weight1 = 1.0
       Weight2 = 0.0
       Weight3 = 0.0
-    end if
+    endif
 
   contains
     !=======================================================================
@@ -256,11 +256,11 @@ contains
           Weight1 = Area1/AreaSum
           Weight2 = Area2/AreaSum
           Weight3 = Area3/AreaSum
-        end if
+        endif
         is_inside_triangle = .true.
       else
         is_inside_triangle = .false.
-      end if
+      endif
 
     end function is_inside_triangle
 
@@ -385,9 +385,9 @@ contains
         diaedg = 1
       else
         diaedg = 0
-      end if
+      endif
 
-    end if
+    endif
 
     return
   end function diaedg
@@ -505,9 +505,9 @@ contains
             < abs(point_xy(j, m) - point_xy(j, m1))) then
           k = j
           exit
-        end if
+        endif
 
-      end do
+      enddo
 
       if (k == 0) then
         write(*, '(a)') ' '
@@ -519,9 +519,9 @@ contains
         write(*, '(a,2g14.6)') '  X,Y(M1) = ', point_xy(1, m1), point_xy(2, m1)
         ierr = 224
         return
-      end if
+      endif
 
-    end do
+    enddo
     !
     !  Starting from points M1 and M2, search for a third point M that
     !  makes a "healthy" triangle (M1,M2,M)
@@ -537,7 +537,7 @@ contains
         write(*, '(a)') 'DTRIS2 - Fatal error!'
         ierr = 225
         return
-      end if
+      endif
 
       m = j
 
@@ -546,11 +546,11 @@ contains
 
       if (lr /= 0) then
         exit
-      end if
+      endif
 
       j = j + 1
 
-    end do
+    enddo
     !
     !  Set up the triangle information for (M1,M2,M), and for any other
     !  triangles you created because points were collinear with M1, M2.
@@ -575,7 +575,7 @@ contains
         tri_nabe(2, i - 1) = i
         tri_nabe(3, i) = i - 1
 
-      end do
+      enddo
 
       tri_nabe(1, tri_num) = -3*tri_num - 1
       tri_nabe(2, tri_num) = -5
@@ -598,14 +598,14 @@ contains
         tri_nabe(3, i - 1) = i
         tri_nabe(1, i) = -3*i - 3
         tri_nabe(2, i) = i - 1
-      end do
+      enddo
 
       tri_nabe(3, tri_num) = -3*tri_num
       tri_nabe(2, 1) = -3*tri_num - 2
       ledg = 2
       ltri = 1
 
-    end if
+    endif
     !
     !  Insert the vertices one at a time from outside the convex hull,
     !  determine visible boundary edges, and apply diagonal edge swaps until
@@ -622,7 +622,7 @@ contains
         m2 = tri_vert(ledg + 1, ltri)
       else
         m2 = tri_vert(1, ltri)
-      end if
+      endif
 
       lr = lrline(point_xy(1, m), point_xy(2, m), point_xy(1, m1), &
                   point_xy(2, m1), point_xy(1, m2), point_xy(2, m2), 0.0)
@@ -635,7 +635,7 @@ contains
         l = -tri_nabe(ledg, ltri)
         rtri = l/3
         redg = mod(l, 3) + 1
-      end if
+      endif
 
       call vbedg(point_xy(1, m), point_xy(2, m), point_num, point_xy, tri_num, &
                  tri_vert, tri_nabe, ltri, ledg, rtri, redg)
@@ -654,7 +654,7 @@ contains
           m1 = tri_vert(e + 1, t)
         else
           m1 = tri_vert(1, t)
-        end if
+        endif
 
         tri_num = tri_num + 1
         tri_nabe(e, t) = tri_num
@@ -672,15 +672,15 @@ contains
           write(*, '(a)') 'DTRIS2 - Fatal error!'
           write(*, '(a)') '  Stack overflow.'
           return
-        end if
+        endif
 
         stack(top) = tri_num
 
         if (t == rtri .and. e == redg) then
           exit
-        end if
+        endif
 
-      end do
+      enddo
 
       tri_nabe(ledg, ltri) = -3*n - 1
       tri_nabe(2, n) = -3*tri_num - 2
@@ -696,17 +696,17 @@ contains
         write(*, '(a)') 'DTRIS2 - Fatal error!'
         write(*, '(a)') '  Error return from SWAPEC.'
         return
-      end if
+      endif
 
-    end do
+    enddo
     !
     !  Now account for the sorting that we did.
     !
     do i = 1, 3
       do j = 1, tri_num
         tri_vert(i, j) = indx(tri_vert(i, j))
-      end do
-    end do
+      enddo
+    enddo
 
     call perm_inv(point_num, indx)
 
@@ -776,13 +776,13 @@ contains
       write(*, '(a)') 'I4_MODP - Fatal error!'
       write(*, '(a,i8)') '  I4_MODP ( I, J ) called with J = ', j
       call CON_stop('share/Library/src/ModTriangulate ERROR')
-    end if
+    endif
 
     i4_modp = mod(i, j)
 
     if (i4_modp < 0) then
       i4_modp = i4_modp + abs(j)
-    end if
+    endif
 
     return
   end function i4_modp
@@ -850,7 +850,7 @@ contains
       i4_wrap = jlo
     else
       i4_wrap = jlo + i4_modp(ival - jlo, wide)
-    end if
+    endif
 
     return
   end function i4_wrap
@@ -884,7 +884,7 @@ contains
 
     do i = 1, n
       a(i) = i
-    end do
+    enddo
 
     return
   end subroutine i4vec_indicator
@@ -944,11 +944,11 @@ contains
 
     if (n <= 1) then
       return
-    end if
+    endif
 
     do i = 1, n
       indx(i) = i
-    end do
+    enddo
 
     l = n/2 + 1
     ir = n
@@ -971,9 +971,9 @@ contains
         if (ir == 1) then
           indx(1) = indxt
           exit
-        end if
+        endif
 
-      end if
+      endif
 
       i = l
       j = l + l
@@ -983,8 +983,8 @@ contains
         if (j < ir) then
           if (a(indx(j)) < a(indx(j + 1))) then
             j = j + 1
-          end if
-        end if
+          endif
+        endif
 
         if (aval < a(indx(j))) then
           indx(i) = indx(j)
@@ -992,13 +992,13 @@ contains
           j = j + j
         else
           j = ir + 1
-        end if
+        endif
 
-      end do
+      enddo
 
       indx(i) = indxt
 
-    end do
+    enddo
 
     return
   end subroutine i4vec_sort_heap_index_a
@@ -1084,7 +1084,7 @@ contains
       lrline = 0
     else
       lrline = -1
-    end if
+    endif
 
     return
   end function lrline
@@ -1121,7 +1121,7 @@ contains
       write(*, '(a)') 'PERM_INV - Fatal error!'
       write(*, '(a,i8)') '  Input value of N = ', n
       call CON_stop('share/Library/src/ModTriangulate ERROR')
-    end if
+    endif
 
     is = 1
 
@@ -1133,12 +1133,12 @@ contains
         i2 = p(i1)
         p(i1) = -i2
         i1 = i2
-      end do
+      enddo
 
       is = -sign(1, p(i))
       p(i) = sign(p(i), is)
 
-    end do
+    enddo
 
     do i = 1, n
 
@@ -1155,16 +1155,16 @@ contains
 
           if (i2 < 0) then
             exit
-          end if
+          endif
 
           i0 = i1
           i1 = i2
 
-        end do
+        enddo
 
-      end if
+      endif
 
-    end do
+    enddo
 
     return
   end subroutine perm_inv
@@ -1259,20 +1259,20 @@ contains
             write(*, '(a)') ' '
             write(*, '(a)') 'R82VEC_PERMUTE - Fatal error!'
             call CON_stop('share/Library/src/ModTriangulate ERROR')
-          end if
+          endif
 
           if (iget == istart) then
             a(1:2, iput) = a_temp(1:2)
             exit
-          end if
+          endif
 
           a(1:2, iput) = a(1:2, iget)
 
-        end do
+        enddo
 
-      end if
+      endif
 
-    end do
+    enddo
     !
     !  Restore the signs of the entries.
     !
@@ -1336,12 +1336,12 @@ contains
 
     if (n < 1) then
       return
-    end if
+    endif
 
     if (n == 1) then
       indx(1) = 1
       return
-    end if
+    endif
 
     call i4vec_indicator(n, indx)
 
@@ -1366,9 +1366,9 @@ contains
         if (ir == 1) then
           indx(1) = indxt
           exit
-        end if
+        endif
 
-      end if
+      endif
 
       i = l
       j = l + l
@@ -1380,8 +1380,8 @@ contains
               (a(1, indx(j)) == a(1, indx(j + 1)) .and. &
                a(2, indx(j)) < a(2, indx(j + 1)))) then
             j = j + 1
-          end if
-        end if
+          endif
+        endif
 
         if (aval(1) < a(1, indx(j)) .or. &
             (aval(1) == a(1, indx(j)) .and. &
@@ -1391,13 +1391,13 @@ contains
           j = j + j
         else
           j = ir + 1
-        end if
+        endif
 
-      end do
+      enddo
 
       indx(i) = indxt
 
-    end do
+    enddo
 
     return
   end subroutine r82vec_sort_heap_index_a
@@ -1512,7 +1512,7 @@ contains
 
       if (top <= 0) then
         exit
-      end if
+      endif
 
       t = stack(top)
       top = top - 1
@@ -1526,7 +1526,7 @@ contains
       else
         e = 1
         b = tri_vert(2, t)
-      end if
+      endif
 
       a = tri_vert(e, t)
       u = tri_nabe(e, t)
@@ -1540,7 +1540,7 @@ contains
       else
         f = 3
         c = tri_vert(2, u)
-      end if
+      endif
 
       swap = diaedg(x, y, point_xy(1, a), point_xy(2, a), point_xy(1, c), &
                     point_xy(2, c), point_xy(1, b), point_xy(2, b))
@@ -1564,7 +1564,7 @@ contains
         if (0 < tri_nabe(fm1, u)) then
           top = top + 1
           stack(top) = u
-        end if
+        endif
 
         if (0 < s) then
 
@@ -1574,14 +1574,14 @@ contains
             tri_nabe(2, s) = t
           else
             tri_nabe(3, s) = t
-          end if
+          endif
 
           top = top + 1
 
           if (point_num < top) then
             ierr = 8
             return
-          end if
+          endif
 
           stack(top) = t
 
@@ -1590,7 +1590,7 @@ contains
           if (u == btri .and. fp1 == bedg) then
             btri = t
             bedg = e
-          end if
+          endif
 
           l = -(3*t + e - 1)
           tt = t
@@ -1606,13 +1606,13 @@ contains
               ee = 1
             else
               ee = 2
-            end if
+            endif
 
-          end do
+          enddo
 
           tri_nabe(ee, tt) = l
 
-        end if
+        endif
 
         if (0 < r) then
 
@@ -1622,14 +1622,14 @@ contains
             tri_nabe(2, r) = u
           else
             tri_nabe(3, r) = u
-          end if
+          endif
 
         else
 
           if (t == btri .and. ep1 == bedg) then
             btri = u
             bedg = f
-          end if
+          endif
 
           l = -(3*u + f - 1)
           tt = u
@@ -1645,17 +1645,17 @@ contains
               ee = 1
             else
               ee = 2
-            end if
+            endif
 
-          end do
+          enddo
 
           tri_nabe(ee, tt) = l
 
-        end if
+        endif
 
-      end if
+      endif
 
-    end do
+    enddo
 
     return
   end subroutine swapec
@@ -1755,7 +1755,7 @@ contains
       ledg = redg
     else
       ldone = .true.
-    end if
+    endif
 
     do
 
@@ -1768,23 +1768,23 @@ contains
         b = tri_vert(e + 1, t)
       else
         b = tri_vert(1, t)
-      end if
+      endif
 
       lr = lrline(x, y, point_xy(1, a), point_xy(2, a), point_xy(1, b), &
                   point_xy(2, b), 0.0)
 
       if (lr <= 0) then
         exit
-      end if
+      endif
 
       rtri = t
       redg = e
 
-    end do
+    enddo
 
     if (ldone) then
       return
-    end if
+    endif
 
     t = ltri
     e = ledg
@@ -1804,9 +1804,9 @@ contains
           e = 1
         else
           e = 2
-        end if
+        endif
 
-      end do
+      enddo
 
       a = tri_vert(e, t)
 
@@ -1815,9 +1815,9 @@ contains
 
       if (lr <= 0) then
         exit
-      end if
+      endif
 
-    end do
+    enddo
 
     ltri = t
     ledg = e
@@ -1847,8 +1847,8 @@ contains
       do i1 = 1, n1
         n = n + 1
         CoordXy_DI(:, n) = (/10.0*i1 + i2, 3.0*i2/)
-      end do
-    end do
+      enddo
+    enddo
 
     write(*, '(a)') 'Testing mesh_triangulation'
     call mesh_triangulation(n1, n2, CoordXy_DI, &

--- a/share/Library/src/ModTriangulateSpherical.f90
+++ b/share/Library/src/ModTriangulateSpherical.f90
@@ -131,7 +131,7 @@ contains
     if (kk < 4) then
       ier = -1
       return
-    end if
+    endif
 !
 !  Initialization:
 !
@@ -139,7 +139,7 @@ contains
     ist = nst
     if (ist < 1) then
       ist = km1
-    end if
+    endif
 
     p(1) = x(kk)
     p(2) = y(kk)
@@ -157,7 +157,7 @@ contains
     if (i1 == 0) then
       ier = -2
       return
-    end if
+    endif
 
     if (i3 /= 0) then
 
@@ -166,20 +166,20 @@ contains
       if (p(1) == x(l) .and. p(2) == y(l) .and. p(3) == z(l)) then
         ier = l
         return
-      end if
+      endif
 
       l = i2
 
       if (p(1) == x(l) .and. p(2) == y(l) .and. p(3) == z(l)) then
         ier = l
         return
-      end if
+      endif
 
       l = i3
       if (p(1) == x(l) .and. p(2) == y(l) .and. p(3) == z(l)) then
         ier = l
         return
-      end if
+      endif
 
       call intadd(kk, i1, i2, i3, list, lptr, lend, lnew)
 
@@ -189,9 +189,9 @@ contains
         call bdyadd(kk, i1, i2, list, lptr, lend, lnew)
       else
         call covsph(kk, i1, list, lptr, lend, lnew)
-      end if
+      endif
 
-    end if
+    endif
 
     ier = 0
 !
@@ -211,7 +211,7 @@ contains
 
       if (list(lp) < 0) then
         go to 2
-      end if
+      endif
 
       lp = lptr(lp)
       in1 = abs(list(lp))
@@ -223,7 +223,7 @@ contains
 
       if (.not. swptst(in1, kk, io1, io2, x, y, z)) then
         go to 2
-      end if
+      endif
 
       call swap(in1, kk, io1, io2, list, lptr, lend, lpo1)
 !
@@ -234,7 +234,7 @@ contains
       if (lpo1 == 0) then
         lpo1 = lpo1s
         go to 2
-      end if
+      endif
 
       io1 = in1
       cycle
@@ -245,13 +245,13 @@ contains
 
       if (lpo1 == lpf .or. list(lpo1) < 0) then
         exit
-      end if
+      endif
 
       io2 = io1
       lpo1 = lptr(lpo1)
       io1 = abs(list(lpo1))
 
-    end do
+    enddo
 
     return
   end subroutine addnod
@@ -402,7 +402,7 @@ contains
     if (abs(s12) <= tol .or. abs(s23) <= tol .or. abs(s31) <= tol) then
       areas = 0.0E+00
       return
-    end if
+    endif
 
     s12 = sqrt(s12)
     s23 = sqrt(s23)
@@ -438,7 +438,7 @@ contains
 
     if (areas < 0.0E+00) then
       areas = 0.0E+00
-    end if
+    endif
 
     return
   end function areas
@@ -539,12 +539,12 @@ contains
 
       if (next == n2) then
         exit
-      end if
+      endif
 
       next = -list(lp)
       list(lp) = next
 
-    end do
+    enddo
 !
 !  Add the boundary nodes between N1 and N2 as neighbors of node K.
 !
@@ -558,7 +558,7 @@ contains
 
       if (next == n2) then
         exit
-      end if
+      endif
 
       list(lnew) = next
       lptr(lnew) = lnew + 1
@@ -566,7 +566,7 @@ contains
       lp = lend(next)
       next = list(lp)
 
-    end do
+    enddo
 
     list(lnew) = -n2
     lptr(lnew) = lsav
@@ -655,9 +655,9 @@ contains
       if (list(lp) < 0) then
         nst = i
         exit
-      end if
+      endif
 
-    end do
+    enddo
 !
 !  The triangulation contains no boundary nodes.
 !
@@ -666,7 +666,7 @@ contains
       na = 3*(nn - 2)
       nt = 2*(nn - 2)
       return
-    end if
+    endif
 !
 !  NST is the first boundary node encountered.
 !
@@ -686,12 +686,12 @@ contains
 
       if (n0 == nst) then
         exit
-      end if
+      endif
 
       k = k + 1
       nodes(k) = n0
 
-    end do
+    enddo
 !
 !  Store the counts.
 !
@@ -774,7 +774,7 @@ contains
     if (cnorm == 0.0E+00) then
       ier = 1
       return
-    end if
+    endif
 
     c(1:3) = cu(1:3)/cnorm
 
@@ -857,9 +857,9 @@ contains
 
       if (next == nst) then
         exit
-      end if
+      endif
 
-    end do
+    enddo
 !
 !  Traverse the boundary again, adding each node to K's adjacency list.
 !
@@ -875,9 +875,9 @@ contains
 
       if (next == nst) then
         exit
-      end if
+      endif
 
-    end do
+    enddo
 
     lptr(lnew - 1) = lsav
     lend(k) = lnew - 1
@@ -1082,7 +1082,7 @@ contains
     if (nn < 3) then
       ier = 1
       return
-    end if
+    endif
 !
 !  Search for a boundary node N1.
 !
@@ -1093,15 +1093,15 @@ contains
       if (list(lend(n1)) < 0) then
         lp = lend(n1)
         exit
-      end if
+      endif
 
-    end do
+    enddo
 !
 !  The triangulation already covers the sphere.
 !
     if (lp == 0) then
       go to 9
-    end if
+    endif
 !
 !  There are NB >= 3 boundary nodes.  Add NB-2 pseudo-
 !  triangles (N1,N2,N3) by connecting N3 to the NB-3
@@ -1130,7 +1130,7 @@ contains
         ltri(4, nt) = nt + 1
         ltri(5, nt) = nt - 1
         ltri(6, nt) = 0
-      end if
+      endif
 
       n1 = n2
       lp = lend(n1)
@@ -1138,16 +1138,16 @@ contains
 
       if (n2 == n3) then
         exit
-      end if
+      endif
 
-    end do
+    enddo
 
     nb = nt + 2
 
     if (ncol < nt) then
       ier = 2
       return
-    end if
+    endif
 
     ltri(4, nt) = 0
 !
@@ -1171,7 +1171,7 @@ contains
 
             if (kt2 <= kt1) then
               cycle
-            end if
+            endif
 !
 !  The LTRI row indexes (I1,I2,I3) of triangle KT1 =
 !  (N1,N2,N3) are a cyclical permutation of (1,2,3).
@@ -1185,7 +1185,7 @@ contains
             else
               i1 = 1
               i2 = 2
-            end if
+            endif
 
             n1 = ltri(i1, kt1)
             n2 = ltri(i2, kt1)
@@ -1199,7 +1199,7 @@ contains
               i4 = 2
             else
               i4 = 3
-            end if
+            endif
 
             n4 = ltri(i4, kt2)
 !
@@ -1209,7 +1209,7 @@ contains
 !
             if (.not. swptst(n1, n2, n3, n4, x, y, z)) then
               cycle
-            end if
+            endif
 !
 !  Swap arc N1-N2 for N3-N4.  KTij is the triangle opposite
 !  Nj as a vertex of KTi.
@@ -1227,7 +1227,7 @@ contains
             else
               i2 = 1
               i1 = 2
-            end if
+            endif
 
             kt21 = ltri(i1 + 3, kt2)
             kt22 = ltri(i2 + 3, kt2)
@@ -1251,9 +1251,9 @@ contains
               if (ltri(4, kt11) /= kt1) then
                 i4 = 5
                 if (ltri(5, kt11) /= kt1) i4 = 6
-              end if
+              endif
               ltri(i4, kt11) = kt2
-            end if
+            endif
 
             if (kt22 /= 0) then
               i4 = 4
@@ -1261,22 +1261,22 @@ contains
                 i4 = 5
                 if (ltri(5, kt22) /= kt2) then
                   i4 = 6
-                end if
-              end if
+                endif
+              endif
               ltri(i4, kt22) = kt1
-            end if
+            endif
 
-          end do
+          enddo
 
-        end do
+        enddo
 
         if (.not. swp) then
           exit
-        end if
+        endif
 
-      end do
+      enddo
 
-    end if
+    endif
 !
 !  Compute and store the negative circumcenters and radii of
 !  the pseudo-triangles in the first NT positions.
@@ -1301,7 +1301,7 @@ contains
       if (ierr /= 0) then
         ier = 3
         return
-      end if
+      endif
 !
 !  Store the negative circumcenter and radius (computed from <V1,C>).
 !
@@ -1315,7 +1315,7 @@ contains
 
       rc(kt) = acos(t)
 
-    end do
+    enddo
 !
 !  Compute and store the circumcenters and radii of the
 !  actual triangles in positions KT = NT+1, NT+2, ...
@@ -1365,7 +1365,7 @@ contains
           if (ierr /= 0) then
             ier = 3
             return
-          end if
+          endif
 !
 !  Store the circumcenter, radius and triangle index.
 !
@@ -1390,20 +1390,20 @@ contains
           lpn = lstptr(lend(n3), n1, list, lptr)
           listc(lpn) = kt
 
-        end if
+        endif
 
         if (lp == lpl) then
           exit
-        end if
+        endif
 
-      end do
+      enddo
 
-    end do
+    enddo
 
     if (nt == 0) then
       ier = 0
       return
-    end if
+    endif
 !
 !  Store the first NT triangle indexes in LISTC.
 !
@@ -1430,9 +1430,9 @@ contains
         i2 = 2
         i3 = 3
         exit
-      end if
+      endif
 
-    end do
+    enddo
 
     n1 = ltri(i1, kt1)
     n0 = n1
@@ -1459,7 +1459,7 @@ contains
 
         if (kt2 == 0) then
           exit
-        end if
+        endif
 !
 !  Append KT2 to N1's triangle list.
 !
@@ -1484,9 +1484,9 @@ contains
           i1 = 3
           i2 = 1
           i3 = 2
-        end if
+        endif
 
-      end do
+      enddo
 !
 !  Store the saved first-triangle pointer in LPTR(LP), set
 !  N1 to the next boundary node, test for termination,
@@ -1499,14 +1499,14 @@ contains
 
       if (n1 == n0) then
         exit
-      end if
+      endif
 
       i4 = i3
       i3 = i2
       i2 = i1
       i1 = i4
 
-    end do
+    enddo
 
     ier = 0
 
@@ -1596,7 +1596,7 @@ contains
         n2 < 1 .or. n2 > n .or. n1 == n2) then
       ier = 1
       return
-    end if
+    endif
 
     lpl = lend(n2)
 
@@ -1607,8 +1607,8 @@ contains
       if (-list(lpl) /= n1) then
         ier = 2
         return
-      end if
-    end if
+      endif
+    endif
 !
 !  Set N3 to the node opposite N1->N2 (the second neighbor
 !  of N1), and test for error 3 (N3 already a boundary node).
@@ -1622,7 +1622,7 @@ contains
     if (list(lpl) <= 0) then
       ier = 3
       return
-    end if
+    endif
 !
 !  Delete N2 as a neighbor of N1, making N3 the first
 !  neighbor, and test for error 4 (N2 not a neighbor
@@ -1634,7 +1634,7 @@ contains
     if (lph < 0) then
       ier = 4
       return
-    end if
+    endif
 !
 !  Delete N1 as a neighbor of N2, making N3 the new last neighbor.
 !
@@ -1740,7 +1740,7 @@ contains
              nb > nn .or. nn < 3) then
       lph = -1
       return
-    end if
+    endif
 !
 !  Find pointers to neighbors of N0:
 !
@@ -1756,23 +1756,23 @@ contains
 
       if (list(lpb) == nb) then
         go to 2
-      end if
+      endif
 
       lpp = lpb
       lpb = lptr(lpp)
 
       if (lpb == lpl) then
         exit
-      end if
+      endif
 
-    end do
+    enddo
 !
 !  Test for error 2 (NB not found).
 !
     if (abs(list(lpb)) /= nb) then
       lph = -2
       return
-    end if
+    endif
 !
 !  NB is the last neighbor of N0.  Make NP the new last
 !  neighbor and, if NB is a boundary node, then make N0
@@ -1783,7 +1783,7 @@ contains
 
     if (list(lp) < 0) then
       list(lpp) = -list(lpp)
-    end if
+    endif
 
     go to 3
 !
@@ -1798,7 +1798,7 @@ contains
     if (list(lp) < 0 .and. list(lpl) > 0) then
       lend(n0) = lpp
       list(lpp) = -list(lpp)
-    end if
+    endif
 !
 !  Update LPTR so that the neighbor following NB now follows
 !  NP, and fill in the hole at location LPB.
@@ -1814,14 +1814,14 @@ contains
       if (lend(i) == lnw) then
         lend(i) = lpb
         exit
-      end if
-    end do
+      endif
+    enddo
 
     do i = 1, lnw - 1
       if (lptr(i) == lnw) then
         lptr(i) = lpb
-      end if
-    end do
+      endif
+    enddo
 !
 !  No errors encountered.
 !
@@ -1991,7 +1991,7 @@ contains
     if (n1 < 1 .or. n1 > nn .or. nn < 4 .or. lwk < 0) then
       ier = 1
       return
-    end if
+    endif
 
     lpl = lend(n1)
     lpf = lptr(lpl)
@@ -2000,12 +2000,12 @@ contains
 
     if (bdry) then
       nnb = nnb + 1
-    end if
+    endif
 
     if (nnb < 3) then
       ier = 3
       return
-    end if
+    endif
 
     lwkl = lwk
     lwk = nnb - 3
@@ -2013,13 +2013,13 @@ contains
     if (lwkl < lwk) then
       ier = 2
       return
-    end if
+    endif
 
     iwl = 0
 
     if (nnb == 3) then
       go to 3
-    end if
+    endif
 !
 !  Initialize for loop on arcs N1-N2 for neighbors N2 of N1,
 !  beginning with the second neighbor.  NR and NL are the
@@ -2050,7 +2050,7 @@ contains
 
       if (nl == nfrst .and. bdry) then
         exit
-      end if
+      endif
 
       xl = x(nl)
       yl = y(nl)
@@ -2073,7 +2073,7 @@ contains
         yr = y2
         zr = z2
         go to 2
-      end if
+      endif
 !
 !  The quadrilateral defined by adjacent triangles
 !  (N1,N2,NL) and (N2,N1,NR) is convex.  Swap in
@@ -2090,7 +2090,7 @@ contains
         yr = y2
         zr = z2
         go to 2
-      end if
+      endif
 
       iwl = iwl + 1
 
@@ -2098,13 +2098,13 @@ contains
         iwk(1, iwl) = nl
       else
         iwk(1, iwl) = nl - 1
-      end if
+      endif
 
       if (nr <= n1) then
         iwk(2, iwl) = nr
       else
         iwk(2, iwl) = nr - 1
-      end if
+      endif
 !
 !  Recompute the LIST indexes and NFRST, and decrement NNB.
 !
@@ -2113,7 +2113,7 @@ contains
 
       if (nnb == 3) then
         exit
-      end if
+      endif
 
       lpf = lptr(lpl)
       nfrst = list(lpf)
@@ -2139,7 +2139,7 @@ contains
         zr = z(nr)
         cycle
 
-      end if
+      endif
 !
 !  Bottom of loop -- test for termination of loop.
 !
@@ -2147,7 +2147,7 @@ contains
 
       if (n2 == nfrst) then
         exit
-      end if
+      endif
 
       n2 = nl
       x2 = xl
@@ -2155,7 +2155,7 @@ contains
       z2 = zl
       lp = lptr(lp)
 
-    end do
+    enddo
 !
 !  Delete N1 and all its incident arcs.  If N1 is an interior
 !  node and either NNB > 3 or NNB = 3 and N2 LEFT NR->NL,
@@ -2179,7 +2179,7 @@ contains
         n2 = list(lp)
         nl = list(lpl)
         bdry = left(x(nr), y(nr), z(nr), x(nl), y(nl), z(nl), x(n2), y(n2), z(n2))
-      end if
+      endif
 !
 !  If a boundary node already exists, then N1 and its
 !  neighbors cannot be converted to boundary nodes.
@@ -2191,22 +2191,22 @@ contains
           if (list(lend(i)) < 0) then
             bdry = .false.
             go to 5
-          end if
-        end do
+          endif
+        enddo
 
         list(lpl) = -list(lpl)
         nnb = nnb + 1
 
-      end if
+      endif
 
-    end if
+    endif
 
 5   continue
 
     if (.not. bdry .and. nnb > 3) then
       ier = 4
       return
-    end if
+    endif
 !
 !  Initialize for loop on neighbors.  LPL points to the last
 !  neighbor of N1.  LNEW is stored in local variable LNW.
@@ -2226,21 +2226,21 @@ contains
     if (lph < 0) then
       ier = 3
       return
-    end if
+    endif
 !
 !  LP and LPL may require alteration.
 !
     if (lpl == lnw) then
       lpl = lph
-    end if
+    endif
 
     if (lp == lnw) then
       lp = lph
-    end if
+    endif
 
     if (lp /= lpl) then
       go to 6
-    end if
+    endif
 !
 !  Delete N1 from X, Y, Z, and LEND, and remove its adjacency
 !  list from LIST and LPTR.  LIST entries (nodal indexes)
@@ -2250,26 +2250,26 @@ contains
 
     if (n1 > nn) then
       go to 9
-    end if
+    endif
 
     do i = n1, nn
       x(i) = x(i + 1)
       y(i) = y(i + 1)
       z(i) = z(i + 1)
       lend(i) = lend(i + 1)
-    end do
+    enddo
 
     do i = 1, lnw - 1
 
       if (list(i) > n1) then
         list(i) = list(i) - 1
-      end if
+      endif
 
       if (list(i) < -n1) then
         list(i) = list(i) + 1
-      end if
+      endif
 
-    end do
+    enddo
 !
 !  For LPN = first to last neighbors of N1, delete the
 !  preceding neighbor (indexed by LP).
@@ -2285,7 +2285,7 @@ contains
 
     if (bdry) then
       nnb = nnb - 1
-    end if
+    endif
 
     lpn = lpl
 
@@ -2303,14 +2303,14 @@ contains
         if (lend(i) == lnw) then
           lend(i) = lp
           exit
-        end if
-      end do
+        endif
+      enddo
 
       do i = lnw - 1, 1, -1
         if (lptr(i) == lnw) lptr(i) = lp
-      end do
+      enddo
 
-    end do
+    enddo
 !
 !  Update N and LNEW, and optimize the patch of triangles
 !  containing K (on input) by applying swaps to the arcs in IWK.
@@ -2332,14 +2332,14 @@ contains
         write(*, '(a,i6)') '  NIT = ', nit
         write(*, '(a,i6)') '  IERR = ', ierr
         return
-      end if
+      endif
 
       if (ierr == 1) then
         ier = 6
         return
-      end if
+      endif
 
-    end if
+    endif
 
     ier = 0
 
@@ -2508,7 +2508,7 @@ contains
     if (n1 < 1 .or. n2 < 1 .or. n1 == n2 .or. iwend < 0) then
       ier = 1
       return
-    end if
+    endif
 !
 !  Test for N2 as a neighbor of N1.  LPL points to the last neighbor of N1.
 !
@@ -2521,16 +2521,16 @@ contains
       if (n0 == n2) then
         ier = 0
         return
-      end if
+      endif
 
       lp = lptr(lp)
       n0 = list(lp)
 
       if (lp == lpl) then
         exit
-      end if
+      endif
 
-    end do
+    enddo
 !
 !  Initialize parameters.
 !
@@ -2566,7 +2566,7 @@ contains
 
       if (n1lst < 0) then
         go to 4
-      end if
+      endif
 !
 !  N1 is an interior node.  Set NL to the first candidate
 !  for NR (NL LEFT N2->N1).
@@ -2575,16 +2575,16 @@ contains
 
         if (left(x2, y2, z2, x1, y1, z1, x(nl), y(nl), z(nl))) then
           go to 4
-        end if
+        endif
 
         lp = lptr(lp)
         nl = list(lp)
 
         if (nl == n1frst) then
           exit
-        end if
+        endif
 
-      end do
+      enddo
 !
 !  All neighbors of N1 are strictly left of N1->N2.
 !
@@ -2616,7 +2616,7 @@ contains
           if ((dp2l - dp12*dp1l >= 0.0E+00 .or. dp2r - dp12*dp1r >= 0.0E+00) .and. &
               (dp1l - dp12*dp2l >= 0.0E+00 .or. dp1r - dp12*dp2r >= 0.0E+00)) then
             go to 6
-          end if
+          endif
 !
 !  NL-NR does not intersect N1-N2.  However, there is
 !  another candidate for the first arc if NL lies on
@@ -2624,17 +2624,17 @@ contains
 !
           if (.not. left(x2, y2, z2, x1, y1, z1, x(nl), y(nl), z(nl))) then
             exit
-          end if
+          endif
 
-        end if
+        endif
 !
 !  Bottom of loop.
 !
         if (nl == n1frst) then
           exit
-        end if
+        endif
 
-      end do
+      enddo
 !
 !  Either the triangulation is invalid or N1-N2 lies on the
 !  convex hull boundary and an edge NR->NL (opposite N1 and
@@ -2653,12 +2653,12 @@ contains
         write(*, '(a,i6)') '  IN1 = ', in1
         write(*, '(a,i6)') '  IN2 = ', in2
         return
-      end if
+      endif
 
       nit = 1
       call i_swap(n1, n2)
 
-    end do
+    enddo
 !
 !  Store the ordered sequence of intersecting edges NL->NR in
 !  IWK(1,IWL)->IWK(2,IWL).
@@ -2670,7 +2670,7 @@ contains
     if (iwl > iwend) then
       ier = 2
       return
-    end if
+    endif
 
     iwk(1, iwl) = nl
     iwk(2, iwl) = nr
@@ -2686,15 +2686,15 @@ contains
 
       if (list(lp) == nr) then
         go to 8
-      end if
+      endif
 
       lp = lptr(lp)
 
       if (lp == lpl) then
         exit
-      end if
+      endif
 
-    end do
+    enddo
 !
 !  NR must be the last neighbor, and NL->NR cannot be a boundary edge.
 !
@@ -2706,7 +2706,7 @@ contains
       write(*, '(a,i6)') '  IN1 = ', in1
       write(*, '(a,i6)') '  IN2 = ', in2
       return
-    end if
+    endif
 !
 !  Set NEXT to the neighbor following NR, and test for
 !  termination of the store loop.
@@ -2724,11 +2724,11 @@ contains
         nl = next
       else
         nr = next
-      end if
+      endif
 
       go to 6
 
-    end if
+    endif
 !
 !  IWL is the number of arcs which intersect N1-N2.
 !  Store LWK.
@@ -2768,14 +2768,14 @@ contains
 
     if (iwc == iwl) then
       go to 21
-    end if
+    endif
 
     iwcp1 = iwc + 1
     next = iwk(1, iwcp1)
 
     if (next /= nl) then
       go to 16
-    end if
+    endif
 
     next = iwk(2, iwcp1)
 !
@@ -2784,16 +2784,16 @@ contains
     if (.not. left(x0, y0, z0, x(nr), y(nr), z(nr), x(next), &
                    y(next), z(next))) then
       go to 14
-    end if
+    endif
 
     if (lft >= 0) then
       go to 12
-    end if
+    endif
 
     if (.not. left(x(nl), y(nl), z(nl), x0, y0, z0, x(next), &
                    y(next), z(next))) then
       go to 14
-    end if
+    endif
 !
 !  Replace NL->NR with N0->NEXT.
 !
@@ -2812,7 +2812,7 @@ contains
     do i = iwcp1, iwl
       iwk(1, i - 1) = iwk(1, i)
       iwk(2, i - 1) = iwk(2, i)
-    end do
+    enddo
 
     iwk(1, iwl) = n0
     iwk(2, iwl) = next
@@ -2846,16 +2846,16 @@ contains
     if (.not. &
         left(x(nl), y(nl), z(nl), x0, y0, z0, x(next), y(next), z(next))) then
       go to 19
-    end if
+    endif
 
     if (lft <= 0) then
       go to 17
-    end if
+    endif
 
     if (.not. &
         left(x0, y0, z0, x(nr), y(nr), z(nr), x(next), y(next), z(next))) then
       go to 19
-    end if
+    endif
 !
 !  Replace NL->NR with NEXT->N0.
 !
@@ -2874,7 +2874,7 @@ contains
     do i = iwc - 1, iwf, -1
       iwk(1, i + 1) = iwk(1, i)
       iwk(2, i + 1) = iwk(2, i)
-    end do
+    enddo
 
     iwk(1, iwf) = n0
     iwk(2, iwf) = next
@@ -2910,7 +2910,7 @@ contains
 !
     if (.not. left(x0, y0, z0, x(nr), y(nr), z(nr), x2, y2, z2)) then
       go to 10
-    end if
+    endif
 !
 !  Swap NL-NR for N0-N2 and store N0-N2 in the right portion of IWK.
 !
@@ -2926,7 +2926,7 @@ contains
 
     if (.not. left(x(nl), y(nl), z(nl), x0, y0, z0, x2, y2, z2)) then
       go to 10
-    end if
+    endif
 !
 !  Swap NL-NR for N0-N2, shift columns IWF,...,IWL-1 to the
 !  right, and store N0-N2 in the left portion of IWK.
@@ -2942,9 +2942,9 @@ contains
 
       if (i <= iwf) then
         exit
-      end if
+      endif
 
-    end do
+    enddo
 
     iwk(1, iwf) = n0
     iwk(2, iwf) = n2
@@ -2979,13 +2979,13 @@ contains
         write(*, '(a,i6)') '  NIT = ', nit
         write(*, '(a,i6)') '  IER = ', ier
         return
-      end if
+      endif
 
       if (ierr == 1) then
         ier = 5
-      end if
+      endif
 
-    end if
+    endif
 !
 !  Optimize the set of new arcs to the right of IN1->IN2.
 !
@@ -3003,19 +3003,19 @@ contains
         write(*, '(a,i6)') '  NIT = ', nit
         write(*, '(a,i6)') '  IER = ', ier
         return
-      end if
+      endif
 
       if (ierr == 1) then
         ier = 5
         return
-      end if
+      endif
 
-    end if
+    endif
 
     if (ier == 5) then
       ier = 5
       return
-    end if
+    endif
 
     return
   end subroutine edge
@@ -3114,7 +3114,7 @@ contains
     if (l < 2) then
       ier = 1
       return
-    end if
+    endif
 
     ier = 0
 !
@@ -3128,7 +3128,7 @@ contains
     do i = 1, l - 1
       ni = npts(i)
       lend(ni) = -lend(ni)
-    end do
+    enddo
 !
 !  Candidates for NP = NPTS(L) are the unmarked neighbors
 !  of nodes in NPTS.  DNP is initially greater than -cos(PI)
@@ -3157,18 +3157,18 @@ contains
           if (dnb < dnp) then
             np = nb
             dnp = dnb
-          end if
-        end if
+          endif
+        endif
 
         lp = lptr(lp)
 
         if (lp == lpl) then
           exit
-        end if
+        endif
 
-      end do
+      enddo
 
-    end do
+    enddo
 
     npts(l) = np
     df = dnp
@@ -3178,7 +3178,7 @@ contains
     do i = 1, l - 1
       ni = npts(i)
       lend(ni) = -lend(ni)
-    end do
+    enddo
 
     return
   end subroutine getnp
@@ -3444,7 +3444,7 @@ contains
     if (n < 3 .or. n > imx) then
       ier = 1
       return
-    end if
+    endif
 !
 !  Initialize K0.
 !
@@ -3454,7 +3454,7 @@ contains
     if (i1 < 1 .or. i1 > imx) then
       ier = 2
       return
-    end if
+    endif
 !
 !  Increment K0 and set Q to a point immediately to the left
 !  of the midpoint of edge V1->V2 = LISTV(K0)->LISTV(K0+1):
@@ -3467,7 +3467,7 @@ contains
     if (k0 > n) then
       ier = 4
       return
-    end if
+    endif
 
     i1 = listv(k0)
 
@@ -3475,12 +3475,12 @@ contains
       i2 = listv(k0 + 1)
     else
       i2 = listv(1)
-    end if
+    endif
 
     if (i2 < 1 .or. i2 > imx) then
       ier = 2
       return
-    end if
+    endif
 
     vn(1) = yv(i1)*zv(i2) - zv(i1)*yv(i2)
     vn(2) = zv(i1)*xv(i2) - xv(i1)*zv(i2)
@@ -3489,7 +3489,7 @@ contains
 
     if (vnrm == 0.0E+00) then
       go to 1
-    end if
+    endif
 
     q(1) = xv(i1) + xv(i2) + eps*vn(1)/vnrm
     q(2) = yv(i1) + yv(i2) + eps*vn(2)/vnrm
@@ -3509,7 +3509,7 @@ contains
 
     if (cn(1) == 0.0E+00 .and. cn(2) == 0.0E+00 .and. cn(3) == 0.0E+00) then
       go to 1
-    end if
+    endif
 
     pn(1) = p(2)*cn(3) - p(3)*cn(2)
     pn(2) = p(3)*cn(1) - p(1)*cn(3)
@@ -3531,7 +3531,7 @@ contains
     if (i2 < 1 .or. i2 > imx) then
       ier = 2
       return
-    end if
+    endif
 
     lft2 = cn(1)*xv(i2) + cn(2)*yv(i2) + cn(3)*zv(i2) > 0.0E+00
 !
@@ -3546,13 +3546,13 @@ contains
       if (i2 < 1 .or. i2 > imx) then
         ier = 2
         return
-      end if
+      endif
 
       lft2 = cn(1)*xv(i2) + cn(2)*yv(i2) + cn(3)*zv(i2) > 0.0E+00
 
       if (lft1 .eqv. lft2) then
         cycle
-      end if
+      endif
 !
 !  I1 and I2 are on opposite sides of Q->P.  Compute the
 !  point of intersection B.
@@ -3582,31 +3582,31 @@ contains
         if (d > bq) then
           bq = d
           qinr = lft2
-        end if
+        endif
 
         d = dot_product(b(1:3), p(1:3))
 
         if (d > bp) then
           bp = d
           pinr = lft1
-        end if
+        endif
 
-      end if
+      endif
 
-    end do
+    enddo
 !
 !  Test for consistency:  NI must be even and QINR must be TRUE.
 !
     if (ni /= 2*(ni/2) .or. .not. qinr) then
       go to 1
-    end if
+    endif
 !
 !  Test for error 3:  different values of PINR and EVEN.
 !
     if (pinr .neqv. even) then
       ier = 3
       return
-    end if
+    endif
 
     ier = 0
     inside = even
@@ -3780,7 +3780,7 @@ contains
     if (d1 == d2) then
       ier = 1
       return
-    end if
+    endif
 !
 !  Solve for T such that <PP,CN> = 0 and compute PP and PPN.
 !
@@ -3790,14 +3790,14 @@ contains
     do i = 1, 3
       pp(i) = p1(i) + t*(p2(i) - p1(i))
       ppn = ppn + pp(i)*pp(i)
-    end do
+    enddo
 !
 !  PPN = 0 iff PP = 0 iff P2 = -P1 (and T = .5).
 !
     if (ppn == 0.0E+00) then
       ier = 2
       return
-    end if
+    endif
 
     ppn = sqrt(ppn)
 !
@@ -3984,15 +3984,15 @@ contains
 
       if (nd == nb) then
         exit
-      end if
+      endif
 
       lp = lptr(lp)
 
       if (lp == lpl) then
         exit
-      end if
+      endif
 
-    end do
+    enddo
 
     lstptr = lp
 
@@ -4056,11 +4056,11 @@ contains
 
       if (lp == lpl) then
         exit
-      end if
+      endif
 
       k = k + 1
 
-    end do
+    enddo
 
     nbcnt = k
 
@@ -4207,13 +4207,13 @@ contains
 
     if (nn < 3) then
       return
-    end if
+    endif
 
     nst = ist
 
     if (nst < 1 .or. nst > nn) then
       nst = 1
-    end if
+    endif
 !
 !  Find a triangle (I1,I2,I3) containing P, or the rightmost
 !  (I1) and leftmost (I2) visible boundary nodes as viewed from P.
@@ -4224,7 +4224,7 @@ contains
 !
     if (i1 == 0) then
       return
-    end if
+    endif
 !
 !  Store the linked list of 'neighbors' of P in LISTP and
 !  LPTRP.  I1 is the first neighbor, and 0 is stored as
@@ -4264,15 +4264,15 @@ contains
 
         if (n1 == i2 .or. lp1 >= lmax) then
           exit
-        end if
+        endif
 
-      end do
+      enddo
 
       l = lp1
       listp(l) = 0
       lptrp(l) = 1
 
-    end if
+    endif
 !
 !  Initialize variables for a loop on arcs N1-N2 opposite P
 !  in which new 'neighbors' are 'swapped' in.  N1 follows
@@ -4299,7 +4299,7 @@ contains
 !
         if (l == lmax) then
           exit
-        end if
+        endif
 
         dx1 = x(n1) - p(1)
         dy1 = y(n1) - p(2)
@@ -4328,16 +4328,16 @@ contains
           n1 = n3
           cycle
 
-        end if
+        endif
 
-      end if
+      endif
 !
 !  No swap:  Advance to the next arc and test for termination
 !  on N1 = I1 (LP1 = 1) or N1 followed by 0.
 !
       if (lp1 == 1) then
         exit
-      end if
+      endif
 
       lp2 = lp1
       n2 = n1
@@ -4346,9 +4346,9 @@ contains
 
       if (n1 == 0) then
         exit
-      end if
+      endif
 
-    end do
+    enddo
 !
 !  Set NR and DSR to the index of the nearest node to P and
 !  an increasing function (negative cosine) of its distance
@@ -4363,16 +4363,16 @@ contains
 
       if (n1 == 0) then
         cycle
-      end if
+      endif
 
       ds1 = -(x(n1)*p(1) + y(n1)*p(2) + z(n1)*p(3))
 
       if (ds1 < dsr) then
         nr = n1
         dsr = ds1
-      end if
+      endif
 
-    end do
+    enddo
 
     dsr = -dsr
     dsr = min(dsr, 1.0E+00)
@@ -4490,7 +4490,7 @@ contains
       nit = 0
       ier = 2
       return
-    end if
+    endif
 !
 !  Initialize iteration count ITER and test for NA = 0.
 !
@@ -4500,7 +4500,7 @@ contains
       nit = 0
       ier = 0
       return
-    end if
+    endif
 !
 !  Top of loop.
 !  SWP = TRUE iff a swap occurred in the current iteration.
@@ -4511,7 +4511,7 @@ contains
         nit = iter
         ier = 1
         return
-      end if
+      endif
 
       iter = iter + 1
       swp = .false.
@@ -4538,16 +4538,16 @@ contains
 
           if (list(lp) == io2) then
             go to 3
-          end if
+          endif
 
           lpp = lp
           lp = lptr(lpp)
 
           if (lp == lpl) then
             exit
-          end if
+          endif
 
-        end do
+        enddo
 !
 !  IO2 should be the last neighbor of IO1.  Test for no
 !  arc and bypass the swap test if IO1 is a boundary node.
@@ -4556,7 +4556,7 @@ contains
           nit = iter
           ier = 3
           return
-        end if
+        endif
 
         if (list(lp) < 0) go to 4
 !
@@ -4582,25 +4582,25 @@ contains
               nit = iter
               ier = 4
               return
-            end if
+            endif
 
             swp = .true.
             iwk(1, i) = n1
             iwk(2, i) = n2
 
-          end if
+          endif
 
-        end if
+        endif
 
 4       continue
 
-      end do
+      enddo
 
       if (.not. swp) then
         exit
-      end if
+      endif
 
-    end do
+    enddo
 
     nit = iter
     ier = 0
@@ -4674,9 +4674,9 @@ contains
         x(i) = x(i)/norm
         y(i) = y(i)/norm
         z(i) = z(i)/norm
-      end if
+      endif
 
-    end do
+    enddo
 
     return
   end subroutine r3vec_normalize
@@ -4726,13 +4726,13 @@ contains
       plon = atan2(py, px)
     else
       plon = 0.0E+00
-    end if
+    endif
 
     if (pnrm /= 0.0E+00) then
       plat = asin(pz/pnrm)
     else
       plat = 0.0E+00
-    end if
+    endif
 
     return
   end subroutine scoord
@@ -4842,7 +4842,7 @@ contains
     if (abs(list(lp)) == in2) then
       lp21 = 0
       return
-    end if
+    endif
 !
 !  Delete IO2 as a neighbor of IO1.
 !
@@ -4854,7 +4854,7 @@ contains
 !
     if (lend(io1) == lph) then
       lend(io1) = lp
-    end if
+    endif
 !
 !  Insert IN2 as a neighbor of IN1 following IO1 using the hole created above.
 !
@@ -4874,7 +4874,7 @@ contains
 !
     if (lend(io2) == lph) then
       lend(io2) = lp
-    end if
+    endif
 !
 !  Insert IN1 as a neighbor of IN2 following IO2.
 !
@@ -5036,7 +5036,7 @@ contains
         ampm = 'Noon'
       else
         ampm = 'PM'
-      end if
+      endif
     else
       h = h - 12
       if (h < 12) then
@@ -5046,9 +5046,9 @@ contains
           ampm = 'Midnight'
         else
           ampm = 'AM'
-        end if
-      end if
-    end if
+        endif
+      endif
+    endif
 
     write(*, '(a,1x,i2,1x,i4,2x,i2,a1,i2.2,a1,i2.2,a1,i3.3,1x,a)') &
       trim(month(m)), d, y, h, ':', n, ':', s, '.', mm, trim(ampm)
@@ -5120,7 +5120,7 @@ contains
       x(i) = cosphi*cos(theta)
       y(i) = cosphi*sin(theta)
       z(i) = sin(phi)
-    end do
+    enddo
 
     return
   end subroutine trans
@@ -5290,7 +5290,7 @@ contains
 
     if (n0 < 1 .or. n < n0) then
       n0 = jrand(n, ix, iy, iz)
-    end if
+    endif
 !
 !  Compute the relative machine precision EPS and TOL.
 !
@@ -5325,9 +5325,9 @@ contains
         n1 = list(lp)
         if (n1 == nl) then
           go to 6
-        end if
+        endif
         go to 3
-      end if
+      endif
 
     else
 !
@@ -5341,7 +5341,7 @@ contains
         n1 = n0
         n2 = nf
         go to 9
-      end if
+      endif
 !
 !  Is P to the right of the boundary edge NL->N0?
 !
@@ -5349,9 +5349,9 @@ contains
         n1 = nl
         n2 = n0
         go to 9
-      end if
+      endif
 
-    end if
+    endif
 !
 !  P is to the left of arcs N0->N1 and NL->N0.  Set N2 to the
 !  next neighbor of N0 (following N1).
@@ -5363,17 +5363,17 @@ contains
 
     if (det(x(n0), y(n0), z(n0), x(n2), y(n2), z(n2), xp, yp, zp) < 0.0E+00) then
       go to 7
-    end if
+    endif
 
     n1 = n2
 
     if (n1 /= nl) then
       go to 4
-    end if
+    endif
 
     if (det(x(n0), y(n0), z(n0), x(nf), y(nf), z(nf), xp, yp, zp) < 0.0E+00) then
       go to 6
-    end if
+    endif
 !
 !  P is left of or on arcs N0->NB for all neighbors NB
 !  of N0.  Test for P = +/-N0.
@@ -5389,7 +5389,7 @@ contains
 
         if (det(x(n1), y(n1), z(n1), x(n0), y(n0), z(n0), xp, yp, zp) < 0.0E+00) then
           exit
-        end if
+        endif
 
         lp = lptr(lp)
         n1 = abs(list(lp))
@@ -5399,11 +5399,11 @@ contains
           i2 = 0
           i3 = 0
           return
-        end if
+        endif
 
-      end do
+      enddo
 
-    end if
+    endif
 !
 !  P is to the right of N1->N0, or P = +/-N0.  Set N0 to N1 and start over.
 !
@@ -5441,7 +5441,7 @@ contains
 
       if (list(lp) < 0) then
         go to 9
-      end if
+      endif
 
       lp = lptr(lp)
       n4 = abs(list(lp))
@@ -5454,15 +5454,15 @@ contains
         n1s = n1
         if (n2 /= n2s .and. n2 /= n0) then
           go to 8
-        end if
+        endif
       else
         n3 = n1
         n1 = n4
         n2s = n2
         if (n1 /= n1s .and. n1 /= n0) then
           go to 8
-        end if
-      end if
+        endif
+      endif
 !
 !  The starting node N0 or edge N1-N2 was encountered
 !  again, implying a cycle (infinite loop).  Restart
@@ -5471,7 +5471,7 @@ contains
       n0 = jrand(n, ix, iy, iz)
       go to 2
 
-    end if
+    endif
 !
 !  P is in (N1,N2,N3) unless N0, N1, N2, and P are collinear
 !  or P is close to -N0.
@@ -5488,7 +5488,7 @@ contains
       if (b1 < -tol .or. b2 < -tol) then
         n0 = jrand(n, ix, iy, iz)
         go to 2
-      end if
+      endif
 
     else
 !
@@ -5507,9 +5507,9 @@ contains
       if (b1 < -tol .or. b2 < -tol) then
         n0 = jrand(n, ix, iy, iz)
         go to 2
-      end if
+      endif
 
-    end if
+    endif
 !
 !  P is in (N1,N2,N3).
 !
@@ -5555,7 +5555,7 @@ contains
 !  the leftmost visible node.
 !
       nl = n2
-    end if
+    endif
 !
 !  Bottom of counterclockwise loop:
 !
@@ -5564,7 +5564,7 @@ contains
 
     if (n2 /= n1s) then
       go to 10
-    end if
+    endif
 !
 !  All boundary nodes are visible from P.
 !
@@ -5606,17 +5606,17 @@ contains
 
         if (xp*q(1) + yp*q(2) + zp*q(3) >= 0.0E+00) then
           go to 13
-        end if
+        endif
 
         if (x(next)*q(1) + y(next)*q(2) + z(next)*q(3) >= 0.0E+00) then
           go to 13
-        end if
+        endif
 !
 !  P, NEXT, N1, and N2 are nearly collinear and N1 is the rightmost
 !  visible node.
 !
         nf = n1
-      end if
+      endif
 !
 !  Bottom of clockwise loop:
 !
@@ -5625,7 +5625,7 @@ contains
 
       if (n1 /= n1s) then
         go to 12
-      end if
+      endif
 !
 !  All boundary nodes are visible from P.
 !
@@ -5640,7 +5640,7 @@ contains
 
       nl = n1
 
-    end if
+    endif
 !
 !  NF and NL have been found.
 !
@@ -5760,7 +5760,7 @@ contains
       nt = 0
       ier = 1
       return
-    end if
+    endif
 !
 !  Initialize parameters for loop on triangles KT = (N1,N2,
 !  N3), where N1 < N2 and N1 < N3.
@@ -5814,7 +5814,7 @@ contains
         else
           i1 = n2
           i2 = n1
-        end if
+        endif
 !
 !  Set I3 to the neighbor of I1 that follows I2 unless
 !  I2->I1 is a boundary arc.
@@ -5826,15 +5826,15 @@ contains
 
           if (list(lp) == i2) then
             go to 3
-          end if
+          endif
 
           lp = lptr(lp)
 
           if (lp == lpl) then
             exit
-          end if
+          endif
 
-        end do
+        enddo
 !
 !  Invalid triangulation data structure:  I1 is a neighbor of
 !  I2, but I2 is not a neighbor of I1.
@@ -5843,7 +5843,7 @@ contains
           nt = 0
           ier = 2
           return
-        end if
+        endif
 !
 !  I2 is the last neighbor of I1.  Bypass the search for a neighboring
 !  triangle if I2->I1 is a boundary arc.
@@ -5852,7 +5852,7 @@ contains
 
         if (list(lp) < 0) then
           go to 6
-        end if
+        endif
 !
 !  I2->I1 is not a boundary arc, and LP points to I2 as
 !  a neighbor of I1.
@@ -5879,13 +5879,13 @@ contains
           i1 = i3
           i3 = i2
           i2 = isv
-        end if
+        endif
 !
 !  Test for KN > KT (triangle index not yet assigned).
 !
         if (i1 > n1) then
           cycle
-        end if
+        endif
 !
 !  Find KN, if it exists, by searching the triangle list in
 !  reverse order.
@@ -5893,7 +5893,7 @@ contains
         do kn = kt - 1, 1, -1
           if (ltri(1, kn) == i1 .and. ltri(2, kn) == &
               i2 .and. ltri(3, kn) == i3) go to 5
-        end do
+        enddo
 
         cycle
 !
@@ -5913,9 +5913,9 @@ contains
           ka = ka + 1
           ltri(i + 6, kt) = ka
           if (kn /= 0) ltri(j + 6, kn) = ka
-        end if
+        endif
 
-      end do
+      enddo
 !
 !  Bottom of loop on triangles.
 !
@@ -5923,11 +5923,11 @@ contains
 
       if (lp2 /= lpln1) then
         go to 1
-      end if
+      endif
 
 9     continue
 
-    end do
+    enddo
 
     nt = kt
     ier = 0
@@ -6028,7 +6028,7 @@ contains
         nt < 1 .or. nt > nmax) then
       write(*, 110) n, nrow, nt
       return
-    end if
+    endif
 !
 !  Print X, Y, and Z.
 !
@@ -6043,10 +6043,10 @@ contains
           write(*, '(a)') ' '
           write(*, '(a)') ' '
           nl = 0
-        end if
+        endif
         write(*, 103) i, x(i), y(i), z(i)
         nl = nl + 1
-      end do
+      enddo
 !
 !  Print X (longitude) and Y (latitude).
 !
@@ -6062,12 +6062,12 @@ contains
           write(*, '(a)') ' '
           write(*, '(a)') ' '
           nl = 0
-        end if
+        endif
         write(*, 104) i, x(i), y(i)
         nl = nl + 1
-      end do
+      enddo
 
-    end if
+    endif
 !
 !  Print the triangulation LTRI.
 !
@@ -6076,13 +6076,13 @@ contains
       write(*, '(a)') ' '
       write(*, '(a)') ' '
       nl = 0
-    end if
+    endif
 
     if (nrow == 6) then
       write(*, 105)
     else
       write(*, 106)
-    end if
+    endif
 
     nl = nl + 5
 
@@ -6092,10 +6092,10 @@ contains
         write(*, '(a)') ' '
         write(*, '(a)') ' '
         nl = 0
-      end if
+      endif
       write(*, 107) k, ltri(1:nrow, k)
       nl = nl + 1
-    end do
+    enddo
 !
 !  Print NB, NA, and NT (boundary nodes, arcs, and triangles).
 !
@@ -6106,7 +6106,7 @@ contains
       na = 3*n - 6
     else
       na = nt + n - 1
-    end if
+    endif
 
     write(*, '(a)') ' '
     write(*, '(a,i6)') '  Number of boundary nodes NB = ', nb
@@ -6344,7 +6344,7 @@ contains
     if (nn < 3) then
       ier = -1
       return
-    end if
+    endif
 !
 !  Store the first triangle in the linked list.
 !
@@ -6400,7 +6400,7 @@ contains
 !
       ier = -2
       return
-    end if
+    endif
 !
 !  Initialize LNEW and test for N = 3.
 !
@@ -6409,7 +6409,7 @@ contains
     if (nn == 3) then
       ier = 0
       return
-    end if
+    endif
 !
 !  A nearest-node data structure (NEAR, NEXT, and DIST) is
 !  used to obtain an expected-time (N*log(N)) incremental
@@ -6462,9 +6462,9 @@ contains
         dist(k) = d3
         next(k) = near(3)
         near(3) = k
-      end if
+      endif
 
-    end do
+    enddo
 !
 !  Add the remaining nodes.
 !
@@ -6474,7 +6474,7 @@ contains
 
       if (ier /= 0) then
         return
-      end if
+      endif
 !
 !  Remove K from the set of unprocessed nodes associated with NEAR(K).
 !
@@ -6495,13 +6495,13 @@ contains
 
           if (i == k) then
             exit
-          end if
+          endif
 
-        end do
+        enddo
 
         next(i0) = next(k)
 
-      end if
+      endif
 
       near(k) = 0
 !
@@ -6527,7 +6527,7 @@ contains
 
         if (i == 0) then
           exit
-        end if
+        endif
 
         nexti = next(i)
 !
@@ -6548,17 +6548,17 @@ contains
             near(j) = nexti
           else
             next(i0) = nexti
-          end if
+          endif
 
           next(i) = near(k)
           near(k) = i
         else
           i0 = i
-        end if
+        endif
 
         i = nexti
 
-      end do
+      enddo
 !
 !  Bottom of loop on neighbors J.
 !
@@ -6566,11 +6566,11 @@ contains
 
       if (lp /= lpl) then
         go to 3
-      end if
+      endif
 
 6     continue
 
-    end do
+    enddo
 
     return
   end subroutine trmesh
@@ -6761,7 +6761,7 @@ contains
     else if (n < 3) then
       ier = 1
       return
-    end if
+    endif
 
     if (abs(elat) > 90.0E+00) then
       ier = 2
@@ -6772,7 +6772,7 @@ contains
     else if (a > 90.0E+00) then
       ier = 2
       return
-    end if
+    endif
 !
 !  Compute a conversion factor CF for degrees to radians.
 !
@@ -6870,7 +6870,7 @@ contains
     else
       r11 = 0.0E+00
       r12 = 1.0E+00
-    end if
+    endif
 
     r21 = -ez*r12
     r22 = ez*r11
@@ -6884,14 +6884,14 @@ contains
 
       if (z0 < 0.0E+00) then
         cycle
-      end if
+      endif
 
       x0 = r11*x(n0) + r12*y(n0)
       y0 = r21*x(n0) + r22*y(n0) + r23*z(n0)
 
       if (x0*x0 + y0*y0 > wrs) then
         cycle
-      end if
+      endif
 
       lpl = lend(n0)
       lp = lpl
@@ -6918,7 +6918,7 @@ contains
           t = sqrt(x1*x1 + y1*y1)
           x1 = x1/t
           y1 = y1/t
-        end if
+        endif
 !
 !  If node N1 is in the window and N1 < N0, bypass edge
 !  N0->N1 (since edge N1->N0 has already been drawn).
@@ -6928,15 +6928,15 @@ contains
         if (z1 < 0.0E+00 .or. x1*x1 + y1*y1 > wrs .or. n1 >= n0) then
           write(lun, '(2f12.6,a,2f12.6,a)') &
             x0, y0, ' moveto', x1, y1, ' lineto'
-        end if
+        endif
 
         if (lp == lpl) then
           exit
-        end if
+        endif
 
-      end do
+      enddo
 
-    end do
+    enddo
 !
 !  Paint the path and restore the saved graphics state (with
 !  no clip path).
@@ -6961,14 +6961,14 @@ contains
 
         if (ex*x(n0) + ey*y(n0) + ez*z(n0) < 0.0E+00) then
           cycle
-        end if
+        endif
 
         x0 = r11*x(n0) + r12*y(n0)
         y0 = r21*x(n0) + r22*y(n0) + r23*z(n0)
 
         if (x0*x0 + y0*y0 > wrs) then
           cycle
-        end if
+        endif
 !
 !  Move to (X0,Y0) and draw the label N0.  The first char-
 !  acter will will have its lower left corner about one
@@ -6977,9 +6977,9 @@ contains
         write(lun, '(2f12.6,a)') x0, y0, ' moveto'
         write(lun, '(a,i3,a)') '(', n0, ') show'
 
-      end do
+      enddo
 
-    end if
+    endif
 !
 !  Convert FSIZT from points to world coordinates, and output
 !  the commands to select a font and scale it.
@@ -7010,7 +7010,7 @@ contains
       write(lun, '(2f12.6,a)') x0, y0, ' moveto'
       write(lun, '(a,f5.2,a)') '(Angular extent = ', a, ') show'
 
-    end if
+    endif
 !
 !  Paint the path and output the showpage command and
 !  end-of-file indicator.
@@ -7123,7 +7123,7 @@ contains
       write(*, '(a)') 'TRPRNT - Fatal error!'
       write(*, '(a)') '  N is outside its valid range.'
       return
-    end if
+    endif
 !
 !  Initialize NL (the number of lines printed on the current
 !  page) and NB (the number of boundary nodes encountered).
@@ -7152,9 +7152,9 @@ contains
           nabor(k) = nd
           if (lp == lpl) then
             exit
-          end if
+          endif
 
-        end do
+        enddo
 !
 !  NODE is a boundary node.  Correct the sign of the last
 !  neighbor, add 0 to the end of the list, and increment NB.
@@ -7165,7 +7165,7 @@ contains
           nabor(k) = 0
           nb = nb + 1
 
-        end if
+        endif
 !
 !  Increment NL and print the list of neighbors.
 !
@@ -7177,14 +7177,14 @@ contains
           write(*, '(a)') ' '
           write(*, '(a)') ' '
           nl = inc
-        end if
+        endif
 
         write(*, 104) node, nabor(1:k)
         if (k /= 14) then
           write(*, '(a)') ' '
-        end if
+        endif
 
-      end do
+      enddo
 
     else if (iflag > 0) then
 !
@@ -7207,9 +7207,9 @@ contains
 
           if (lp == lpl) then
             exit
-          end if
+          endif
 
-        end do
+        enddo
 
         if (nd <= 0) then
 !
@@ -7219,7 +7219,7 @@ contains
           k = k + 1
           nabor(k) = 0
           nb = nb + 1
-        end if
+        endif
 !
 !  Increment NL and print X, Y, and NABOR.
 !
@@ -7231,15 +7231,15 @@ contains
           write(*, '(a)') ' '
           write(*, '(a)') ' '
           nl = inc
-        end if
+        endif
 
         write(*, 105) node, x(node), y(node), nabor(1:k)
 
         if (k /= 8) then
           write(*, '(a)') ' '
-        end if
+        endif
 
-      end do
+      enddo
 
     else
 !
@@ -7262,9 +7262,9 @@ contains
 
           if (lp == lpl) then
             exit
-          end if
+          endif
 
-        end do
+        enddo
 !
 !  NODE is a boundary node.
 !
@@ -7273,7 +7273,7 @@ contains
           k = k + 1
           nabor(k) = 0
           nb = nb + 1
-        end if
+        endif
 !
 !  Increment NL and print X, Y, Z, and NABOR.
 !
@@ -7285,17 +7285,17 @@ contains
           write(*, '(a)') ' '
           write(*, '(a)') ' '
           nl = inc
-        end if
+        endif
 
         write(*, 106) node, x(node), y(node), z(node), nabor(1:k)
 
         if (k /= 5) then
           write(*, '(a)') ' '
-        end if
+        endif
 
-      end do
+      enddo
 
-    end if
+    endif
 !
 !  Print NB, NA, and NT (boundary nodes, arcs, and triangles).
 !
@@ -7305,7 +7305,7 @@ contains
     else
       na = 3*nn - 6
       nt = 2*nn - 4
-    end if
+    endif
 
     write(*, '(a)') ' '
     write(*, 109) nb, na, nt
@@ -7393,17 +7393,17 @@ contains
 
         if (lp == lpl) then
           exit
-        end if
+        endif
 
-      end do
+      enddo
 
       if (0 < sides .and. sides < side_max) then
         count(sides) = count(sides) + 1
       else
         count(side_max) = count(side_max) + 1
-      end if
+      endif
 
-    end do
+    enddo
 
     edges = edges/2
 
@@ -7423,12 +7423,12 @@ contains
     do i = 1, side_max - 1
       if (count(i) /= 0) then
         write(*, '(i6,i6)') i, count(i)
-      end if
-    end do
+      endif
+    enddo
 
     if (count(side_max) /= 0) then
       write(*, '(i6,i6)') side_max, count(side_max)
-    end if
+    endif
 
     return
   end subroutine voronoi_poly_count
@@ -7645,12 +7645,12 @@ contains
         n < 3 .or. nt /= 2*n - 4) then
       ier = 1
       return
-    end if
+    endif
 
     if (abs(elat) > 90.0E+00 .or. abs(elon) > 180.0E+00 .or. a > 90.0E+00) then
       ier = 2
       return
-    end if
+    endif
 !
 !  Compute a conversion factor CF for degrees to radians.
 !
@@ -7748,7 +7748,7 @@ contains
     else
       r11 = 0.0E+00
       r12 = 1.0E+00
-    end if
+    endif
 
     r21 = -ez*r12
     r22 = ez*r11
@@ -7811,20 +7811,20 @@ contains
             t = sqrt(x2*x2 + y2*y2)
             x2 = x2/t
             y2 = y2/t
-          end if
+          endif
 
           write(lun, '(2f12.6,a,2f12.6,a)') &
             x1, y1, ' moveto', x2, y2, ' lineto'
 
-        end if
+        endif
 
         if (lp == lpl) then
           exit
-        end if
+        endif
 
-      end do
+      enddo
 
-    end do
+    enddo
 !
 !  Paint the path and restore the saved graphics state (with no clip path).
 !
@@ -7848,7 +7848,7 @@ contains
 
         if (ex*x(n0) + ey*y(n0) + ez*z(n0) < 0.0E+00) then
           cycle
-        end if
+        endif
 
         x0 = r11*x(n0) + r12*y(n0)
         y0 = r21*x(n0) + r22*y(n0) + r23*z(n0)
@@ -7859,11 +7859,11 @@ contains
         if (x0*x0 + y0*y0 <= wrs) then
           write(lun, '(2f12.6,a)') x0, y0, ' moveto'
           write(lun, '(a,i3,a)') '(', n0, ') show'
-        end if
+        endif
 
-      end do
+      enddo
 
-    end if
+    endif
 !
 !  Convert FSIZT from points to world coordinates, and output
 !  the commands to select a font and scale it.
@@ -7893,7 +7893,7 @@ contains
       write(lun, '(2f12.6,a)') x0, y0, ' moveto'
       write(lun, '(a,f5.2,a)') '(Angular extent = ', a, ') show'
 
-    end if
+    endif
 !
 !  Paint the path and output the showpage command and end-of-file indicator.
 !
@@ -7954,17 +7954,17 @@ contains
       Xyz1_D = 0.0
     else
       Xyz1_D = CoordXyzIn_DI(:, i1)
-    end if
+    endif
     if (i2 == 0) then
       Xyz2_D = 0.0
     else
       Xyz2_D = CoordXyzIn_DI(:, i2)
-    end if
+    endif
     if (i3 == 0) then
       Xyz3_D = 0.0
     else
       Xyz3_D = CoordXyzIn_DI(:, i3)
-    end if
+    endif
 
 !  write(*,*) 'Node1 Xyz', Xyz1_D
 !  write(*,*) 'Node2 Xyz', Xyz2_D
@@ -7990,7 +7990,7 @@ contains
       iNode1 = 0
       iNode2 = 0
       iNode3 = 0
-    end if
+    endif
 
   end subroutine find_triangle_sph
 end Module ModTriangulateSpherical

--- a/share/Library/src/ModUtility.f90
+++ b/share/Library/src/ModUtility.f90
@@ -141,7 +141,7 @@ contains
       iPermission = 493 ! which is O'0755'
     else
       iPermission = iPermissionIn
-    end if
+    endif
 
     ! Create the directory.
     ! If NameDir contains one or more /, then create the top directory first
@@ -169,13 +169,13 @@ contains
           write(*, *) NameSub, ' iError, iErrorNumber=', iError, iErrorNumber
           call CON_stop(NameSub// &
                         ' failed to open directory '//trim(NameDir))
-        end if
-      end if
+        endif
+      endif
 
       i = j + 1
       if (i > l) EXIT
 
-    end do
+    enddo
 
     if (present(iErrorOut)) iErrorOut = iError
     if (present(iErrorNumberOut)) iErrorNumberOut = iErrorNumber
@@ -219,7 +219,7 @@ contains
                     //trim(NameDir))
     else
       close(UNITTMP_, status='DELETE')
-    end if
+    endif
 
   end subroutine check_dir
 
@@ -321,28 +321,28 @@ contains
             if (present(NameCaller)) write(*, *) 'NameCaller=', NameCaller
             call CON_stop(NameSub// &
                           ' processor 0 could not open file='//trim(File))
-          end if
+          endif
           ! Make sure all processors wait until proc 0 has opened file
           call MPI_barrier(iComm, iError)
           ! Other processors open with status "old"
           if (iProc > 0) &
             open(iUnit, FILE=File, FORM=TypeForm, STATUS='old', &
                  ACCESS=TypeAccess, RECL=Recl, IOSTAT=iError)
-        end if
+        endif
       else
         open(iUnit, FILE=File, FORM=TypeForm, STATUS=TypeStatus, &
              ACCESS=TypeAccess, RECL=Recl, IOSTAT=iError)
-      end if
+      endif
     else
       open(iUnit, FILE=File, FORM=TypeForm, STATUS=TypeStatus, &
            POSITION=TypePosition, ACCESS=TypeAccess, IOSTAT=iError)
-    end if
+    endif
 
     if (iError /= 0) then
       write(*, *) NameSub, ' iUnit, iError=', iUnit, iError
       if (present(NameCaller)) write(*, *) 'NameCaller=', NameCaller
       call CON_stop(NameSub//' could not open file='//trim(File))
-    end if
+    endif
 
   end subroutine open_file
 
@@ -373,13 +373,13 @@ contains
       close(iUnit, STATUS=Status, IOSTAT=iError)
     else
       close(iUnit, IOSTAT=iError)
-    end if
+    endif
 
     if (iError /= 0) then
       write(*, *) NameSub, ' iUnit, iError=', iUnit, iError
       if (present(NameCaller)) write(*, *) 'NameCaller=', NameCaller
       call CON_stop(NameSub//' could not close unit')
-    end if
+    endif
 
   end subroutine close_file
 
@@ -511,7 +511,7 @@ contains
     else
       StringSep = ' '
       lSep = 1
-    end if
+    endif
 
     UseArraySyntax = .false.
     if (present(UseArraySyntaxIn)) UseArraySyntax = UseArraySyntaxIn
@@ -519,7 +519,7 @@ contains
     lKeep = 0
     if (present(DoAddSeparator)) then
       if (DoAddSeparator) lKeep = lSep
-    end if
+    endif
 
     nString = 0
     StringTmp = String
@@ -533,7 +533,7 @@ contains
 
       if (lKeep > 0) then                         ! Do not keep added separator
         if (i + lKeep >= len_trim(StringTmp)) lKeep = 0
-      end if
+      endif
 
       String_I(nString) = StringTmp(1:i - 1 + lKeep) ! Put part into string array
       StringTmp = StringTmp(i + lSep:l + lSep) ! Delete part+separator from string
@@ -541,7 +541,7 @@ contains
       if (UseArraySyntax) call expand_array(String_I(nString))
 
       if (nString == MaxString) EXIT        ! Check for maximum number of parts
-    end do
+    enddo
 
     if (present(nStringOut)) nStringOut = nString
 
@@ -579,7 +579,7 @@ contains
       else
         iFirst = 1
         l = j
-      end if
+      endif
 
       ! Check for a second colon
       m = index(String1, ':', back=.true.)
@@ -591,7 +591,7 @@ contains
       else
         Di = 1
         m = k
-      end if
+      endif
 
       ! read the last index value between the l and m positions
       read(String1(l + 1:m - 1), *, IOSTAT=iError) iLast
@@ -616,7 +616,7 @@ contains
 
         if (nString == MaxString) RETURN
 
-      end do
+      enddo
     end subroutine expand_array
 
   end subroutine split_string
@@ -673,12 +673,12 @@ contains
     else
       StringSep = ' '
       l = 1
-    end if
+    endif
     String = String_I(1)
 
     do i = 2, nString
       String = trim(String)//StringSep(1:l)//String_I(i)
-    end do
+    enddo
 
   end subroutine join_string
 
@@ -700,7 +700,7 @@ contains
     do i = 1, len_trim(String)
       iC = ichar(String(i:i))
       if (iC >= iA .and. iC <= iZ) String(i:i) = char(iC + Di)
-    end do
+    enddo
 
   end subroutine upper_case
 
@@ -722,7 +722,7 @@ contains
     do i = 1, len_trim(String)
       iC = ichar(String(i:i))
       if (iC >= iA .and. iC <= iZ) String(i:i) = char(iC + Di)
-    end do
+    enddo
 
   end subroutine lower_case
 
@@ -747,7 +747,7 @@ contains
     n = len_trim(String)
     do i = 1, n
       String_I(i) = String(i:i)
-    end do
+    enddo
     String_I(n + 1) = c_null_char
 
   end subroutine string_to_char_array
@@ -772,7 +772,7 @@ contains
     do i = 1, len(String)
       if (String_I(i) == c_null_char) EXIT
       String(i:i) = String_I(i)
-    end do
+    enddo
 
   end subroutine char_array_to_string
 
@@ -796,7 +796,7 @@ contains
     tCpu0 = MPI_WTIME()
     do
       if (MPI_WTIME() > tCpu0 + DtCpu) RETURN
-    end do
+    enddo
     !EOC
   end subroutine sleep
 
@@ -827,7 +827,7 @@ contains
       kGCD = i
     else
       kGCD = greatest_common_divisor(j, mod(i, j))
-    end if
+    endif
 
   end function greatest_common_divisor
   !============================================================================
@@ -907,25 +907,25 @@ contains
     write(*, '(a,i3,a)') 'with space separator split to', nString, ' parts:'
     do iString = 1, nString
       write(*, '(a)') trim(String_I(iString))
-    end do
+    enddo
 
     call split_string(String, String_I, nString, ",")
     write(*, '(a,i3,a)') 'with "," separator split to', nString, ' parts:'
     do iString = 1, nString
       write(*, '(a)') trim(String_I(iString))
-    end do
+    enddo
 
     call split_string(String, String_I, nString, ") ", DoAddSeparator=.true.)
     write(*, '(a,i3,a)') 'with ") " separator split to', nString, ' parts:'
     do iString = 1, nString
       write(*, '(a)') trim(String_I(iString))
-    end do
+    enddo
 
     call split_string(String, String_I, nString, UseArraySyntaxIn=.true.)
     write(*, '(a,i3,a)') 'with UseArraySyntax split to', nString, ' parts:'
     do iString = 1, nString
       write(*, '(a)') trim(String_I(iString))
-    end do
+    enddo
 
     write(*, '(/,a)') 'testing join_string'
     call join_string(nString, String_I, String)

--- a/share/Library/src/PostIDL.f90
+++ b/share/Library/src/PostIDL.f90
@@ -139,7 +139,7 @@ program post_idl
   READPARAM: do
     if (.not. read_line(StringLine)) then
       EXIT READPARAM
-    end if
+    endif
 
     if (.not. read_command(NameCommand)) CYCLE READPARAM
 
@@ -162,8 +162,8 @@ program post_idl
           write(*, *) '!!! Warning: PostIDL was compiled with ', &
             nByteReal, ' byte reals but file contains nByteReal=', &
             nByteRealRead
-        end if
-      end if
+        endif
+      endif
 
       ! Get rid of the directory part
       NameFileHead = NameFileHead( &
@@ -183,19 +183,19 @@ program post_idl
       do i = 1, nDimSim
         call read_var('CoordMin', CoordMin_D(i))
         call read_var('CoordMax', CoordMax_D(i))
-      end do
+      enddo
 
     case ('#PLOTRESOLUTION')
       CellSizePlot_D = 1
       do i = 1, nDimSim
         call read_var('CellSizePlot', CellSizePlot_D(i))
-      end do
+      enddo
 
     case ('#CELLSIZE')
       dCoordMin_D = 1
       do i = 1, nDimSim
         call read_var('CellSizeMin', dCoordMin_D(i))
-      end do
+      enddo
 
     case ('#NCELL')
       call read_var('nCellPlot', nCellPlot)
@@ -210,7 +210,7 @@ program post_idl
       allocate(PlotParam_I(nParamPlot))
       do i = 1, nParamPlot
         call read_var('Param', PlotParam_I(i))
-      end do
+      enddo
 
     case ('#GRIDGEOMETRYLIMIT')
       call read_var('TypeGeometry', TypeGeometry)
@@ -221,19 +221,19 @@ program post_idl
         allocate(LogRgen_I(nRgen))
         do i = 1, nRgen
           call read_var('LogRgen', LogRgen_I(i))
-        end do
-      end if
+        enddo
+      endif
 
       if (TypeGeometry == 'roundcube') then
         call read_var('rRound0', rRound0)
         call read_var('rRound1', rRound1)
         call read_var('SqrtNDim', SqrtNDim)
-      end if
+      endif
 
     case ('#PERIODIC')
       do i = 1, nDimSim
         call read_var('IsPeriodic', IsPeriodic_D(i))
-      end do
+      enddo
 
     case ('#OUTPUTFORMAT')
       call read_var('TypeOutPutFormat', TypeFile)
@@ -251,7 +251,7 @@ program post_idl
       write(*, *) 'WARNING: unknown command ', NameCommand
     end select
 
-  end do READPARAM
+  enddo READPARAM
 
   if (NameFileHead(1:3) == 'sph') then
     NameCoord_D = (/'r    ', 'theta', 'phi  '/)
@@ -268,7 +268,7 @@ program post_idl
     case ('round')
       NameCoord_D = (/'xi   ', 'eta  ', 'zeta '/)
     end select
-  end if
+  endif
 
   ! Save input CellSizePlot_D into dCoordPlot_D that may get overwritten
   dCoordPlot_D = CellSizePlot_D
@@ -301,8 +301,8 @@ program post_idl
       nParamExtra = nParamExtra + 1
       ParamExtra_I(nParamExtra) = 0.5*(CoordMax_D(iDim) + CoordMin_D(iDim))
       NameVar = trim(NameVar)//' cut'//trim(NameCoord_D(iDim))
-    end if
-  end do
+    endif
+  enddo
 
   if (IsVerbose) then
     write(*, *) 'dCoordPlot_D=', dCoordPlot_D
@@ -310,7 +310,7 @@ program post_idl
     write(*, *) 'NameCoord_D =', NameCoord_D
     write(*, *) 'nDim        =', nDim
     write(*, *) 'iDimCut_D   =', iDimCut_D
-  end if
+  endif
 
   if (nDim == 2 .and. NameFileHead(1:3) /= 'cut') then
     ! For double cut
@@ -330,28 +330,28 @@ program post_idl
         ! Use rMin < r' < 2*rMax - rMin as generalized coordinate
         UseDoubleCut = .true.; 
         ! nCell_D(1) = 2*nCell_D(1)
-      end if
+      endif
 
       ! Do not attempt to use structured grid for double cuts
       if (UseDoubleCut) then
         IsStructured = .false.
         CellSizePlot_D = -1.0
-      end if
-    end if
+      endif
+    endif
 
     if (IsVerbose) then
       write(*, *) 'iDim1, iDim2, iDim0=', iDim1, iDim2, iDim0
       write(*, *) 'CoordShift1, Shift2=', CoordShift1, CoordShift2
       write(*, *) 'UseDoubleCut       =', UseDoubleCut
-    end if
+    endif
 
-  end if
+  endif
 
   ! For unstructured grid make the Coord_DC and PlotVar_VC arrays linear
   if (.not. IsStructured) then
     nCell_D(1) = nCellPlot
     nCell_D(2:3) = 1
-  end if
+  endif
 
   ! Set scalars for plot size
   n1 = nCell_D(1); n2 = nCell_D(2); n3 = nCell_D(3)
@@ -367,7 +367,7 @@ program post_idl
   if (.not. IsStructured) then
     allocate(GenCoord_DI(nDim, nCellPlot), STAT=iError)
     if (iError /= 0) stop 'PostIDL.exe ERROR: could not allocate enCoord_DI'
-  end if
+  endif
 
   if (DoReadBinary .and. nByteRealRead == 4) allocate(PlotVar4_V(nPlotVar))
   if (DoReadBinary .and. nByteRealRead == 8) allocate(PlotVar8_V(nPlotVar))
@@ -411,11 +411,11 @@ program post_idl
           NameCoord = trim(NameCoord)//' [deg]'
         end select
         NameCoord = trim(NameCoord)//'", "'
-      end do
+      enddo
 
       NameUnit = NameCoord(1:len_trim(NameCoord) - 2)//NameUnit(l4:len(NameUnit))
-    end if
-  end if
+    endif
+  endif
 
   ! Logic for Tecplot conversion
   if (DoReadTecplot) then
@@ -435,18 +435,18 @@ program post_idl
     ! Read Tecplot file header
     do iHeaderTec = 1, nHeaderTec
       read(UnitTmp_, *) StringTecHeader
-    end do
+    enddo
     ! Read the coordinates and variables at the nodes
     do iNodeTec = 1, nNodeTec
       read(UnitTmp_, *) XyzTec_DI(:, iNodeTec), PlotVarTec_VI(:, iNodeTec)
-    end do
+    enddo
     ! Read the node indexes of the nodes surrounding each cell center
     do iCellTec = 1, nCellTec
       read(UnitTmp_, *) iNodeTec_II(:, iCellTec)
-    end do
+    enddo
 
     close(UnitTmp_)
-  end if
+  endif
 
   ! Collect info from all files and put it into PlotVar_VC and Coord_DC
   VolumeCheck = 0.0
@@ -461,7 +461,7 @@ program post_idl
         write(NameFile, '(a,i5.5,a)') NameFileHead(1:l - 2)//"_pe", iProc, '.idl'
       else
         write(NameFile, '(a,i4.4,a)') NameFileHead(1:l - 2)//"_pe", iProc, '.idl'
-      end if
+      endif
 
       if (iProc == 0) write(*, *) 'reading files=', trim(NameFile), &
         '...', nProc - 1, '.idl'
@@ -471,11 +471,11 @@ program post_idl
              iostat=iError)
       else
         open(UnitTmp_, file=NameFile, status='old', iostat=iError)
-      end if
+      endif
 
       ! Assume that missing files were empty.
       if (iError /= 0) CYCLE
-    end if
+    endif
 
     ! Read file
     do
@@ -496,7 +496,7 @@ program post_idl
           xMaxTec = max(xMaxTec, XyzTec_DI(1, iNodeTec))
           Xyz_D = Xyz_D + XyzTec_DI(:, iNodeTec)
           PlotVar_V = PlotVar_V + PlotVarTec_VI(:, iNodeTec)
-        end do
+        enddo
         CellSize1 = xMaxTec - xMinTec
         Xyz_D = Xyz_D/8.
         PlotVar_V = PlotVar_V/8.
@@ -507,10 +507,10 @@ program post_idl
         else
           read(UnitTmp_, ERR=999, END=999) DxCell8, Xyz8_D, PlotVar8_V
           CellSize1 = DxCell8; Xyz_D = Xyz8_D; PlotVar_V = PlotVar8_V
-        end if
+        endif
       else
         read(UnitTmp_, *, ERR=999, END=999) CellSize1, Xyz_D, PlotVar_V
-      end if
+      endif
 
       nCellCheck = nCellCheck + 1
 
@@ -531,12 +531,12 @@ program post_idl
         do iDim = 1, nDim
           Coord_DC(iDim, iCell, 1, 1) = Xyz_D(iDimCut_D(iDim))
           GenCoord_DI(iDim, iCell) = GenCoord_D(iDimCut_D(iDim))
-        end do
+        enddo
 
         ! We are finished with unstructured
         CYCLE
 
-      end if
+      endif
 
       if (CellSize1 < dCoord1Plot + 1.e-6) then
         ! Cell has the correct size or finer
@@ -548,13 +548,13 @@ program post_idl
           Fraction = (CellSize1/dCoord1Plot)**nDim
         else
           Fraction = 1.0
-        end if
+        endif
 
         PlotVar_VC(:, i, j, k) = PlotVar_VC(:, i, j, k) + Fraction*PlotVar_V
         do iDim = 1, nDim
           Coord_DC(iDim, i, j, k) = Coord_DC(iDim, i, j, k) &
                                     + Fraction*Xyz_D(iDimCut_D(iDim))
-        end do
+        enddo
         VolumeCheck = VolumeCheck + Fraction
       else
         ! Cell is coarser than required resolution
@@ -571,12 +571,12 @@ program post_idl
           PlotVar_VC(iVar, iMin:iMax, jMin:jMax, kMin:kMax) = &
             PlotVar_VC(iVar, iMin:iMax, jMin:jMax, kMin:kMax) &
             + PlotVar_V(iVar)
-        end do
+        enddo
         do iDim = 1, nDim
           Coord_DC(iDim, iMin:iMax, jMin:jMax, kMin:kMax) = &
             Coord_DC(iDim, iMin:iMax, jMin:jMax, kMin:kMax) &
             + Xyz_D(iDimCut_D(iDim))
-        end do
+        enddo
 
         if (iMax < iMin .or. jMax < jMin .or. kMax < kMin) &
           write(*, *) '!!! Empty box for cell CellSize_D(1), GenCoord_D=', &
@@ -584,13 +584,13 @@ program post_idl
 
         VolumeCheck = VolumeCheck &
                       + (iMax - iMin + 1)*(jMax - jMin + 1)*(kMax - kMin + 1)
-      end if
-    end do ! read file
+      endif
+    enddo ! read file
 
 999 continue
 
     if (.not. DoReadTecplot) close(UnitTmp_)
-  end do ! iProc
+  enddo ! iProc
 
   if (IsVerbose) write(*, *) 'nCellCheck=', nCellCheck, &
     ' nCellPlot=', nCellPlot
@@ -612,14 +612,14 @@ program post_idl
     elseif (abs(VolumeCheck/VolumePlot - 1.0) > 0.0001) then
       write(*, *) '!!! Discrepancy in structured file:', &
         'filled VolumeCheck=', VolumeCheck, ' VolumePlot=', VolumePlot, ' !!!'
-    end if
+    endif
   else
     if (iCell /= nCellPlot) &
       write(*, *) '!!! Error: nCellPlot=', nCellPlot, ' /= iCell=', iCell, ' !!!'
 
     n1 = iCell
     nCell_D(1) = iCell
-  end if
+  endif
 
   if (NameFileHead(1:3) == 'cut') then
 
@@ -634,36 +634,36 @@ program post_idl
           do k = 1, n3; do j = 1, n2; do i = 1, n1
               Coord_DC(iDim, i, j, k) = exp(linear(LogRgen_I, 0, nRgen - 1, &
                                                    Coord_DC(iDim, i, j, k)*(nRgen - 1), DoExtrapolate=.true.))
-            end do; end do; end do
-        end if
+            enddo; enddo; enddo
+        endif
 
       case ('phi', 'theta', 'lat')
         Coord_DC(iDim, 1:n1, :, :) = Coord_DC(iDim, 1:n1, :, :)*cRadToDeg
       end select
-    end do
+    enddo
 
-  end if
+  endif
 
   if (TypeFile == 'tec') then
     NameFile = NameFileHead(1:l - 2)//'.dat'
   else
     NameFile = NameFileHead(1:l - 2)//'.out'
-  end if
+  endif
   write(*, *) 'writing file =', trim(NameFile)
 
   ! Param_I is the combination of eqpar and ParamExtra_I
   allocate(Param_I(nParamPlot + nParamExtra))
   do i = 1, nParamPlot
     Param_I(i) = PlotParam_I(i)
-  end do
+  enddo
   do i = 1, nParamExtra
     Param_I(i + nParamPlot) = ParamExtra_I(i)
-  end do
+  enddo
 
   if (IsVerbose) then
     write(*, *) 'nParamPlot, nParamExtra=', nParamPlot, nParamExtra
     write(*, *) ' Param_I=', Param_I
-  end if
+  endif
 
   if (.not. IsStructured .and. (nDim < 3 .or. DoSort3D)) then
     if (IsVerbose) write(*, *) 'Sorting unstructured grid points'
@@ -704,16 +704,16 @@ program post_idl
           nSum = nSum + 1
           j = j + 1
           if (j > n1) EXIT
-        end do
+        enddo
         if (j > i + 1) then
           ! Put average value into i-th element
           PlotVar_VC(:, i, 1, 1) = StateSum_V/nSum
-        end if
+        endif
         ! Save the index for the unique coordinates
         iSort_I(k) = i
         k = k + 1
         i = j
-      end do
+      enddo
       deallocate(StateSum_V, CellSizeMin_D, GenCoord_DI)
 
       ! Special judgement for the last point
@@ -722,26 +722,26 @@ program post_idl
         n1 = k
       else
         n1 = k - 1
-      end if
+      endif
 
       ! move the elements after finding out all the coinciding ones
       Coord_DC(:, 1:n1, 1, 1) = Coord_DC(:, iSort_I(1:n1), 1, 1)
       PlotVar_VC(:, 1:n1, 1, 1) = PlotVar_VC(:, iSort_I(1:n1), 1, 1)
 
       if (IsVerbose) write(*, *) 'Averaging done'
-    end if
+    endif
 
     deallocate(Sort_I, iSort_I)
 
     if (IsVerbose) then
       write(*, *) 'After sorting and averaging n1=', n1
-    end if
-  end if
+    endif
+  endif
 
   if (IsVerbose) then
     write(*, *) 'shape(Coord_DC)  =', shape(Coord_DC)
     write(*, *) 'shape(PlotVar_VC)=', shape(PlotVar_VC)
-  end if
+  endif
 
   ! the sizes of Coord_DC and PlotVar_VC may be modified by cell averaging
   ! in unstructured grids. Only the first dimension (1:n1) needs to be set
@@ -794,7 +794,7 @@ contains
       GenCoord_D = Xyz_D
 
       RETURN
-    end if
+    endif
 
     if (TypeGeometry == 'roundcube') then
 
@@ -816,7 +816,7 @@ contains
           else
             ! No distortion
             GenCoord_D = Xyz_D
-          end if
+          endif
 
         else
           ! The rounded (distorted) grid is inside of the non-distorted part
@@ -830,14 +830,14 @@ contains
             Coef2 = -(1 - Dist1/Dist2)/(rRound0 - rRound1)*Dist1
             Coef2 = (-Coef1 + sqrt(Coef1**2 - 4*Coef2))*0.5
             GenCoord_D = Xyz_D/Coef2
-          end if
-        end if
+          endif
+        endif
 
       else
         GenCoord_D = 0.0
-      end if
+      endif
       RETURN
-    end if
+    endif
 
     if (TypeGeometry(1:7) == 'rotated') then
 
@@ -880,12 +880,12 @@ contains
 
           nVector = nVector + 1
           iVarVector_I(nVector) = iVar
-        end do
+        enddo
         deallocate(NameVar_V)
 
         !write(*,*)'nVector, iVarVector_I=', nVector, iVarVector_I(1:nVector)
 
-      end if
+      endif
 
       ! Unrotate the coordinates for comparison with Cartesian runs
       Xyz_D = matmul(Xyz_D, GridRot_DD)
@@ -895,10 +895,10 @@ contains
       do iVector = 1, nVector
         iVar = iVarVector_I(iVector)
         PlotVar_V(iVar:iVar + 2) = matmul(PlotVar_V(iVar:iVar + 2), GridRot_DD)
-      end do
+      enddo
 
       RETURN
-    end if
+    endif
 
     rCyl = sqrt(Xyz_D(1)**2 + Xyz_D(2)**2)
 
@@ -909,7 +909,7 @@ contains
       GenCoord_D(2) = &
         modulo(atan2(Xyz_D(2), Xyz_D(1)) - CoordMin_D(2), cTwoPi) &
         + CoordMin_D(2)
-    end if
+    endif
 
     select case (TypeGeometry)
     case ('cylindrical', 'cylindrical_lnr', 'cylindrical_genr')
@@ -931,7 +931,7 @@ contains
           if (UseDoubleCut .and. Xyz_D(1) < 0.0) &
             GenCoord_D(1) = GenCoord_D(1) + CoordShift1
         end select
-      end if
+      endif
     case ('spherical', 'spherical_lnr', 'spherical_genr')
       GenCoord_D(1) = sqrt(rCyl**2 + Xyz_D(3)**2)
 
@@ -950,7 +950,7 @@ contains
           ! projecting the points down to the X-Y plane
           Xyz_D(1:2) = Xyz_D(1:2)*GenCoord_D(1)/rCyl
         end select
-      end if
+      endif
       ! Latitude
       GenCoord_D(3) = asin(Xyz_D(3)/GenCoord_D(1))
       ! Shift by width of latitude range for the left half
@@ -970,7 +970,7 @@ contains
                        + (GenCoord_D(1) - LogRgen_I(i)) &
                        /(LogRgen_I(i + 1) - LogRgen_I(i))) &
                       /(nRgen - 1)
-    end if
+    endif
 
   end subroutine set_gen_coord
 

--- a/share/Library/test/test_interpolate_amr.f90
+++ b/share/Library/test/test_interpolate_amr.f90
@@ -75,9 +75,9 @@ contains
             Xyz_DCB(:, i, j, k, iBlock) = XyzCorner_D + &
                                           DxyzCoarse_D*(iCellIndex_D(1:nDim) - 0.50)
             Var_CB(i, j, k, iBlock) = random_real(iSeed)
-          end do
-        end do
-      end do
+          enddo
+        enddo
+      enddo
       do iSubGrid = 1, 2**nDim
         iBlock = iGrid*(2**nDim) + iSubGrid
         XyzCorner_D = DxyzCoarseBlock_D*iShift_DI(1:nDim, iGrid) + &
@@ -89,11 +89,11 @@ contains
               Xyz_DCB(:, i, j, k, iBlock) = XyzCorner_D + &
                                             DxyzFine_D*(iCellIndex_D(1:nDim) - 0.50)
               Var_CB(i, j, k, iBlock) = 0.25 + 0.50*random_real(iSeed)
-            end do
-          end do
-        end do
-      end do
-    end do
+            enddo
+          enddo
+        enddo
+      enddo
+    enddo
 
     nIndexes = nDim + 1
     CASE: do iCase = 0, 2**(2**nDim) - 2
@@ -103,7 +103,7 @@ contains
         iGrid = iGrid + 1
         iLevelTest_I(iGrid) = mod(iMisc, 2)
         iMisc = (iMisc - iLevelTest_I(iGrid))/2
-      end do
+      enddo
       !write(*,*)'Case=',iLevelTest_I(1:2**nDim)
       !\
       ! We generated refinement, now sample points
@@ -111,7 +111,7 @@ contains
       SAMPLE: do iSample = 1, nSample
         do iDir = 1, nDim
           Xyz_D(iDir) = (0.01 + 0.98*random_real(iSeed))*DxyzDomain_D(iDir)
-        end do
+        enddo
         !\
         ! call interpolate_amr
         !/
@@ -141,7 +141,7 @@ contains
                             Weight_I(iGrid)* &
                             Var_CB(iCellIndex_D(1), iCellIndex_D(2), &
                                    iCellIndex_D(3), iBlock)
-        end do
+        enddo
         if (any(abs(Xyz_D - XyzInterpolated_D) > 1.0e-6) .and. &
             IsSecondOrder) then
           write(*, *) 'Approximation test failed'
@@ -156,17 +156,17 @@ contains
             write(*, *) iIndexes_II(1:nDim, iGrid), iBlock, &
               Xyz_DCB(:, iCellIndex_D(1), iCellIndex_D(2), &
                       iCellIndex_D(3), iBlock), Weight_I(iGrid)
-          end do
+          enddo
           write(*, *) 'Xyz_D=', Xyz_D
           write(*, *) 'XyzInterpolated_D=', XyzInterpolated_D
           call CON_stop('Correct code and redo test')
-        end if
+        endif
         !\
         ! Test continuity
         !/
         do iDir = 1, nDim
           XyzCont_D(iDir) = Xyz_D(iDir) + (0.02*random_real(iSeed) - 0.01)
-        end do
+        enddo
         !\
         ! call interpolate_amr
         !/
@@ -196,7 +196,7 @@ contains
           XyzInterpolated_D = XyzInterpolated_D + Weight_I(iGrid)* &
                               Xyz_DCB(:, iCellIndex_D(1), iCellIndex_D(2), &
                                       iCellIndex_D(3), iBlock)
-        end do
+        enddo
         if (any(abs(XyzCont_D - XyzInterpolated_D) > 1.0e-6) .and. &
             IsSecondOrder) then
           write(*, *) 'Approximation test failed'
@@ -211,11 +211,11 @@ contains
             write(*, *) iIndexes_II(1:nDim, iGrid), iBlock, &
               Xyz_DCB(:, iCellIndex_D(1), iCellIndex_D(2), &
                       iCellIndex_D(3), iBlock), Weight_I(iGrid)
-          end do
+          enddo
           write(*, *) 'XyzCont_D=', XyzCont_D
           write(*, *) 'XyzInterpolated_D=', XyzInterpolated_D
           call CON_stop('Correct code and redo test')
-        end if
+        endif
         if (abs(VarContInterpolated - VarInterpolated) > nDim*0.01) then
           write(*, *) 'Continuity test failed'
           write(*, *) 'Grid:', iLevelTest_I
@@ -229,7 +229,7 @@ contains
             write(*, *) iIndexes_II(1:nDim, iGrid), iBlock, &
               Xyz_DCB(:, iCellIndex_D(1), iCellIndex_D(2), &
                       iCellIndex_D(3), iBlock), Weight_I(iGrid)
-          end do
+          enddo
           write(*, *) 'Xyz_D=', Xyz_D
           call interpolate_amr( &
             nDim=nDim, &
@@ -249,11 +249,11 @@ contains
             write(*, *) iIndexes_II(1:nDim, iGrid), iBlock, &
               Xyz_DCB(:, iCellIndex_D(1), iCellIndex_D(2), &
                       iCellIndex_D(3), iBlock), Weight_I(iGrid)
-          end do
+          enddo
           call CON_stop('Correct code and redo test')
-        end if
-      end do SAMPLE
-    end do CASE
+        endif
+      enddo SAMPLE
+    enddo CASE
     deallocate(Xyz_DCB, Var_CB)
 
   end subroutine test_interpolate_amr
@@ -309,7 +309,7 @@ contains
       iBlock = iGrid
       Dxyz_D = DxyzCoarse_D
       RETURN
-    end if
+    endif
     !\
     ! The coarser block is refined, find into which fine block
     ! the point falls

--- a/share/Library/test/test_process_var_name.f90
+++ b/share/Library/test/test_process_var_name.f90
@@ -29,7 +29,7 @@ program process_var_name_test
   do iVar = 1, nVar
     NameVarFixed_V(iVar) = NameVar_V(iVar)
     call lower_case(NameVarFixed_V(iVar))
-  end do
+  enddo
 
   call process_var_name(nVar, NameVarFixed_V, &
                         nDensity, nSpeed, nP, nPpar, nWaveName, nMaterialName)
@@ -38,7 +38,7 @@ program process_var_name_test
   write(*, *) '--------  ------------'
   do iVar = 1, nVar
     write(*, *) NameVar_V(iVar), '         ', trim(NameVarFixed_V(iVar))
-  end do
+  enddo
 
   deallocate(NameVarFixed_V)
 
@@ -60,16 +60,16 @@ contains
         write(NameWave, '(a,i2.2)') 'i', iWave
         NameVar_V(iVar) = NameWave
         iWave = iWave + 1
-      end if
+      endif
 
       ! Fix the NameVar_V string for material levels
       if (index(NameVar_V(iVar), 'M?') >= 1) then
         write(NameMaterial, '(a,i1.1)') 'm', iMaterial
         NameVar_V(iVar) = NameMaterial
         iMaterial = iMaterial + 1
-      end if
+      endif
 
-    end do
+    enddo
 
   end subroutine set_namevar
 

--- a/src/Earth.f90
+++ b/src/Earth.f90
@@ -34,13 +34,13 @@ subroutine fill_photo
   if (nSpecies > 3) then
     iSpecies = iN_4S_
     photoabs(:, min(iSpecies, nSpecies)) = PhotoIon_N
-  end if
+  endif
 
   ! JMB:  06/25/2016
   if (nSpecies > 5) then
     iSpecies = iHe_
     photoabs(:, min(iSpecies, nSpecies)) = PhotoAbs_He
-  end if
+  endif
 
   ! This may need to be as defined below....
   photoion(:, iN2P_) = PhotoIon_N2
@@ -98,12 +98,12 @@ subroutine fill_photo
     if (waves(iWave) >= 1250.0 .and. wavel(iWave) <= 1750.0) then
       PhotoDis(iWave, iO2_) = &
         photoabs(iWave, iO2_) - PhotoIon(iWave, iO2P_)
-    end if
+    endif
     if (waves(iWave) >= 800.0 .and. wavel(iWave) <= 1250.0) then
       PhotoDis(iWave, iN2_) = &
         photoabs(iWave, iN2_) - PhotoIon(iWave, iN2P_)
-    end if
-  end do
+    endif
+  enddo
 
   ! Night time ionization:
 
@@ -180,14 +180,14 @@ subroutine calc_planet_sources(iBlock)
       CO2Cooling2d = CO2Cooling2d + &
                      CO2Cooling(1:nLons, 1:nLats, iAlt)* &
                      dAlt_GB(1:nLons, 1:nLats, iAlt, iBlock)
-    end do
+    enddo
 
     CO2Cooling = CO2Cooling/TempUnit(1:nLons, 1:nLats, 1:nAlts)/ &
                  (Rho(1:nLons, 1:nLats, 1:nAlts, iBlock)*cp(:, :, 1:nAlts, iBlock))
 
   else
     CO2Cooling = 0.0
-  end if
+  endif
 
   if (UseNOCooling) then
 
@@ -217,7 +217,7 @@ subroutine calc_planet_sources(iBlock)
       NOCooling2d = NOCooling2d + &
                     NOCooling(1:nLons, 1:nLats, iAlt)* &
                     dAlt_GB(1:nLons, 1:nLats, iAlt, iBlock)
-    end do
+    enddo
 
     NOCooling = NOCooling/TempUnit(1:nLons, 1:nLats, 1:nAlts)/ &
                 (Rho(1:nLons, 1:nLats, 1:nAlts, iBlock)*cp(:, :, 1:nAlts, iBlock))
@@ -226,7 +226,7 @@ subroutine calc_planet_sources(iBlock)
 
     NOCooling = 0.0
 
-  end if
+  endif
 
   if (UseBarriers) call MPI_BARRIER(iCommGITM, iError)
   if (iDebugLevel > 4) write(*, *) "=====> UseOCooling", iproc, UseOCooling
@@ -259,7 +259,7 @@ subroutine calc_planet_sources(iBlock)
       OCooling2d = OCooling2d + &
                    OCooling(1:nLons, 1:nLats, iAlt)* &
                    dAlt_GB(1:nLons, 1:nLats, iAlt, iBlock)
-    end do
+    enddo
 
     ! In our special units:
     OCooling = OCooling/TempUnit(1:nLons, 1:nLats, 1:nAlts)/ &
@@ -269,7 +269,7 @@ subroutine calc_planet_sources(iBlock)
 
     OCooling = 0.0
 
-  end if
+  endif
 
 !  do iAlt = 1,15
 !     write(*,*) 'no, co2 : ',iAlt, Altitude_GB(1,1,iAlt,iBlock)/1e3, &
@@ -296,7 +296,7 @@ subroutine calc_planet_sources(iBlock)
       PhotoElectronHeating2d(1:nLons, 1:nLats) + &
       PhotoElectronHeating(:, :, iAlt, iBlock)* &
       dAlt_GB(1:nLons, 1:nLats, iAlt, iBlock)
-  end do
+  enddo
 
   PhotoElectronHeating(:, :, :, iBlock) = &
     PhotoElectronHeating(:, :, :, iBlock)/ &
@@ -323,15 +323,15 @@ subroutine calc_planet_sources(iBlock)
 
             call get_glow(iLon, iLat, iBlock)
 
-          end do
-        end do
+          enddo
+        enddo
 
         call end_timing("glow")
 
-      end if
-    end if
+      endif
+    endif
     PhotoElectronDensity(:, :, :, :, iBlock) = PhotoElectronRate(:, :, :, :, iBlock)*dt
-  end if
+  endif
 
 end subroutine calc_planet_sources
 
@@ -402,10 +402,10 @@ subroutine calc_eddy_diffusion_coefficient(iBlock)
                                                           EddyDiffusionPressure1)/ &
                                                          (EddyDiffusionPressure0 - EddyDiffusionPressure1)
 
-        end if
-      end do
-    end do
-  end do
+        endif
+      enddo
+    enddo
+  enddo
 
 end subroutine calc_eddy_diffusion_coefficient
 

--- a/src/Jupiter.f90
+++ b/src/Jupiter.f90
@@ -212,7 +212,7 @@ subroutine calc_radcooling(iBlock)
   !
   do i = 1, np
     pnb(i) = 1.0e-4*exp(pnbr(i)) ! p into Pa
-  end do
+  enddo
 
   ! ****  Initialize to zero
   cooltot(1:nLons, 1:nLats, 1:nAlts) = 0.0
@@ -231,7 +231,7 @@ subroutine calc_radcooling(iBlock)
         co2(iAlt) = vmrco2(iLon, iLat, iAlt)
         o3p(iAlt) = vmro(iLon, iLat, iAlt)
         n2co(iAlt) = vmrn2co(iLon, iLat, iAlt)
-      end do
+      enddo
 
       !        interpolate escape functions (only) to nlayer grid
       call interp1(escf2, player, nlayer, ef2, pnb, np)
@@ -263,7 +263,7 @@ subroutine calc_radcooling(iBlock)
           if (tlayer(i) .le. 175.0) then
             k19xca = 3.3e-15
             k19xcb = 7.6e-16
-          end if
+          endif
           k19xca = k19xca*rfvt
           k19xcb = k19xcb*rfvt
           k19cap1 = k19xca*2.0*exp(-ee*nu1/tlayer(i))
@@ -311,11 +311,11 @@ subroutine calc_radcooling(iBlock)
           !        Cooling Rate (K/sec units)
           cooltot(iLon, iLat, i) = 0.1*hr(i)*tlayer(i)/(4.4*player(i))
 
-        end if
-      end do  !-------- END OF MAIN ALTITUDE LOOP
+        endif
+      enddo  !-------- END OF MAIN ALTITUDE LOOP
 
-    end do  !-------- END OF MAIN LONGITUDE LOOP
-  end do  !-------- END OF MAIN LATITUDE LOOP
+    enddo  !-------- END OF MAIN LONGITUDE LOOP
+  enddo  !-------- END OF MAIN LATITUDE LOOP
 
   !-------------------------------------------------------------
 
@@ -358,12 +358,12 @@ subroutine interp1(escout, p, nlayer, escin, pin, nl)
           np = n + 1
           wm = abs(pin(np) - p(n1))/(pin(nm) - pin(np))
           wp = 1.0 - wm
-        end if
-      end do
+        endif
+      enddo
       !write(*,*) 'nm =',nm
       escout(n1) = escin(nm)*wm + escin(np)*wp
-    end if
-  end do
+    endif
+  enddo
 
 end subroutine interp1
 

--- a/src/Mars.f90
+++ b/src/Mars.f90
@@ -197,7 +197,7 @@ subroutine calc_planet_sources(iBlock)
 
     OCooling = 0.0
 
-  end if
+  endif
 
   RadCooling(1:nLons, 1:nLats, 1:nAlts, iBlock) = &
     RadCooling(1:nLons, 1:nLats, 1:nAlts, iBlock) + OCooling
@@ -221,7 +221,7 @@ subroutine calc_planet_sources(iBlock)
 
   do NW = 1, L_NSPECTV
     SOL(nw) = SOLARF(NW)/(SunPlanetDistance**2)
-  end do
+  enddo
 
   !##############################################################
   ! MAIN LOOP, for MarsGITM horizontal grid (Latitude,Longitude)
@@ -249,14 +249,14 @@ subroutine calc_planet_sources(iBlock)
     do i = 1, 7
       pbs = pbs + Ls_a(i)*dcos(pi/180.0*(0.985626*deltat/ &
                                          Ls_tau(i) + Ls_phi(i)))
-    end do
+    enddo
     ell_s = ell_s + pbs
 
     if (ell_s > 0.0) then
       ell_s = 360.0*(ell_s/360.0 - floor(ell_s/360.0))
     else
       ell_s = 360.0 + 360.0*(ell_s/360.0 - ceiling(ell_s/360.0))
-    end if
+    endif
 
 !              print*, ell_s
 
@@ -279,12 +279,12 @@ subroutine calc_planet_sources(iBlock)
           Temperature(iLon, iLat, -1, iBlock) = SurfaceTemp(iLon, iLat, iBlock)/ &
                                                 TempUnit(iLon, iLat, -1)
 
-        end if
+        endif
 
         ! Determining the top of the lower atmosphere radiative zone
         do iAlt = 1, nAlts
           if (pressure(iLon, iLat, iAlt, iBlock)*0.01 .gt. prad) L_LAYERS = iAlt
-        end do
+        enddo
 
         !        L_LAYERS = 20
 
@@ -296,14 +296,14 @@ subroutine calc_planet_sources(iBlock)
         call calc_lowatmosrad(iblock, iLat, iLon, L_LAYERS, L_LEVELS, &
                               L_NLAYRAD, L_NLEVRAD)
 
-      end do !Latitude Loop
-    end do    !Longitude Loop
+      enddo !Latitude Loop
+    enddo    !Longitude Loop
 
 !!$     xLowAtmosRadRate(1:nLons,1:nLats,1:nAlts,iBlock) = &
 !!$          xLowAtmosRadRate(1:nLons,1:nLats,1:nAlts,iBlock)/&
 !!$          (TempUnit(1:nLons,1:nLats,1:nAlts))
 
-  end if
+  endif
 
   !################# END MAIN COMPUTATIONAL LOOP#################
 
@@ -340,8 +340,8 @@ subroutine init_topography
         SurfaceAltitude(iLon, iLat, iEast_), &
         SurfaceAltitude(iLon, iLat, iUp_)
 
-    end do
-  end do
+    enddo
+  enddo
   close(iInputUnit_)
 
   do iBlock = 1, nBlocks
@@ -359,8 +359,8 @@ subroutine init_topography
             rLon = 1.0 - (LonFind - SurfaceAltitude(jLon, 1, iEast_))/ &
                    (SurfaceAltitude(jLon + 1, 1, iEast_) - SurfaceAltitude(jLon, 1, iEast_))
 
-          end if
-        end do
+          endif
+        enddo
 
         do jLat = 1, nMOLALats - 1
 
@@ -369,18 +369,18 @@ subroutine init_topography
             iiLat = jLat
             rLat = 1.0 - (LatFind - SurfaceAltitude(1, jLat, iNorth_))/ &
                    (SurfaceAltitude(1, jLat + 1, iNorth_) - SurfaceAltitude(1, jLat, iNorth_))
-          end if
-        end do
+          endif
+        enddo
 
         altzero(iLon, iLat, iBlock) = (rLon)*(rLat)*SurfaceAltitude(iiLon, iiLat, iUp_) + &
                                       (1 - rLon)*(rLat)*SurfaceAltitude(iiLon + 1, iiLat, iUp_) + &
                                       (rLon)*(1 - rLat)*SurfaceAltitude(iiLon, iiLat + 1, iUp_) + &
                                       (1 - rLon)*(1 - rLat)*SurfaceAltitude(iiLon + 1, iiLat + 1, iUp_)
 
-      end do
-    end do
+      enddo
+    enddo
 
-  end do
+  enddo
 
 end subroutine init_topography
 !---------------------------------------------------------+
@@ -536,7 +536,7 @@ subroutine calc_radcooling(iBlock)
   !
   do i = 1, np
     pnb(i) = 1.0e-4*exp(pnbr(i)) ! p into Pa
-  end do
+  enddo
 
   ! ****  Initialize to zero
   cooltot(1:nLons, 1:nLats, 1:nAlts) = 0.0
@@ -555,7 +555,7 @@ subroutine calc_radcooling(iBlock)
         co2(iAlt) = vmrco2(iLon, iLat, iAlt)
         o3p(iAlt) = vmro(iLon, iLat, iAlt)
         n2co(iAlt) = vmrn2co(iLon, iLat, iAlt)
-      end do
+      enddo
 
       !        interpolate escape functions (only) to nlayer grid
       call interp1(escf2, player, nlayer, ef2, pnb, np)
@@ -587,7 +587,7 @@ subroutine calc_radcooling(iBlock)
           if (tlayer(i) .le. 175.0) then
             k19xca = 3.3e-15
             k19xcb = 7.6e-16
-          end if
+          endif
           k19xca = k19xca*rfvt
           k19xcb = k19xcb*rfvt
           k19cap1 = k19xca*2.0*exp(-ee*nu1/tlayer(i))
@@ -639,11 +639,11 @@ subroutine calc_radcooling(iBlock)
           !        Cooling Rate (K/sec units)
           cooltot(iLon, iLat, i) = 0.1*hr(i)*tlayer(i)/(4.4*player(i))
 
-        end if
+        endif
 
-      end do  !-------- END OF MAIN ALTITUDE LOOP
-    end do  !-------- END OF MAIN LONGITUDE LOOP
-  end do  !-------- END OF MAIN LATITUDE LOOP
+      enddo  !-------- END OF MAIN ALTITUDE LOOP
+    enddo  !-------- END OF MAIN LONGITUDE LOOP
+  enddo  !-------- END OF MAIN LATITUDE LOOP
 
   !-------------------------------------------------------------
 
@@ -722,13 +722,13 @@ subroutine interp1(escout, p, nlayer, escin, pin, nl)
           np = n + 1
           wm = abs(pin(np) - p(n1))/(pin(nm) - pin(np))
           wp = 1.0 - wm
-        end if
+        endif
 
-      end do
+      enddo
 
       escout(n1) = escin(nm)*wm + escin(np)*wp
-    end if
-  end do
+    endif
+  enddo
 
 end subroutine interp1
 !---------------------------------------------------------+
@@ -856,10 +856,10 @@ subroutine init_isochem
           if (Altitude_GB(iLon, iLat, ialt, iBlock)/1000.0 .le. AltMinIono) &
             iAltMinIono(iLon, iLat, iBlock) = iAlt
           if (ialtminiono(ilon, ilat, iblock) .lt. 1) ialtminiono(ilon, ilat, iblock) = 1
-        end do
-      end do
-    end do
-  end do
+        enddo
+      enddo
+    enddo
+  enddo
 
 end subroutine init_isochem
 
@@ -927,13 +927,13 @@ subroutine calc_eddy_diffusion_coefficient(iBlock)
           if (First == 0) then
             NEddyMax(iLon, iLat) = NDensity(iLon, iLat, iAlt, iBlock)
             First = 1
-          end if
-        end if
+          endif
+        endif
 
-      end do
+      enddo
 
-    end do
-  end do
+    enddo
+  enddo
 
   ! Now we have all the trigger densities as a function of Longitude and Latitude
 
@@ -963,10 +963,10 @@ subroutine calc_eddy_diffusion_coefficient(iBlock)
 !                  max(100.0e+02, KappaEddyDiffusion(iLon,iLat,iAlt,iBlock) )
         !
 
-      end do
-    end do
+      enddo
+    enddo
 
-  end do
+  enddo
 
 end subroutine calc_eddy_diffusion_coefficient
 
@@ -1010,7 +1010,7 @@ subroutine calc_gw(iBlock)
 
   if (CurrentTime - StartTime .lt. 3600) then
     return
-  end if
+  endif
   do ilon = 1, nLons
     do ilat = 1, nLats
 
@@ -1080,7 +1080,7 @@ subroutine calc_gw(iBlock)
 
         dtheta(nl) = theta(nl + 1) - theta(nl)
 
-      end do
+      enddo
 
       !      Calculate the surface drag magnitude, using lowest layer midpoint
       !     density and wind speed values, and N (Brunt-Vaisala frequency) value
@@ -1161,7 +1161,7 @@ subroutine calc_gw(iBlock)
             !    below it would be more appropriate to  goto  statement  6  since
             !    at this point this column is completed
             goto 22
-          end if
+          endif
           !    the above  endif  ends the treatment of CRITICAL LEVELS
 
           !  Calculate the Brunt-Vaisala frequency at the top boundary of
@@ -1275,11 +1275,11 @@ subroutine calc_gw(iBlock)
               ! stress(nl) - stress(nl+1)
 
               dstress(nl) = stress(nl - 1) - stress(nl)
-            end if
-          end if
+            endif
+          endif
           !     Endif NL.LE.NLAY-3
 
-        end if
+        endif
         !    Calculate the layer midoint wind accaleration value based upon
         !   the layer's value of  dstress  and the mass within the layer
 
@@ -1291,7 +1291,7 @@ subroutine calc_gw(iBlock)
         if (dudt(nl) .ne. 0.0) then
           !     write(17,*) msol,mbin,nl,dudt(nl),1.25+(NLAY-nl)*2.5
 !                 write(17,*) msol,mbin,nl,dudt(nl),1.25+(nl-1)*2.5
-        end if
+        endif
 
         !    Populate the GWAccel array
         !   Be sure that the GWAccel array is properly zeroed upon each entry in to
@@ -1319,7 +1319,7 @@ subroutine calc_gw(iBlock)
           dstress(nlay) = stress(nlay - 1)
           dudt(nlay) = -dstress(nlay)/((plev(nlay) - plev(nlay - 1))/gravv)
 !              write(17,*) msol,mbin,nlay,dudt(nlay),1.25+nlay*2.5
-        end if
+        endif
 
         !  Populate the top active layer of the GWAccel  array
         GWAccel(ilon, ilat, nlay, iEast_) = dudt(nlay)*Dt
@@ -1340,8 +1340,8 @@ subroutine calc_gw(iBlock)
 99      format(i3, 14(2x, 1pe10.3))
 98      format(i3, 14(3x, 1pe10.3))
 
-      end do
-    end do
+      enddo
+    enddo
 
     !  Set all GWAccel values to zero.. so there will be
     ! no effect upon the zonal wind speed, but all components
@@ -1482,10 +1482,10 @@ subroutine calc_gw(iBlock)
         do N = 1, nDustTimes
           DustTime(N) = TimeDust(N)
 
-        end do
+        enddo
         do N = 1, nConrathTimes
           ConrathTime(N) = TimeConrath(N)
-        end do
+        enddo
 
         tDiff = CurrentTime - DustTime
         ctDiff = CurrentTime - ConrathTime
@@ -1516,7 +1516,7 @@ subroutine calc_gw(iBlock)
       else
         tautot = tautot_temp
         conrnu = conrnu_temp
-      end if
+      endif
 
       CALL DUSTPROFILE(PLEV(L_LEVELS), PTROP, PLEV, TAUCUM, TAUREF, L_LEVELS, TauTot, ConrNU)
 
@@ -1580,7 +1580,7 @@ subroutine calc_gw(iBlock)
         FLUXUPV = 0.0
         FLUXDNV = 0.0
         FMNETV = 0.0
-      end if
+      endif
 
       !C  Check for ground ice.  Change the IR albedo if there is any ice.
 
@@ -1616,7 +1616,7 @@ subroutine calc_gw(iBlock)
           COOLCORRECTION(L1) = 1.0
         ELSE
           COOLCORRECTION(L1) = 0.0
-        END IF
+        ENDIF
         IF (P(L_NLAYRAD - L1) .GT. XLTEPRESSURE(1)) THEN
           XLTECORRECTION(L1) = 1.0
         ELSE
@@ -1625,15 +1625,15 @@ subroutine calc_gw(iBlock)
               GOTO 199
             ELSE
               MALT = N
-            END IF
-          END DO
+            ENDIF
+          ENDDO
 
 199       CONTINUE
           XLTECORRECTION(L1) = XLTEFACTOR(MALT) + &
                                (XLTEFACTOR(MALT + 1) - XLTEFACTOR(MALT))* &
                                DLOG(P(L_NLAYRAD - L1)/XLTEPRESSURE(MALT))/ &
                                DLOG(XLTEPRESSURE(MALT + 1)/XLTEPRESSURE(MALT))
-        END IF
+        ENDIF
 
         fluxid(L1) = FMNETI(L) - FMNETI(L - 1)
         fluxvd(L1) = FMNETV(L) - FMNETV(L - 1)
@@ -1678,7 +1678,7 @@ subroutine calc_gw(iBlock)
                           fluxdni(L_NLAYRAD) - SBconstant*SurfaceTemp(iLon, iLat, iBlock)**4.0) + &
           2.0*PI/PdM*(SubsurfaceTemp(iLon, iLat, iBlock) - SurfaceTemp(iLon, iLat, iBlock))
 
-      end do
+      enddo
 !stop
       fir(iLon, iLat, iBlock) = fluxdni(L_NLAYRAD)
       fvis(iLon, iLat, iBlock) = fluxdnv(L_NLAYRAD)
@@ -1734,7 +1734,7 @@ subroutine calc_gw(iBlock)
       do L = 1, L_Layers + 1
         altbound(L) = (altmid(l) + altmid(l + 1))/2.
 !       write(*,*) "alts: ",altbound(l), altmid(l),altmid(l+1)
-      end do
+      enddo
 !    ALTBOUND(1)=ALTMID(1) + (ALTMID(1)-ALTMIN)
       !    DO L=2,L_LAYERS+1
 !       ALTBOUND(L)=ALTMID(L) + (ALTMID(L)-ALTBOUND(L-1))
@@ -1769,7 +1769,7 @@ subroutine calc_gw(iBlock)
 !write(*,*) altmid(nk),altbound(nk),altlevels(k)-altlevels(k+1)
 !if (iproc .eq. 21) write(*,*) k,nk,plev(k),P(nk),pbot
 !write(*,*)
-      END DO
+      ENDDO
 
 !write(*,*) l_levels,l_layers
 !if (iproc .eq. 21) stop
@@ -1781,7 +1781,7 @@ subroutine calc_gw(iBlock)
                       (ALTLEVELS(K - 1) - ALTLEVELS(K + 1)))
 !write(*,*) altlevels(k),k
 !write(*,*) plev(k),k
-      END DO
+      ENDDO
 
 !    if (altbot .gt. altmin) then
       PLEV(L_LEVELS) = PBOT!EXP(DLOG(PBOT) - (DLOG(PLEV(L_LEVELS-1))-DLOG(PBOT))*&
@@ -1810,13 +1810,13 @@ subroutine calc_gw(iBlock)
       DO K = 4, L_LEVELS - 1, 2
         NK = L_LAYERS - (K/2 - 2)
         TLEV(K) = T(NK)
-      END DO
+      ENDDO
 
       DO K = 3, L_LEVELS - 2, 2
         TLEV(K) = TLEV(K + 1) + (TLEV(K - 1) - TLEV(K + 1))* &
                   DLOG(PLEV(K)/PLEV(K + 1))/ &
                   DLOG(PLEV(K - 1)/PLEV(K + 1))
-      END DO
+      ENDDO
 
       !C  Temperature of the bottom level is the ground temperature.
 
@@ -1835,7 +1835,7 @@ subroutine calc_gw(iBlock)
         TMID(2*L + 2) = TLEV(2*L + 1)
         PMID(2*L + 1) = PLEV(2*L + 1)
         PMID(2*L + 2) = PLEV(2*L + 1)
-      END DO
+      ENDDO
 
       TMID(L_LEVELS) = TLEV(L_LEVELS)
       PMID(L_LEVELS) = PLEV(L_LEVELS)
@@ -1880,7 +1880,7 @@ subroutine calc_gw(iBlock)
 
       do n = 2, npdst
         prdst(n) = refpr*prdst(n - 1)
-      end do
+      enddo
 
       !C Calculate the Mixing Ratio at the Reference Pressure Level
 
@@ -1890,9 +1890,9 @@ subroutine calc_gw(iBlock)
           pave = 0.5*(prdst(n) + prdst(n - 1))
           sum = sum + exp(conrnu*(1.-(rptau/pave)))* &
                 (prdst(n) - prdst(n - 1))
-        end if
+        endif
         if (prdst(n) .ge. rptau) go to 10
-      end do
+      enddo
 
 10    continue
 
@@ -1912,7 +1912,7 @@ subroutine calc_gw(iBlock)
         if (rptau .gt. prdst(n + 1)) then
           pave = 0.5*(prdst(n + 1) + prdst(n))
           qrdst(n) = qrdst0*exp(conrnu*(1.0 - (rptau/pave)))
-        end if
+        endif
 
         !C Region 2: Reference pressure level within this layer.
 
@@ -1923,15 +1923,15 @@ subroutine calc_gw(iBlock)
           qrdst(n) = qrdst0*( &
                      exp(conrnu*(1.0 - (rptau/pave)))*pdif1 + pdif2)/ &
                      (prdst(n + 1) - prdst(n))
-        end if
+        endif
 
         !C Region 3: Mixing ratio constant
 
         if (rptau .lt. prdst(n)) then
           qrdst(n) = qrdst0
-        end if
+        endif
 
-      end do
+      enddo
 
       !C Now compute the optical depths (taudst).
 
@@ -1939,7 +1939,7 @@ subroutine calc_gw(iBlock)
 
       do n = 2, npdst
         taudst(n) = taudst(n - 1) + qrdst(n - 1)*(prdst(n) - prdst(n - 1))
-      end do
+      enddo
 
       !C  Dust optical depth at the bottom of each sub-layer.
 
@@ -1955,7 +1955,7 @@ subroutine calc_gw(iBlock)
                     (PRDST(NSTAR + 1) - PRDST(NSTAR))
         TAUREF(K) = TAUCUM(K) - TAUCUM(K - 1)
 
-      END DO
+      ENDDO
 
       TAUREF(L_LEVELS + 1) = 0.0D0
 
@@ -2015,15 +2015,15 @@ subroutine calc_gw(iBlock)
           else
             JH = JM
             JM = (JL + JH)/2
-          end if
+          endif
 
           GOTO 10
-        end if
+        endif
 
         if (TARGET .EQ. SX(JH)) JH = JH + 1
 
         ians = JH
-      end if
+      endif
 
       JSRCHGT = ians
 
@@ -2103,8 +2103,8 @@ subroutine calc_gw(iBlock)
       DO NG = 1, L_NGAUSS - 1
         do NW = 1, L_NSPECTV
           TAUGSURF(NW, NG) = 0.0D0
-        end do
-      end do
+        enddo
+      enddo
 
       do K = 2, L_LEVELS
         DPR(k) = PLEV(K) - PLEV(K - 1)
@@ -2118,13 +2118,13 @@ subroutine calc_gw(iBlock)
 
         do LK = 1, 4
           LKCOEF(K, LK) = LCOEF(LK)
-        end do
+        enddo
 
         DO NW = 1, L_NSPECTV
           TRAY(K, NW) = TAURAY(NW)*DPR(K)
           TAEROS(K, NW) = TAUREF(K)*Qextv(NW)/QextREF
-        END DO
-      end do
+        ENDDO
+      enddo
 
       !C  TAUCLD = is cloud opacity, zero until further notice
       !C  TRAYAER is Tau RAYleigh scattering, plus AERosol opacity
@@ -2138,7 +2138,7 @@ subroutine calc_gw(iBlock)
 
         do K = 2, L_LEVELS
           DTAUKV(K, nw, L_NGAUSS) = TAEROS(K, NW) + TRAY(K, NW) + TAUCLD
-        end do
+        enddo
 
         do ng = L_NGAUSS - 1, 1, -1
           do K = 2, L_LEVELS
@@ -2180,16 +2180,16 @@ subroutine calc_gw(iBlock)
 !                stop
 !endif
 
-          end do
+          enddo
           if (TAUGSURF(NW, NG) .LT. TLIMIT) THEN
             goto 10
           else
             NGWV(NW) = NG
-          end if
+          endif
 
-        end do
+        enddo
 10      continue
-      end do
+      enddo
 
       !C  Now the full treatment for the layers, where besides the opacity
       !C  we need to calculate the scattering albedo and asymmetry factors
@@ -2210,7 +2210,7 @@ subroutine calc_gw(iBlock)
           WBARV(L, nw, ng) = (QSCATV(NW)*TAUREFL + &
                               (TRAY(K, NW) + TRAY(K + 1, NW))*0.9999)/ &
                              DTAUV(L, nw, ng)
-        END DO
+        ENDDO
 
         !C  Special bottom layer
 
@@ -2223,7 +2223,7 @@ subroutine calc_gw(iBlock)
         WBARV(L, nw, ng) = (QSCATV(NW)*TAUREFL + TRAY(K, NW)*0.9999)/ &
                            DTAUV(L, nw, ng)
 
-      END DO
+      ENDDO
 
       !C  . . .Now the other Gauss points, if needed.
 
@@ -2237,7 +2237,7 @@ subroutine calc_gw(iBlock)
             WBARV(L, nw, ng) = (QSCATV(NW)*TAUREFL + &
                                 (TRAY(K, NW) + TRAY(K + 1, NW))*0.9999)/ &
                                DTAUV(L, nw, ng)
-          END DO
+          ENDDO
 
           !C  Special bottom layer
 
@@ -2253,9 +2253,9 @@ subroutine calc_gw(iBlock)
 !             write(*,*) dtauv(l,nw,ng),dtaukv(k,nw,ng),l,nw,ng
 !             stop
 !             endif
-        END DO
+        ENDDO
 
-      END DO     ! NW spectral loop
+      ENDDO     ! NW spectral loop
 
       !C     TOTAL EXTINCTION OPTICAL DEPTHS
 
@@ -2264,25 +2264,25 @@ subroutine calc_gw(iBlock)
         TAUV(1, NW, NG) = 0.0D0
         DO L = 1, L_NLAYRAD
           TAUV(L + 1, NW, NG) = TAUV(L, NW, NG) + DTAUV(L, NW, NG)
-        END DO
+        ENDDO
 
         TAUCUMV(1, NW, NG) = 0.0D0
         DO K = 2, L_LEVELS
           TAUCUMV(K, NW, NG) = TAUCUMV(K - 1, NW, NG) + DTAUKV(K, NW, NG)
-        END DO
+        ENDDO
 
         DO NG = L_NGAUSS - 1, NGWV(NW), -1
           TAUV(1, NW, NG) = 0.0D0
           DO L = 1, L_NLAYRAD
             TAUV(L + 1, NW, NG) = TAUV(L, NW, NG) + DTAUV(L, NW, NG)
-          END DO
+          ENDDO
 
           TAUCUMV(1, NW, NG) = 0.0D0
           DO K = 2, L_LEVELS
             TAUCUMV(K, NW, NG) = TAUCUMV(K - 1, NW, NG) + DTAUKV(K, NW, NG)
-          END DO
-        END DO
-      END DO
+          ENDDO
+        ENDDO
+      ENDDO
 
     END SUBROUTINE OPTCV
     ! ----------------------------------------------------------------------
@@ -2384,14 +2384,14 @@ subroutine calc_gw(iBlock)
             MT = n
             U = (TW - TREF(MT))/(TREF(MT + 1) - TREF(MT))
             goto 10
-          end if
-        end do
+          endif
+        enddo
 
         MT = L_NTREF - 1
         U = 1.0D0
 
 10      continue
-      END IF
+      ENDIF
 
       !C     Get the upper and lower Pressure-grid indicies that bound the
       !C     requested pressure.  If the requested pressure is outside
@@ -2408,14 +2408,14 @@ subroutine calc_gw(iBlock)
             MP = n - 1
             T = (PWL - PREF(MP))/(PREF(MP + 1) - PREF(MP))
             goto 20
-          end if
-        end do
+          endif
+        enddo
 
         MP = L_PINT - 1
         T = 1.0D0
 
 20      continue
-      end if
+      endif
 
       !C  Fill the interpolation coeficients:
 
@@ -2439,9 +2439,9 @@ subroutine calc_gw(iBlock)
             NH2O = N - 1
             WRATIO = (QH2O - WREFH2O(N - 1))/(WREFH2O(N) - WREFH2O(N - 1))
             GOTO 30
-          END IF
-        END DO
-      END IF
+          ENDIF
+        ENDDO
+      ENDIF
 
 30    CONTINUE
 
@@ -2495,7 +2495,7 @@ subroutine calc_gw(iBlock)
         FMNETV(L) = 0.0
         FLUXUPV(L) = 0.0
         FLUXDNV(L) = 0.0
-      END DO
+      ENDDO
 
       DIFFVT = 0.0
 
@@ -2514,7 +2514,7 @@ subroutine calc_gw(iBlock)
 
         DO NG = 1, NGWV(NW) - 1
           fzero = fzero + (1.0 - FZEROV(NW))*GWEIGHT(NG)
-        END DO
+        ENDDO
 
         !C  This loop includes only those Gauss points with sufficient gas opacity
 
@@ -2553,13 +2553,13 @@ subroutine calc_gw(iBlock)
             FLUXDNV(L) = FLUXDNV(L) + FMDV(L)*GWEIGHT(NG)* &
                          (1.0 - FZEROV(NW))
 
-          END DO
+          ENDDO
 
           !C         THE DIFFUSE COMPONENT OF THE DOWNWARD SOLAR FLUX
 
           DIFFVT = DIFFVT + DIFFV*GWEIGHT(NG)*(1.0 - FZEROV(NW))
 
-        END DO   ! the Gauss loop
+        ENDDO   ! the Gauss loop
 
 40      continue
 
@@ -2596,7 +2596,7 @@ subroutine calc_gw(iBlock)
           FLUXUPV(L) = FLUXUPV(L) + FMUPV(L)*FZERO
           FLUXDNV(L) = FLUXDNV(L) + FMDV(L)*FZERO
 
-        END DO
+        ENDDO
         !C       THE DIFFUSE COMPONENT OF THE DOWNWARD SOLAR FLUX
 
         DIFFVT = DIFFVT + DIFFV*FZERO
@@ -2708,7 +2708,7 @@ subroutine calc_gw(iBlock)
             TAUCUMP(K + 1) = TAUCUMP(k) + (TAUCUM(K + 1) - TAUCUM(k))* &
                              (1.-WDEL(L)*CDEL(L)**2)
 
-          END DO
+          ENDDO
 
           !C  Bottom layer
 
@@ -2736,7 +2736,7 @@ subroutine calc_gw(iBlock)
             G3(L) = 0.5*(1.0 - SQRT(3.0)*COSBAR(L)*UBAR0)
             LAMDA(L) = SQRT(G1(L)**2 - G2(L)**2)
             GAMA(L) = (G1(L) - LAMDA(L))/G2(L)
-          END DO
+          ENDDO
 
           DO L = 1, L_NLAYRAD
             G4 = 1.0 - G3(L)
@@ -2749,7 +2749,7 @@ subroutine calc_gw(iBlock)
 
             IF (DENOM .EQ. 0.) THEN
               DENOM = 1.E-10
-            END IF
+            ENDIF
 
             AM = F0PI*W0(L)*(G4*(G1(L) + 1./UBAR0) + G2(L)*G3(L))/DENOM
             AP = F0PI*W0(L)*(G3(L)*(G1(L) - 1./UBAR0) + G2(L)*G4)/DENOM
@@ -2766,7 +2766,7 @@ subroutine calc_gw(iBlock)
             CP(L) = AP*EXP(-TAU(L + 1)/UBAR0)
             CM(L) = AM*EXP(-TAU(L + 1)/UBAR0)
 
-          END DO
+          ENDDO
 
           !C     NOW CALCULATE THE EXPONENTIAL TERMS NEEDED
           !C     FOR THE TRIDIAGONAL ROTATED LAYERED METHOD
@@ -2783,7 +2783,7 @@ subroutine calc_gw(iBlock)
 !          if (E2(L) .ne. e2(L)) then
 !             write(*,*) "e2: ",exptrm(L),taumax,lamda(l),dtau(l),iproc,l
 !          endif
-          END DO
+          ENDDO
 
           CALL DSOLVER(NAYER, GAMA, CP, CM, CPM1, CMM1, E1, E2, E3, E4, BTOP, &
                        BSURF, RSF, XK1, XK2)
@@ -2808,7 +2808,7 @@ subroutine calc_gw(iBlock)
 
             IF (DENOM .EQ. 0.) THEN
               DENOM = 1.E-10
-            END IF
+            ENDIF
 
             AM = F0PI*W0(L)*(G4*(G1(L) + 1./UBAR0) + G2(L)*G3(L))/DENOM
             AP = F0PI*W0(L)*(G3(L)*(G1(L) - 1./UBAR0) + G2(L)*G4)/DENOM
@@ -2829,7 +2829,7 @@ subroutine calc_gw(iBlock)
 
             FMIDM(L) = FMIDM(L) + UBAR0*F0PI*EXP(-MIN(TAUMID, TAUMAX)/UBAR0)
 
-          END DO
+          ENDDO
 
           !C     FLUX AT THE Ptop layer
 
@@ -2845,7 +2845,7 @@ subroutine calc_gw(iBlock)
 
           IF (DENOM .EQ. 0.) THEN
             DENOM = 1.E-10
-          END IF
+          ENDIF
 
           AM = F0PI*W0(1)*(G4*(G1(1) + 1./UBAR0) + G2(1)*G3(1))/DENOM
           AP = F0PI*W0(1)*(G3(1)*(G1(1) - 1./UBAR0) + G2(1)*G4)/DENOM
@@ -2885,7 +2885,7 @@ subroutine calc_gw(iBlock)
 
           IF (DENOM .EQ. 0.) THEN
             DENOM = 1.E-10
-          END IF
+          ENDIF
 
           AM = F0PI*W0(L)*(G4*(G1(L) + 1./UBAR0) + G2(L)*G3(L))/DENOM
           AP = F0PI*W0(L)*(G3(L)*(G1(L) - 1./UBAR0) + G2(L)*G4)/DENOM
@@ -2981,7 +2981,7 @@ subroutine calc_gw(iBlock)
             CF(I) = 2.0*(1.-GAMA(N + 1)**2)
             DF(I) = (GAMA(N + 1) - 1.)*(CPM1(N + 1) - CP(N)) + &
                     (1.-GAMA(N + 1))*(CM(N) - CMM1(N + 1))
-          END DO
+          ENDDO
 
           N = 0
           LM1 = L - 1
@@ -2991,7 +2991,7 @@ subroutine calc_gw(iBlock)
             BF(I) = (E1(N) - E3(N))*(1.+GAMA(N + 1))
             CF(I) = (E1(N) + E3(N))*(GAMA(N + 1) - 1.)
             DF(I) = E3(N)*(CPM1(N + 1) - CP(N)) + E1(N)*(CM(N) - CMM1(N + 1))
-          END DO
+          ENDDO
 
           AF(L) = E1(NL) - RSF*E3(NL)
           BF(L) = E2(NL) - RSF*E4(NL)
@@ -3058,14 +3058,14 @@ subroutine calc_gw(iBlock)
 !             if (ds(L+1-I) .ne. ds(L+1-I))then
 !                write(*,*)"dtr: ",I, df(L+1-I),DF(L+1-I),DS(L+2-I),X,BF(L+1-I),cf(L+1-I),AS(L+2-I),af(L+1-I)
 !             endif
-              END DO
+              ENDDO
 
               XK(1) = DS(1)
               DO I = 2, L
                 XKB = XK(I - 1)
                 XK(I) = DS(I) - AS(I)*XKB
 
-              END DO
+              ENDDO
 
             END SUBROUTINE DTRIDGL
 
@@ -3149,8 +3149,8 @@ subroutine calc_gw(iBlock)
               DO NG = 1, L_NGAUSS - 1
                 do NW = 1, L_NSPECTI
                   TAUGSURF(NW, NG) = 0.0D0
-                end do
-              end do
+                enddo
+              enddo
 
               do K = 2, L_LEVELS
                 DPR(k) = PLEV(K) - PLEV(K - 1)
@@ -3164,12 +3164,12 @@ subroutine calc_gw(iBlock)
 
                 do LK = 1, 4
                   LKCOEF(K, LK) = LCOEF(LK)
-                end do
+                enddo
 
                 DO NW = 1, L_NSPECTI
                   TAEROS(K, NW) = TAUREF(K)*Qexti(NW)/Qrefv
-                END DO
-              end do
+                ENDDO
+              enddo
 !stop
               !C  TAUCLD = is cloud opacity, zero until further notice
 
@@ -3183,7 +3183,7 @@ subroutine calc_gw(iBlock)
 
                 do K = 2, L_LEVELS
                   DTAUKI(K, NW, L_NGAUSS) = TAEROS(K, NW) + TAUCLD
-                end do
+                enddo
 
                 do ng = L_NGAUSS - 1, 1, -1
                   do K = 2, L_LEVELS
@@ -3221,18 +3221,18 @@ subroutine calc_gw(iBlock)
 !                   if (nw .eq. 3 .and. ng .eq. 15) then1
 !                      write(*,*) dtauki(k,nw,ng),taugas,u(k),ans
 !                   endif
-                  end do
+                  enddo
 
                   if (TAUGSURF(NW, NG) .LT. TLIMIT) THEN
                     goto 10
                   else
                     NGWI(NW) = NG
-                  end if
+                  endif
 
-                end do
+                enddo
 10              continue
 
-              end do
+              enddo
 !stop
               !C  Now the full treatment for the layers, where besides the opacity
               !C  we need to calculate the scattering albedo and asymmetry factors
@@ -3253,18 +3253,18 @@ subroutine calc_gw(iBlock)
                   else
                     WBARI(L, nw, ng) = 0.0D0
                     DTAUI(L, NW, NG) = 1.0E-9
-                  end if
+                  endif
 
                   TAUAC = TAEROS(K, NW) + TAUCLD
                   if (TAUAC .GT. 0.0) then
                     cosbi(L, NW, NG) = GI(NW)           !change formula to add clouds
                   else
                     cosbi(L, NW, NG) = 0.0D0
-                  end if
+                  endif
 
-                END DO
+                ENDDO
 
-              END DO
+              ENDDO
 
               !C  . . .Now the other Gauss points, if needed.
 
@@ -3280,14 +3280,14 @@ subroutine calc_gw(iBlock)
                     else
                       WBARI(L, nw, ng) = 0.0D0
                       DTAUI(L, NW, NG) = 1.0E-9
-                    end if
+                    endif
 
                     cosbi(L, NW, NG) = cosbi(L, NW, L_NGAUSS)
-                  END DO
+                  ENDDO
 
-                END DO
+                ENDDO
 
-              END DO     ! NW spectral loop
+              ENDDO     ! NW spectral loop
 
               !C     TOTAL EXTINCTION OPTICAL DEPTHS
 
@@ -3296,27 +3296,27 @@ subroutine calc_gw(iBlock)
                 TAUI(1, NW, NG) = 0.0D0
                 DO L = 1, L_NLAYRAD
                   TAUI(L + 1, NW, NG) = TAUI(L, NW, NG) + DTAUI(L, NW, NG)
-                END DO
+                ENDDO
 
                 TAUCUMI(1, NW, NG) = 0.0D0
                 DO K = 2, L_LEVELS
                   TAUCUMI(K, NW, NG) = TAUCUMI(K - 1, NW, NG) + DTAUKI(K, NW, NG)
-                END DO
+                ENDDO
 
                 DO NG = L_NGAUSS - 1, NGWI(NW), -1
 
                   TAUI(1, NW, NG) = 0.0D0
                   DO L = 1, L_NLAYRAD
                     TAUI(L + 1, NW, NG) = TAUI(L, NW, NG) + DTAUI(L, NW, NG)
-                  END DO
+                  ENDDO
 
                   TAUCUMI(1, NW, NG) = 0.0D0
                   DO K = 2, L_LEVELS
                     TAUCUMI(K, NW, NG) = TAUCUMI(K - 1, NW, NG) + DTAUKI(K, NW, NG)
-                  END DO
+                  ENDDO
 
-                END DO
-              END DO
+                ENDDO
+              ENDDO
 !write(*,*) taucumi(:,3,15)
 !write(*,*) "dtauk: ",dtauki(:,3,15)
 !write(*,*) "dtaui: ",dtaui(:,3,15)
@@ -3371,7 +3371,7 @@ subroutine calc_gw(iBlock)
                 FMNETI(L) = 0.0
                 FLUXUPI(L) = 0.0
                 FLUXDNI(L) = 0.0
-              END DO
+              ENDDO
 
               !C     WE NOW ENTER A MAJOR LOOP OVER SPECTRAL INTERVALS IN THE INFRARED
               !C     TO CALCULATE THE NET FLUX IN EACH SPECTRAL INTERVAL
@@ -3397,7 +3397,7 @@ subroutine calc_gw(iBlock)
 
                 DO NG = 1, NGWI(NW) - 1
                   fzero = fzero + (1.0 - FZEROI(NW))*GWEIGHT(NG)
-                END DO
+                ENDDO
 
                 DO NG = NGWI(NW), L_NGAUSS - 1
 
@@ -3445,9 +3445,9 @@ subroutine calc_gw(iBlock)
 !   write(*,*) l,l_nlevrad-1,ng,l_ngauss-1,nw,l_nspecti
 !stop
 !endif
-                  END DO
+                  ENDDO
 
-                END DO       !End NGAUSS LOOP
+                ENDDO       !End NGAUSS LOOP
 
 40              CONTINUE
 
@@ -3479,7 +3479,7 @@ subroutine calc_gw(iBlock)
                   FMNETI(L) = FMNETI(L) + (FMUPI(L) - FMDI(L))*DWNI(NW)*FZERO
                   FLUXUPI(L) = FLUXUPI(L) + FMUPI(L)*DWNI(NW)*FZERO
                   FLUXDNI(L) = FLUXDNI(L) + FMDI(L)*DWNI(NW)*FZERO
-                END DO
+                ENDDO
 
 501             CONTINUE      !End Spectral Interval LOOP
 
@@ -3569,7 +3569,7 @@ subroutine calc_gw(iBlock)
 
                     B1(L) = (PLANCKIR(NW, NT2) - PLANCKIR(NW, NT))/DTAU(L)
                     B0(L) = PLANCKIR(NW, NT)
-                  END DO
+                  ENDDO
 
                   !C     Take care of special lower layer
 
@@ -3597,7 +3597,7 @@ subroutine calc_gw(iBlock)
 
                     CPM1(L) = B0(L) + B1(L)*TERM
                     CMM1(L) = B0(L) - B1(L)*TERM
-                  END DO
+                  ENDDO
 
                   !C     NOW CALCULATE THE EXPONENTIAL TERMS NEEDED
                   !C     FOR THE TRIDIAGONAL ROTATED LAYERED METHOD
@@ -3614,7 +3614,7 @@ subroutine calc_gw(iBlock)
                     E2(L) = EP - GAMA(L)*EM
                     E3(L) = GAMA(L)*EP + EM
                     E4(L) = GAMA(L)*EP - EM
-                  END DO
+                  ENDDO
 
                   !c     B81=BTOP  ! RENAME BEFORE CALLING DSOLVER - used to be to set
                   !c     B82=BSURF ! them to real*8 - but now everything is real*8
@@ -3650,7 +3650,7 @@ subroutine calc_gw(iBlock)
 !   write(*,*) "in glux: ",fmidp(l),fmidm(l), taucum(2*l+1),taucum(2*l)
 
 !endif
-                  END DO
+                  ENDDO
 
                   !C     And now, for the special bottom layer
 

--- a/src/ModAeAuroralModel.f90
+++ b/src/ModAeAuroralModel.f90
@@ -48,7 +48,7 @@ contains
     if (IsFirstTime) then
       iError = 0
       IsFirstTime = .false.
-    end if
+    endif
 
     call get_ae(GitmCurrentTime + TimeDelayHighLat, ae, iError)
 
@@ -75,16 +75,16 @@ contains
           iMLat = 1
           do i = 1, nMlats
             if (dist(i) == mindist) iMLat = i
-          end do
+          enddo
 
           ElectronEnergyFlux(iLon, iLat) = eFlux(iAe, iMlt, iMlat)
           ElectronAverageEnergy(iLon, iLat) = AveE(iAe, iMlt, iMlat)
 
-        end if
+        endif
 
-      end do
+      enddo
 
-    end do
+    enddo
 
     call end_timing("run_ae_model")
 
@@ -117,7 +117,7 @@ contains
       if (.not. IsThere) then
         write(*, *) cFile//" cannot be found by read_ovationsm_files"
         call stop_gitm("must stop!!!")
-      end if
+      endif
 
       iError = 0
 
@@ -132,19 +132,19 @@ contains
       ! Read in mlats for all bins:
       do iLat = 1, nMLats
         read(iInputUnit_, *, iostat=iError) mlats(iAe, :, iLat)
-      end do
+      enddo
 
       ! Read in eflux for all bins:
       do iLat = 1, nMLats
         read(iInputUnit_, *, iostat=iError) eFlux(iAe, :, iLat)
-      end do
+      enddo
 
       ! Read in avee for all bins:
       do iLat = 1, nMLats
         read(iInputUnit_, *, iostat=iError) AveE(iAe, :, iLat)
-      end do
+      enddo
 
-    end do
+    enddo
 
     close(iInputUnit_)
 

--- a/src/ModChemistry.Earth.f90
+++ b/src/ModChemistry.Earth.f90
@@ -492,7 +492,7 @@ contains
         ChemicalHeatingS(io2p_e) + &
         Reaction*5.0
 
-    end if
+    endif
 
     IonLosses(iO2P_) = IonLosses(iO2P_) + Reaction
 
@@ -619,7 +619,7 @@ contains
         ChemicalHeatingSub + &
         Reaction*3.31
 
-    end if
+    endif
 
     IonSources(iO_4SP_) = IonSources(iO_4SP_) + Reaction
     IonLosses(iO_2DP_) = IonLosses(iO_2DP_) + Reaction
@@ -1081,7 +1081,7 @@ contains
 
       NeutralSources(iO_3P_) = NeutralSources(iO_3P_) + Reaction
 
-    end if
+    endif
 
     IonSources(iNOP_) = IonSources(iNOP_) + Reaction
     IonLosses(iNP_) = IonLosses(iNP_) + Reaction
@@ -1229,7 +1229,7 @@ contains
         ChemicalHeatingSub + &
         Reaction*2.38
 
-    end if
+    endif
 
     NeutralSources(iN_4S_) = NeutralSources(iN_4S_) + Reaction
     NeutralLosses(iN_2D_) = NeutralLosses(iN_2D_) + Reaction
@@ -1363,7 +1363,7 @@ contains
         ChemicalHeatingSub + &
         Reaction*3.76
 
-    end if
+    endif
     NeutralSources(iNO_) = NeutralSources(iNO_) + Reaction
     NeutralLosses(iN_2D_) = NeutralLosses(iN_2D_) + Reaction
     NeutralLosses(iO2_) = NeutralLosses(iO2_) + Reaction
@@ -1510,7 +1510,7 @@ contains
         ChemicalHeatingS(io1d_o) + &
         Reaction*1.96
 
-    end if
+    endif
 
     ! ----------------------------------------------------------
     ! NO

--- a/src/ModChemistry.Mars.f90
+++ b/src/ModChemistry.Mars.f90
@@ -710,7 +710,7 @@ contains
 
       NeutralSources = 0.0
       NeutralLosses = 0.0
-    end if
+    endif
 
     call end_timing("chemsources")
   end subroutine calc_chemical_sources

--- a/src/ModChemistry.Venus.f90
+++ b/src/ModChemistry.Venus.f90
@@ -711,7 +711,7 @@ contains
 
       NeutralSources = 0.0
       NeutralLosses = 0.0
-    end if
+    endif
 
     call end_timing("chemsources")
   end subroutine calc_chemical_sources

--- a/src/ModCoupSAMI3.f90
+++ b/src/ModCoupSAMI3.f90
@@ -54,7 +54,7 @@ contains
                            -1:(nAlts + 4)*nBlocks - 2, &
                            nprocs))
 
-    end if
+    endif
 
     !! how to take the coratation into consideration when coupling
     ! This then implies that the grid is in local time, so we need to
@@ -93,7 +93,7 @@ contains
                  (iBlock - 1)*(nLats + 4) - 1:iBlock*(nLats + 4) - 2, &
                  (iBlock - 1)*(nAlts + 4) - 1:iBlock*(nAlts + 4) - 2) = &
           NDensityS(:, :, :, loc(iParam), iBlock)
-      end do
+      enddo
 
       GITMVars(8, &
                (iBlock - 1)*(nLons + 4) - 1:iBlock*(nLons + 4) - 2, &
@@ -124,17 +124,17 @@ contains
       do iLon = -1, nLons + 2
         GITMVars(11, (iBlock - 1)*(nLons + 4) + iLon, :, :) = &
           Longitude(iLon, iBlock)
-      end do
+      enddo
 
       do iLat = -1, nLats + 2
         GITMVars(12, :, (iBlock - 1)*(nLats + 4) + iLat, :) = &
           Latitude(iLat, iBlock)
-      end do
+      enddo
       do iAlt = -1, nAlts + 2
         GITMVars(13, :, :, (iBlock - 1)*(nAlts + 4) + iAlt) = &
           Altitude_GB(1, 1, iAlt, iBlock)
-      end do
-    end do
+      enddo
+    enddo
 
     call MPI_Gather(GITMLons, &
                     (nLons + 4)*nBlocks, &
@@ -245,7 +245,7 @@ contains
               if ((xd00*xd01*xd10*xd11*yd0*yd1*zd) < 0) then
                 print *, '===>> Dist', iLon, iLat, iAlt, xd00, xd01, xd10, xd11, yd0, yd1, zd
                 stop
-              end if
+              endif
               InterpFactors(1, iLon, iLat, iAlt) = xd00
               InterpFactors(2, iLon, iLat, iAlt) = xd01
               InterpFactors(3, iLon, iLat, iAlt) = xd10
@@ -254,15 +254,15 @@ contains
               InterpFactors(6, iLon, iLat, iAlt) = yd1
               InterpFactors(7, iLon, iLat, iAlt) = zd
 
-            end if
+            endif
 
-          end do
-        end do
-      end do
+          enddo
+        enddo
+      enddo
 
       IsFirstTime = .false.
 
-    end if
+    endif
 
     if (iproc == 0) &
       print *, '---- GITM Couping init Done!!!', iproc
@@ -368,8 +368,8 @@ contains
               else
 
                 IDensityS(iLon, iLat, iAlt, locgitm(iIon), iBlock) = data_inp(3 + iIon)*1e6
-              end if
-            end do
+              endif
+            enddo
 
             IDensityS(iLon, iLat, iAlt, ie_, iBlock) = &
               sum(IDensityS(iLon, iLat, iAlt, 1:nIons - 1, iBlock))
@@ -380,18 +380,18 @@ contains
                 data_inp(1:2), data_inp(3) - re, data_inp(9), 9
             else
               iTemperature(iLon, iLat, iAlt, iBlock) = data_inp(9)
-            end if
+            endif
             if (data_inp(10) <= 0) then
               print *, '===>>4 Magnetic Lon/Lat ', iproc, gitm_mlon, gitm_mlat, gitm_alt
               print *, '===>>4 The interpolated value', iproc, &
                 data_inp(1:2), data_inp(3) - re, data_inp(10), 10
             else
               eTemperature(iLon, iLat, iAlt, iBlock) = data_inp(10)
-            end if
-          end if
-        end do
-      end do
-    end do
+            endif
+          endif
+        enddo
+      enddo
+    enddo
 
     if (iproc == 0) &
       print *, 'GITM overwrite Done!', iproc
@@ -463,7 +463,7 @@ contains
 
         !print*,'SAMIPhi_g a',SAMIPhi_g(:,1)
 
-      end if
+      endif
 
       call report("GITM Broadcasting SAMI Data", 0)
 
@@ -486,7 +486,7 @@ contains
 
           !if (iProcGlobal == 30) write(*,*) "Looping exchange after barrier", iProcGlobal, i, iZ
 
-        end do
+        enddo
 
 !          call MPI_BARRIER(iCommGITM,iError)
 !          if (iProcGlobal == 30) write(*,*) "Looping exchange start", iProcGlobal, i, nf*nz*nlt
@@ -501,7 +501,7 @@ contains
 !
 !          if (iProcGlobal == 30) write(*,*) "Looping exchange after barrier", iProcGlobal, i
 
-      end do
+      enddo
 
       !write(*,*) "GITM Proc, after bcast : ", irank, iProcGlobal
 
@@ -536,8 +536,8 @@ contains
 
         !print*,'SAMIPhi sami',SAMIPhi(:,1)
 
-      end if
-    end if
+      endif
+    endif
 
     if (iCommGITM /= MPI_COMM_NULL) then
 
@@ -592,12 +592,12 @@ contains
             !endif
             !print*,'-- ip,iLon,iBlockLon,iiLon',ip,iLon,iBlockLon,iiLon
 
-          end do
+          enddo
 
           do iLat = -1, nLats + 2
             iiLat = (iBlockLat - 1)*(nLats) + iLat
             GatLatitude_g0(iiLat) = GatLatitude(iLat, ip)/pi*180.0
-          end do
+          enddo
 
           do iLon = -1, nLons + 2
 
@@ -624,11 +624,11 @@ contains
                   do iAlt = -1, nAlts + 2
                     GatGITMVars_g0(:, iiLon, iiLat, iAlt) = &
                       GatGITMVars(:, iLon, iLat, iAlt, ip)
-                  end do
-                end if
-              end do
-            end if
-          end do
+                  enddo
+                endif
+              enddo
+            endif
+          enddo
 
           !             do iLon = -1, nLons+2
           !                iiLon = (iBlockLon-1)*(nLons) + iLon
@@ -643,7 +643,7 @@ contains
           !                enddo
           !             enddo
 
-        end do
+        enddo
 
         GatAltitude_g0 = GatAltitude(-1:nAlts + 2, 1)/1000.0
 
@@ -669,7 +669,7 @@ contains
 
         deallocate(GatLongitude, GatLatitude, GatAltitude, GatGITMVars)
 
-      end if
+      endif
 
     else if (iCommSAMI0 /= MPI_COMM_NULL) then
 
@@ -698,7 +698,7 @@ contains
         call MPI_RECV(nBlocksLat, 1, MPI_INTEGER, 0, tag_SandR1, &
                       intercomm2, status, iError)
 
-      end if
+      endif
 
       ! if (irank==0) write(*,*) "> SAMI bcasting blocks"
 
@@ -740,7 +740,7 @@ contains
                                1:nLatsTotal, &
                                1:nAltsTotal))
         IsFirstTime = .false.
-      end if
+      endif
 
       call MPI_COMM_RANK(intercomm2, irank, iError)
 
@@ -762,7 +762,7 @@ contains
         call MPI_RECV(GatGITMVars_g, nParams*nPointsTotal, &
                       MPI_REAL, 0, tag_SandR2, intercomm2, status, iError)
 
-      end if
+      endif
 
       ! -------------------------------
       ! Pass the data out to other SAMI PEs
@@ -794,7 +794,7 @@ contains
           ! Move data into temp variable to bcast:
           GatGITMVar = GatGITMVars_g(i, :, :, :)
           ! write(*,*) "> done = ",i
-        end if
+        endif
         ! Pass temp variable to other PEs:
         call mpi_bcast(GatGITMVar, nPointsTotal, MPI_REAL, 0, iCommSAMI0, iError)
         call MPI_BARRIER(iCommSAMI0, iError)
@@ -802,8 +802,8 @@ contains
           ! write(*,*) "> Moving bcast data: ",irank, i
           ! Move data from temp array to permenant array:
           GatGITMVars_g(i, :, :, :) = GatGITMVar
-        end if
-      end do
+        endif
+      enddo
 
       ! write(*,*) "SAMI Proc, after bcast : ", irank
 
@@ -812,13 +812,13 @@ contains
 
       ! if (irank==0) write(*,*) "> SAMI bcasting - done!"
 
-    end if
+    endif
 
     if (iCommGITM /= MPI_COMM_NULL) then
 
       if (iproc == 0) &
         deallocate(GatLongitude_g0, GatLatitude_g0, GatAltitude_g0, GatGITMVars_g0)
-    end if
+    endif
 
     call MPI_BARRIER(iCommGlobal, iError)
 
@@ -897,7 +897,7 @@ contains
             if ((phi_xd00*phi_xd10*phi_yd0) < 0) then
               print *, '===>> Dist', phi_xd00, phi_xd10, phi_yd0
               stop
-            end if
+            endif
 
             phi_InterpFactors(1, iLon, iLat) = phi_xd00
             phi_InterpFactors(2, iLon, iLat) = phi_xd10
@@ -906,14 +906,14 @@ contains
             !call  interp_with_4points(phi_InterpFactors(1,iLon,iLat),&
             !             phi_InterpFactors(2,iLon,iLat),phi_InterpFactors(3,iLon,iLat),&
             !             data_inp2)
-          end if
+          endif
 
-        end do
-      end do
+        enddo
+      enddo
 
       IsFirstTime = .false.
 
-    end if
+    endif
 
     if (iproc == 0) &
       print *, '-- GITM Couping Init Potential Done!!!', iproc
@@ -951,9 +951,9 @@ contains
 
           pot(iLon, iLat) = data_inp
 
-        end if
-      end do
-    end do
+        endif
+      enddo
+    enddo
 
     if (iproc == 0) &
       print *, 'GITM Overwrite_potential Done!', iproc

--- a/src/ModFtaModel.f90
+++ b/src/ModFtaModel.f90
@@ -60,7 +60,7 @@ contains
     if (IsFirstTime) then
       iError = 0
       IsFirstTime = .false.
-    end if
+    endif
 
     call get_ae(GitmCurrentTime + TimeDelayHighLat, ae, iError)
     call get_au(GitmCurrentTime + TimeDelayHighLat, au, iError)
@@ -104,10 +104,10 @@ contains
           if (iMlat == 0) iMlat = nLatsFta
           ElectronEnergyFlux(iLon, iLat) = eFlux(iMlt, iMlat)
           ElectronAverageEnergy(iLon, iLat) = AveE(iMlt, iMlat)
-        end if
+        endif
 
-      end do
-    end do
+      enddo
+    enddo
 
     call end_timing("run_fta_model")
 
@@ -138,7 +138,7 @@ contains
     if (ierror .ne. 0) then
       write(*, *) "Could not find file : ", NameOfIndexFile
       return
-    end if
+    endif
 
     done = .false.
 
@@ -151,11 +151,11 @@ contains
       else
 
         done = .true.
-      end if
+      endif
 
       ipt = ipt + 1
 
-    end do
+    enddo
 
     read(LunIndices_, *) tmp
 
@@ -267,8 +267,8 @@ contains
         deallocate(tmp)
       else
         efs(i) = 0
-      end if
-    end do
+      endif
+    enddo
 
     idx = (/(i, i=1, nLatsFta, 1)/)
     lp1 = efs > 0
@@ -284,8 +284,8 @@ contains
         idxt2 = pack(idxt, idxt > i)
         ii = idxt2(1)
         efs(i) = (efs(i - 1) - efs(ii))*(i - ii)/(i - 1 - ii) + efs(ii)
-      end if
-    end do
+      endif
+    enddo
 
     deallocate(idxt)
     deallocate(idxt2)
@@ -328,7 +328,7 @@ contains
 
       kk_ef2(:, :, i) = k_k2(:, idx2)
       kb_ef2(:, :, i) = k_b2(:, idx2)
-    end do
+    enddo
 
     lats_fixed_grid = (/(i, i=0, nLatsFta - 1, 1)/)*dLat + minLat + dLat/2.0
 
@@ -355,13 +355,13 @@ contains
 
     do i = 1, 2
       if (trim(emis_type) == trim(emissions(i))) iEmission = i
-    end do
+    enddo
 
     if (iEmission == 0) then
       write(*, *) "Cant find emission : ", emis_type, " in emissions"
       write(*, *) "must stop"
       stop
-    end if
+    endif
 
     ALs = -ALs_n
 
@@ -400,7 +400,7 @@ contains
       mlat_p = mlat_b0 + cf_k_lat2*(ALs - AL_split)
       ef_p = ef_b0 + cf_k_ef2*(ALs - AL_split)
 
-    end if
+    endif
 
   end subroutine calc_emission_pattern
 
@@ -433,9 +433,9 @@ contains
           if ((ratio - c) > 0) &
             avee(iMlt, iLat) = 10.0**(log((ratio - c)/a)/lb)
 
-        end if
-      end do
-    end do
+        endif
+      enddo
+    enddo
 
   end subroutine calc_avee
 
@@ -469,7 +469,7 @@ contains
       call interp_to_lat_grid(lats_en, emission_en, emission_lat)
       lbhs(i, :) = emission_lat
 
-    end do
+    enddo
 
     eflux = lbhl/110.0
     call calc_avee(lbhl, lbhs, avee)

--- a/src/ModGITMImplicit.f90
+++ b/src/ModGITMImplicit.f90
@@ -125,12 +125,12 @@ contains
           EpsPointImpl = 1.e-6
         else
           EpsPointImpl = 1.e-9
-        end if
+        endif
         EpsPointImpl_V = 1.e-12
       else
         EpsPointImpl = 1.e-3
         EpsPointImpl_V = 1.e-6
-      end if
+      endif
 
       ! This call should allocate and set the iVarPointImpl_I index array,
       ! set IsPointImplMatrixSet=.true. if the dS/dU matrix is analytic,
@@ -143,14 +143,14 @@ contains
       if (.not. allocated(iVarPointImpl_I)) call stop_GITM( &
         'calc_user_sources did not set iVarPointImpl_I')
 
-    end if
+    endif
 
     ! The beta parameter is always one in the first stage
     if (iStep == 1) then
       BetaStage = 1.0
     else
       BetaStage = BetaPointImpl
-    end if
+    endif
 
     ! Store explicit update
     StateExpl_VC(1:nSpeciesAll) = SpeciesDensity(iLon, iLat, iAlt, :, iBlock) ! After  the solver
@@ -224,7 +224,7 @@ contains
             jvar = ijvar
             DsDu_VVC(jVar, iVar) = DsDu_VVC(jVar, iVar) + &
                                    (Source_VC(jVar) - Source0_VC(jVar))/Epsilon
-          end do
+          enddo
 
         else
 
@@ -253,21 +253,21 @@ contains
             DsDu_VVC(jVar, iVar) = DsDu_VVC(jVar, iVar) + &
                                    0.5*(Source1_VC(jVar) - Source_VC(jVar)) &
                                    /Epsilon
-          end do
+          enddo
 
-        end if
+        endif
 
         !Restore unperturbed state
         State_VGB(iVar) = State0_C
 
-      end do
+      enddo
 
       ! Restore unperturbed source
       Source_VC(1:nVar) = Source0_VC
 
       IsPointImplPerturbed = .false.
 
-    end if
+    endif
 
     ! Do the implicit update
 
@@ -281,7 +281,7 @@ contains
       Rhs_I(iIVar) = StateExpl_VC(iVar) &
                      - StateOld_VCB(iVar) &
                      + DtCell*Source_VC(iVar)
-    end do
+    enddo
 
     ! The matrix to be solved for is A = (I - beta*Dt*dS/dU)
     do iIVar = 1, nVar
@@ -290,11 +290,11 @@ contains
         jvar = ijvar
         Matrix_II(iIVar, iJVar) = -BetaStage*DtCell* &
                                   DsDu_VVC(iVar, jVar)
-      end do
+      enddo
       ! Add unit matrix
       Matrix_II(iIVar, iIVar) = Matrix_II(iIVar, iIVar) + 1.0
 
-    end do
+    enddo
 
     ! Solve the A.dU = RHS equation
     call linear_equation_solver(nVarPointImpl, Matrix_II, Rhs_I)
@@ -305,7 +305,7 @@ contains
       State_VGB(iVar) = &
         StateOld_VCB(iVar) + Rhs_I(iIVar)
 
-    end do
+    enddo
 
     ! Fix negative species densities
     State_VGB = max(1e-5, State_VGB)
@@ -369,9 +369,9 @@ contains
       LHSMAX = 0.00
       DO JL = 1, nVar
         IF (ABS(Matrix_VV(IL, JL)) .GT. LHSMAX) LHSMAX = ABS(Matrix_VV(IL, JL))
-      END DO
+      ENDDO
       SCALING(IL) = 1.00/LHSMAX
-    END DO
+    ENDDO
 
     !\
     ! Peform the LU decompostion using Crout's method.
@@ -381,39 +381,39 @@ contains
         TOTALSUM = Matrix_VV(IL, JL)
         DO KL = 1, IL - 1
           TOTALSUM = TOTALSUM - Matrix_VV(IL, KL)*Matrix_VV(KL, JL)
-        END DO
+        ENDDO
         Matrix_VV(IL, JL) = TOTALSUM
-      END DO
+      ENDDO
       LHSMAX = 0.00
       DO IL = JL, nVar
         TOTALSUM = Matrix_VV(IL, JL)
         DO KL = 1, JL - 1
           TOTALSUM = TOTALSUM - Matrix_VV(IL, KL)*Matrix_VV(KL, JL)
-        END DO
+        ENDDO
         Matrix_VV(IL, JL) = TOTALSUM
         LHSTEMP = SCALING(IL)*ABS(TOTALSUM)
         IF (LHSTEMP .GE. LHSMAX) THEN
           ILMAX = IL
           LHSMAX = LHSTEMP
-        END IF
-      END DO
+        ENDIF
+      ENDDO
       IF (JL .NE. ILMAX) THEN
         DO KL = 1, nVar
           LHSTEMP = Matrix_VV(ILMAX, KL)
           Matrix_VV(ILMAX, KL) = Matrix_VV(JL, KL)
           Matrix_VV(JL, KL) = LHSTEMP
-        END DO
+        ENDDO
         SCALING(ILMAX) = SCALING(JL)
-      END IF
+      ENDIF
       INDX(JL) = ILMAX
       IF (abs(Matrix_VV(JL, JL)) .EQ. 0.00) Matrix_VV(JL, JL) = TINY
       IF (JL .NE. nVar) THEN
         LHSTEMP = 1.00/Matrix_VV(JL, JL)
         DO IL = JL + 1, nVar
           Matrix_VV(IL, JL) = Matrix_VV(IL, JL)*LHSTEMP
-        END DO
-      END IF
-    END DO
+        ENDDO
+      ENDIF
+    ENDDO
 
     !\
     ! Peform the forward and back substitution to obtain
@@ -427,19 +427,19 @@ contains
       IF (II .NE. 0) THEN
         DO JL = II, IL - 1
           TOTALSUM = TOTALSUM - Matrix_VV(IL, JL)*Rhs_V(JL)
-        END DO
+        ENDDO
       ELSE IF (TOTALSUM .NE. 0.00) THEN
         II = IL
-      END IF
+      ENDIF
       Rhs_V(IL) = TOTALSUM
-    END DO
+    ENDDO
     DO IL = nVar, 1, -1
       TOTALSUM = Rhs_V(IL)
       DO JL = IL + 1, nVar
         TOTALSUM = TOTALSUM - Matrix_VV(IL, JL)*Rhs_V(JL)
-      END DO
+      ENDDO
       Rhs_V(IL) = TOTALSUM/Matrix_VV(IL, IL)
-    END DO
+    ENDDO
 
   end subroutine linear_equation_solver
 
@@ -454,7 +454,7 @@ contains
 
     do iVar = 1, nVar
       iVarPointImpl_I(iVar) = iVar
-    end do
+    enddo
 
   end subroutine init_pt_implicit
 

--- a/src/ModHmeModel.f90
+++ b/src/ModHmeModel.f90
@@ -92,11 +92,11 @@ contains
       iOutputError = 1
       write(*, *) 'No Hme Input file was found'
       return
-    end if
+    endif
 
     do i = 1, nHme
       read(LunIndices_, *) hme_arr(i), lpHme_slt(i)
-    end do
+    enddo
 
     close(LunIndices_)
 
@@ -129,7 +129,7 @@ contains
       iOutputError = 1
       write(*, *) 'No HME file was found. Please check the directory of data'
       return
-    end if
+    endif
 
     done = .false.
 
@@ -142,11 +142,11 @@ contains
       else
 
         done = .true.
-      end if
+      endif
 
       ipt = ipt + 1
 
-    end do
+    enddo
 
     read(LunIndices_, *) tmp
 
@@ -191,7 +191,7 @@ contains
       iOutputError = 1
       write(*, *) 'No tidi coef file found. Please check the directory of data'
       return
-    end if
+    endif
 
     done = .false.
 
@@ -204,15 +204,15 @@ contains
       else
 
         done = .true.
-      end if
+      endif
 
       ipt = ipt + 1
 
-    end do
+    enddo
 
     do i = 1, nHme
       read(LunIndices_, *) hme_arr(i), amp_fac_arr(i), pha_shift_arr(i)
-    end do
+    enddo
 
     close(LunIndices_)
 
@@ -236,7 +236,7 @@ contains
     else
       write(*, *) 'Please check hme_tmp', hme_tmp
       call stop_gitm("I am unsure of what to do now! Stopping!")
-    end if
+    endif
 
     if (hme_tmp(2:2) .eq. 'W') then
       read(hme_tmp(3:3), *) s
@@ -250,7 +250,7 @@ contains
     else
       write(*, *) 'Plese check hme_tmp', hme_tmp
       call stop_gitm("I am unsure of what to do now! Stopping!")
-    end if
+    endif
 
   end subroutine get_ns
 
@@ -285,11 +285,11 @@ contains
       ! Use the stored values:
       amp_fac_arr = Storage_Tidi_amp(:, 1)
       pha_shift_arr = Storage_Tidi_phase(:, 1)
-    end if
+    endif
 
     if (count(lpHme_slt) .eq. 0) then
       call stop_gitm('No HMEs found! Plese check selected calc_1tide_iday)')
-    end if
+    endif
 
     ! select HME component
     allocate(hmes_slt(count(lpHme_slt)))
@@ -341,14 +341,14 @@ contains
 
       if (count(lpHme_slt) .eq. 0) then
         call stop_gitm('No HMEs found! Plese check selected calc_1tide)')
-      end if
+      endif
       Storage_Tidi_amp(:, 1) = amp_fac_arr
       Storage_Tidi_phase(:, 1) = pha_shift_arr
     else
       ! Use the stored values:
       amp_fac_arr = Storage_Tidi_amp(:, 1)
       pha_shift_arr = Storage_Tidi_phase(:, 1)
-    end if
+    endif
 
     ! select HME component
     allocate(hmes_slt(count(lpHme_slt)))
@@ -378,7 +378,7 @@ contains
       ! Use the stored values:
       amp_fac_arr = Storage_Tidi_amp(:, 2)
       pha_shift_arr = Storage_Tidi_phase(:, 2)
-    end if
+    endif
 
     ! select HME component
     allocate(amps_slt(count(lpHme_slt)))
@@ -409,9 +409,9 @@ contains
                              (temp2(i, j, k) - temp1(i, j, k)) + temp1(i, j, k)
           dr_rho_3d(i, j, k) = (iday - day1)/(day2 - day1)* &
                                (dr_rho2(i, j, k) - dr_rho1(i, j, k)) + dr_rho1(i, j, k)
-        end do
-      end do
-    end do
+        enddo
+      enddo
+    enddo
 
   end subroutine calc_1tide
 
@@ -487,7 +487,7 @@ contains
         StorageR_amp(i, :, :) = dr_rho_a3
         StorageR_phase(i, :, :) = dr_rho_p3
 
-      end if
+      endif
 
       do j = 1, nLatsHme
         do k = 1, nAltHme ! alt = 95.0, 97.5, 100 km
@@ -522,14 +522,14 @@ contains
                    s*lon(ilon) - dr_rho_p3(j, k)*(n*omega) - &
                    pha_shift) &
                   *pi/180.0)
-          end do
-        end do
-      end do
+          enddo
+        enddo
+      enddo
       if (count(ieee_is_nan(geopt)) > 0) then
         write(*, *) ieee_is_nan(geopt)
         write(*, *) 'i,ilon,ilat,ialt,hme: ', i, ilon, j, k, hme_tmp
         call stop_gitm('nan was found in geopt, stop')
-      end if
+      endif
 
       if (ipt .eq. 1) then
         u_all = u
@@ -543,11 +543,11 @@ contains
         geopt_all = geopt_all + geopt
         temp_all = temp_all + temp
         dr_rho_all = dr_rho_all + dr_rho
-      end if
+      endif
 
       ipt = ipt + 1
 
-    end do
+    enddo
 
     IsReadInHme = .true.
 
@@ -591,7 +591,7 @@ contains
       dr_rho_a3(:, i) = dr_rho_a
       dr_rho_p3(:, i) = dr_rho_p
 
-    end do
+    enddo
 
   end subroutine hme_3alt
 

--- a/src/ModHwm.f90
+++ b/src/ModHwm.f90
@@ -63,7 +63,7 @@ subroutine hwm07(iyd, sec, alt, glat, glon, stl, f107a, f107, ap, w)
     w = qw + dw
   else
     w = qw
-  end if
+  endif
 
   return
 
@@ -189,12 +189,12 @@ subroutine HWMQT(IYD, SEC, ALT, GLAT, GLON, STL, F107A, F107, AP, W)
   if (modelinit) then
     call loadmodel(defaultdata)
     call HWMupdate(input, last, gfs, gfl, gfm, gvbar, gwbar, gbz, gbm, gzwght, glev, u, v)
-  end if
+  endif
 
   if (reset) then
     last = 1.0d-32
     reset = .false.
-  end if
+  endif
 
   call HWMupdate(input, last, gfs, gfl, gfm, gvbar, gwbar, gbz, gbm, gzwght, glev, u, v)
 
@@ -274,10 +274,10 @@ subroutine HWMupdate(input, last, fs, fl, fm, vbar, wbar, ebz, ebm, zwght, lev, 
       BB = dble(s)*AA
       fs(s, 1) = dcos(BB)
       fs(s, 2) = dsin(BB)
-    end do
+    enddo
     refresh(1:5) = .true.
     last(1) = input(1)
-  end if
+  endif
 
   ! Hourly time changes, tidal variations
 
@@ -289,11 +289,11 @@ subroutine HWMupdate(input, last, fs, fl, fm, vbar, wbar, ebz, ebm, zwght, lev, 
       CC = dble(l)*BB
       fl(l, 1) = dcos(CC)
       fl(l, 2) = dsin(CC)
-    end do
+    enddo
 
     refresh(3) = .true.
     last(2) = input(2)
-  end if
+  endif
 
   ! Longitudinal variations, planetary waves
 
@@ -303,10 +303,10 @@ subroutine HWMupdate(input, last, fs, fl, fm, vbar, wbar, ebz, ebm, zwght, lev, 
       BB = dble(m)*AA
       fm(m, 1) = dcos(BB)
       fm(m, 2) = dsin(BB)
-    end do
+    enddo
     refresh(2) = .true.
     last(3) = input(3)
-  end if
+  endif
 
   ! Latitude
 
@@ -318,14 +318,14 @@ subroutine HWMupdate(input, last, fs, fl, fm, vbar, wbar, ebz, ebm, zwght, lev, 
     refresh(3) = .true.
     refresh(4) = .true.
     last(4) = input(4)
-  end if
+  endif
 
   ! Altitude
 
   if (input(5) .ne. last(5)) then
     call vertwght(input(5), zwght, lev)
     last(5) = input(5)
-  end if
+  endif
 
   ! ====================================================================
   ! Linearize the VSH functions
@@ -370,7 +370,7 @@ subroutine HWMupdate(input, last, fs, fl, fm, vbar, wbar, ebz, ebm, zwght, lev, 
         bm(c) = 0.0d0            ! Cr
         bm(c + 1) = 0.5d0*vbar(n, 0)  ! Br
         c = c + 2
-      end do
+      enddo
 
       do s = 1, AMAXS                   ! seasonal variations
         cs = fs(s, 1)
@@ -391,12 +391,12 @@ subroutine HWMupdate(input, last, fs, fl, fm, vbar, wbar, ebz, ebm, zwght, lev, 
           bm(c + 2) = AA   ! Br
           bm(c + 3) = -BB   ! Bi
           c = c + 4
-        end do
-      end do
+        enddo
+      enddo
       cseason = c
     else
       c = cseason
-    end if
+    endif
 
     ! ---------------- Stationary planetary waves --------------------
 
@@ -424,7 +424,7 @@ subroutine HWMupdate(input, last, fs, fl, fm, vbar, wbar, ebz, ebm, zwght, lev, 
 
           c = c + 4
 
-        end do
+        enddo
 
         do s = 1, pmaxs
 
@@ -455,14 +455,14 @@ subroutine HWMupdate(input, last, fs, fl, fm, vbar, wbar, ebz, ebm, zwght, lev, 
 
             c = c + 8
 
-          end do
+          enddo
 
-        end do
+        enddo
         cwave = c
-      end do
+      enddo
     else
       c = cwave
-    end if
+    endif
 
     ! ---------------- Migrating Solar Tides ---------------------
 
@@ -490,7 +490,7 @@ subroutine HWMupdate(input, last, fs, fl, fm, vbar, wbar, ebz, ebm, zwght, lev, 
 
           c = c + 4
 
-        end do
+        enddo
 
         do s = 1, tmaxs
 
@@ -523,14 +523,14 @@ subroutine HWMupdate(input, last, fs, fl, fm, vbar, wbar, ebz, ebm, zwght, lev, 
             bm(c + 7) = -vb*sl*ss    ! Bis * (slss) * -vb
 
             c = c + 8
-          end do
+          enddo
 
-        end do
+        enddo
         ctide = c
-      end do
+      enddo
     else
       c = ctide
-    end if
+    endif
 
     ! ---------------- Non-Migrating Solar Tides ------------------
 
@@ -545,7 +545,7 @@ subroutine HWMupdate(input, last, fs, fl, fm, vbar, wbar, ebz, ebm, zwght, lev, 
     if (component(0)) u = u + zwght(b)*dot_product(bz(1:c), mparm(1:c, d))
     if (component(1)) v = v + zwght(b)*dot_product(bm(1:c), mparm(1:c, d))
 
-  end do
+  enddo
 
   return
 
@@ -575,7 +575,7 @@ subroutine loadmodel(datafile)
   if (allocated(vnode)) then
     deallocate(order, nb, vnode, mparm)
     deallocate(gfs, gfm, gfl, gvbar, gwbar, gzwght, gbz, gbm)
-  end if
+  endif
 
   open(unit=23, file=trim(datafile), form='unformatted', status='old')
   read(23) nbf, maxs, maxm, maxl, maxn, ncomp
@@ -592,7 +592,7 @@ subroutine loadmodel(datafile)
     read(23) order(1:ncomp, i)
     read(23) nb(i)
     read(23) mparm(1:nbf, i)
-  end do
+  enddo
   close(23)
 
   ! Set transition levels
@@ -663,7 +663,7 @@ subroutine vertwght(alt, wght, iz)
     wght(3) = bspline(p, nnode, vnode, iz + 2, alt)
     wght(4) = bspline(p, nnode, vnode, iz + 3, alt)
     return
-  end if
+  endif
   if (alt .gt. 250.0d0) then
     we(0) = 0.0d0
     we(1) = 0.0d0
@@ -676,7 +676,7 @@ subroutine vertwght(alt, wght, iz)
     we(2) = bspline(p, nnode, vnode, iz + 4, alt)
     we(3) = 0.0d0
     we(4) = 0.0d0
-  end if
+  endif
   wght(3) = dot_product(we, e1)
   wght(4) = dot_product(we, e2)
 
@@ -702,17 +702,17 @@ contains
     if ((i .eq. 0) .and. (u .eq. V(0))) then
       bspline = 1.d0
       return
-    end if
+    endif
 
     if ((i .eq. (m - p - 1)) .and. (u .eq. V(m))) then
       bspline = 1.d0
       return
-    end if
+    endif
 
     if (u .lt. V(i) .or. u .ge. V(i + p + 1)) then
       bspline = 0.d0
       return
-    end if
+    endif
 
     N = 0.0d0
     do j = 0, p
@@ -720,15 +720,15 @@ contains
         N(j) = 1.0d0
       else
         N(j) = 0.0d0
-      end if
-    end do
+      endif
+    enddo
 
     do k = 1, p
       if (N(0) .eq. 0.d0) then
         saved = 0.d0
       else
         saved = ((u - V(i))*N(0))/(V(i + k) - V(i))
-      end if
+      endif
       do j = 0, p - k
         Vleft = V(i + j + 1)
         Vright = V(i + j + k + 1)
@@ -739,9 +739,9 @@ contains
           temp = N(j + 1)/(Vright - Vleft)
           N(j) = saved + (Vright - u)*temp
           saved = (u - Vleft)*temp
-        end if
-      end do
-    end do
+        endif
+      enddo
+    enddo
 
     bspline = N(0)
 
@@ -765,7 +765,7 @@ contains
     if (u .ge. V(n + 1)) then
       findspan = n
       return
-    end if
+    endif
 
     low = p
     high = n + 1
@@ -776,9 +776,9 @@ contains
         high = mid
       else
         low = mid
-      end if
+      endif
       mid = (low + high)/2
-    end do
+    enddo
 
     findspan = mid
     return
@@ -859,7 +859,7 @@ subroutine vshbasis(maxn, maxo, theta, vbar, wbar)
     do n = 0, nmm - 1
       pb(n) = -cost
       td(n) = sf(n, m)
-    end do
+    enddo
     if (abs(p0i) .ge. abs(p1i)) then
       pb(0) = p0i
       r = -td(0)*pb(0)
@@ -869,18 +869,18 @@ subroutine vshbasis(maxn, maxo, theta, vbar, wbar)
       pb(1) = p1i
       r = -td(1)*pb(1)
       call tridiag(nmm - 2, r, td(1), pb(2), td(2))
-    end if
+    endif
     do n = m, nmax - 1
       i = nmax - n - 1
       pbar(n, m) = pb(i)
-    end do
-  end do
+    enddo
+  enddo
 
   ! Vector Spherical Harmonic Basis Functions from Pbar
 
   do n = 0, maxn
     vbar(n, 0) = -pbar(n, 1)
-  end do
+  enddo
 
   do m = 1, maxo
     mm1 = m - 1
@@ -889,8 +889,8 @@ subroutine vshbasis(maxn, maxo, theta, vbar, wbar)
       nm1 = n - 1
       vbar(n, m) = a(n, m)*pbar(n, mp1) + b(n, m)*pbar(n, mm1)
       wbar(n, m) = c(n, m)*pbar(nm1, mm1) + d(n, m)*pbar(nm1, mp1)
-    end do
-  end do
+    enddo
+  enddo
 
   return
 
@@ -914,7 +914,7 @@ contains
     if (n .le. 0 .and. m .le. 0) then
       lfpt = dsqrt(0.5d0)
       return
-    end if
+    endif
     cdt = dcos(theta + theta)
     sdt = dsin(theta + theta)
     if (mod(n, 2) .le. 0) then
@@ -928,7 +928,7 @@ contains
           st = sdt*ct + cdt*st
           ct = cth
           lfpt = lfpt + cp(k)*ct
-        end do
+        enddo
       else
         kdo = n/2
         do k = 1, kdo
@@ -936,8 +936,8 @@ contains
           st = sdt*ct + cdt*st
           ct = cth
           lfpt = lfpt + cp(k)*st
-        end do
-      end if
+        enddo
+      endif
     else
       kdo = (n + 1)/2
       ct = dcos(theta)
@@ -948,16 +948,16 @@ contains
           st = sdt*ct + cdt*st
           ct = cth
           lfpt = lfpt + cp(k)*ct
-        end do
+        enddo
       else
         do k = 1, kdo
           cth = cdt*ct - sdt*st
           st = sdt*ct + cdt*st
           ct = cth
           lfpt = lfpt + cp(k)*st
-        end do
-      end if
-    end if
+        enddo
+      endif
+    endif
     return
   end function lfpt
 
@@ -999,8 +999,8 @@ contains
           bih1 = qih - bih*b(i + 1)
           qih = -bih*c(i)
           bih = bih1
-        end if
-      end do
+        endif
+      enddo
     end select
     if (abs(bih) .ge. abs(c(1))) then
       q2 = qih/bih
@@ -1014,12 +1014,12 @@ contains
       b1 = rih/bih
       b(2) = (r - b(1)*b1)/c(1)
       b(1) = b1
-    end if
+    endif
     if (n - 3 .ge. 0) then
       do i = 3, n
         b(i) = -b(i)*b(i - 1) - c(i - 1)*b(i - 2)
-      end do
-    end if
+      enddo
+    endif
     return
   end subroutine tridiag
 
@@ -1056,8 +1056,8 @@ subroutine vshengineinit()
       fnpm = fnpm - 1.d0
       sf(i, m) = dsqrt(dble(fnmm*fnpm/(fnpn*(fnpn + 2.d0))))
       i = i + 1
-    end do
-  end do
+    enddo
+  enddo
 
   ! Theta indepedent scaling factors for calculation of Vbar and Wbar
   ! from Pbar.
@@ -1072,8 +1072,8 @@ subroutine vshengineinit()
       b(n, m) = nfac1*dsqrt(dble(npm*(nmm + 1)))
       c(n, m) = nfac2*dsqrt(dble(npm*(npm - 1)))
       d(n, m) = nfac2*dsqrt(dble(nmm*(nmm - 1)))
-    end do
-  end do
+    enddo
+  enddo
 
   return
 
@@ -1094,19 +1094,19 @@ contains
     if (m .gt. n) then
       cp(1) = 0.0d0
       return
-    end if
+    endif
     if (n .le. 0) then
       cp(1) = dsqrt(2.d0)
       return
-    end if
+    endif
     if (n .eq. 1) then
       if (m .eq. 0) then
         cp(1) = dsqrt(1.5d0)
       else
         cp(1) = dsqrt(0.75d0)
-      end if
+      endif
       return
-    end if
+    endif
     if (mod(n + m, 2) .eq. 0) then
       nmms2 = (n - m)/2
       fnum = dble(n + m + 1)
@@ -1117,7 +1117,7 @@ contains
       fnum = dble(n + m + 2)
       fnmh = dble(n - m + 2)
       pm1 = -1.0d0
-    end if
+    endif
     t1 = 1.0d0
     t2 = 1.0d0
     if (nmms2 .ge. 1) then
@@ -1126,14 +1126,14 @@ contains
         t1 = fnum*t1/fden
         fnum = fnum + 2.0d0
         fden = fden + 2.0d0
-      end do
-    end if
+      enddo
+    endif
     if (m .ne. 0) then
       do i = 1, m
         t2 = fnmh*t2/(fnmh + pm1)
         fnmh = fnmh + 2.0d0
-      end do
-    end if
+      enddo
+    endif
     if (mod(m/2, 2) .ne. 0) t1 = -t1
     cp2 = t1*dsqrt((dble(n) + 0.5d0)*t2)/(2.0d0**(n - 1))
     fnnp1 = dble(n*(n + 1))
@@ -1154,7 +1154,7 @@ contains
       c1 = (fk + 1.0d0)*(fk + 2.0d0) - fnnp1
       cp(l - 1) = -(b1*cp(l) + c1*cp(l + 1))/a1
       l = l - 1
-    end do
+    enddo
     return
   end subroutine alfk
 
@@ -1326,7 +1326,7 @@ subroutine dwm07b(mlt, mlat, kp, mmpwind, mzpwind)
     if (termarr(1, iterm) .ne. 999) termval_temp = termval_temp*kp_terms(termarr(1, iterm))
     if (termarr(2, iterm) .ne. 999) termval_temp = termval_temp*latwgt_terms
     termval(0:1, iterm) = termval_temp
-  end do
+  enddo
 
   !APPLY COEFFICIENTS
   mmpwind = dot_product(coeff, termval(0, 0:nterm - 1))
@@ -1434,10 +1434,10 @@ subroutine vsh_basis_init
           fn_map0(ifn)%irrotational = j
           fn_map0(ifn)%M = m
           fn_map0(ifn)%N = n
-        end do
-      end do
-    end do
-  end do
+        enddo
+      enddo
+    enddo
+  enddo
   nvshfn = ifn + 1
   allocate(fn_map1(0:nvshfn - 1))
   do ifn = 0, nvshfn - 1
@@ -1445,7 +1445,7 @@ subroutine vsh_basis_init
     fn_map1(ifn)%irrotational = fn_map0(ifn)%irrotational
     fn_map1(ifn)%M = fn_map0(ifn)%M
     fn_map1(ifn)%N = fn_map0(ifn)%N
-  end do
+  enddo
 
   !CREATE ARRAY THAT WILL CONTAIN VSH BASIS VALUES
   allocate(vsh_terms(0:1, 0:nvshfn - 1))
@@ -1470,12 +1470,12 @@ subroutine vsh_basis_init
   do m = 0, m_max
     cm(m) = dsqrt(1 + 0.5/dble(max(m, 1)))
     m_arr(m) = dble(m)
-  end do
+  enddo
   do n = 0, n_max
     n_arr(n) = dble(n)
     cn(n) = 1/dsqrt(dble(max(n, 1))*dble(n + 1))
     e0n(n) = dsqrt(dble(n*(n + 1))/2.0)
-  end do
+  enddo
   anm = 0
   bnm = 0
   fnm = 0
@@ -1485,8 +1485,8 @@ subroutine vsh_basis_init
       anm(m, n) = dsqrt(dble((2*n - 1)*(2*n + 1))/dble((n - m)*(n + m)))
       bnm(m, n) = dsqrt(dble((2*n + 1)*(n + m - 1)*(n - m - 1))/dble((n - m)*(n + m)*(2*n - 3)))
       fnm(m, n) = dsqrt(dble((n - m)*(n + m)*(2*n + 1))/dble(2*n - 1))
-    end do
-  end do
+    enddo
+  enddo
 
   return
 
@@ -1542,22 +1542,22 @@ subroutine vsh_basis(theta, phi)
   if (m_max .ge. 1) B(1, 1) = dsqrt(3D0)
   do m = 2, m_max
     B(m, m) = y*cm(m)*B(m - 1, m - 1)
-  end do
+  enddo
   do m = 1, m_max
     do n = m + 1, n_max
       B(m, n) = anm(m, n)*x*B(m, n - 1) - bnm(m, n)*B(m, n - 2)
-    end do
-  end do
+    enddo
+  enddo
 
   !CALCULATE d(Pnm) / d(theta)
   do m = 1, m_max
     do n = m, n_max
       A(m, n) = n_arr(n)*x*B(m, n) - fnm(m, n)*B(m, n - 1)
-    end do
-  end do
+    enddo
+  enddo
   do n = 1, n_max
     A(0, n) = -e0n(n)*y*B(1, n)
-  end do
+  enddo
 
   !CALCULATE m(Pnm) / sin(theta) AND APPLY SECTORAL NORMALIZATION
   do m = 0, m_max
@@ -1565,12 +1565,12 @@ subroutine vsh_basis(theta, phi)
       norm_m = 1D0/sqrt(2D0)  !Holmes and Featherstone norm factor adjusted to match Swartztrauber
     else
       norm_m = 0.5D0          !Holmes and Featherstone norm factor adjusted to match Swartztrauber
-    end if
+    endif
     do n = m, n_max
       B(m, n) = B(m, n)*m_arr(m)*cn(n)*norm_m
       A(m, n) = A(m, n)*cn(n)*norm_m
-    end do
-  end do
+    enddo
+  enddo
 
   !CALCULATE VECTOR SPHERICAL HARMONIC FUNCTIONS
 
@@ -1578,7 +1578,7 @@ subroutine vsh_basis(theta, phi)
     mz = dble(m)*z
     cosmz(m) = cos(mz)
     sinmz(m) = sin(mz)
-  end do
+  enddo
   do ifn = 0, nvshfn - 1
     m = fn_map1(ifn)%M
     n = fn_map1(ifn)%N
@@ -1597,7 +1597,7 @@ subroutine vsh_basis(theta, phi)
       vsh_terms(0, ifn) = real(B(m, n)*cosmz(m))  !Multiplies imag. pt of solen. coeff. (c)
       vsh_terms(1, ifn) = real(A(m, n)*sinmz(m))  !Multiplies imag. pt of solen. coeff. (c)
     end select
-  end do
+  enddo
 
   return
 
@@ -1785,11 +1785,11 @@ subroutine bspline_calc(nnode0, x0, node0, bspline, order, periodic)
     node = (/node0, node0(1:order) + perspan/)
     do i = 0, nnode0 + order - 1
       node1(i) = pershift(node(i), perint)
-    end do
+    enddo
   else
     node = node0
     node1 = node
-  end if
+  endif
 
   !COMPUTE SPLINES
   do i = 0, nnode - 2
@@ -1798,8 +1798,8 @@ subroutine bspline_calc(nnode0, x0, node0, bspline, order, periodic)
       if ((x .ge. node1(i)) .and. (x .lt. node1(i + 1))) bspline0(i) = 1.0
     else
       if ((x .ge. node1(i)) .or. (x .lt. node1(i + 1))) bspline0(i) = 1.0
-    end if
-  end do
+    endif
+  enddo
   do j = 2, k
     do i = 0, nnode - j - 1
       dx1 = x - node1(i)
@@ -1807,11 +1807,11 @@ subroutine bspline_calc(nnode0, x0, node0, bspline, order, periodic)
       if (periodic .eq. 1) then
         if (dx1 .lt. 0) dx1 = dx1 + perspan
         if (dx2 .lt. 0) dx2 = dx2 + perspan
-      end if
+      endif
       bspline0(i) = bspline0(i)*dx1/(node(i + j - 1) - node(i)) &
                     + bspline0(i + 1)*dx2/(node(i + j) - node(i + 1))
-    end do
-  end do
+    enddo
+  enddo
   bspline = bspline0(0:nspl - 1)
   deallocate(node, node1, bspline0)
 
@@ -1851,7 +1851,7 @@ function pershift(x, perint)
     offset = x - a
     offset1 = mod(offset, span)
     if (abs(offset1) .lt. tol) offset1 = 0
-  end if
+  endif
   pershift = a + offset1
   if ((offset .lt. 0) .and. (offset1 .ne. 0)) pershift = pershift + span
 
@@ -1894,12 +1894,12 @@ function ap_to_kp(ap0)
   i = 1
   do while (ap .gt. apgrid(i))
     i = i + 1
-  end do
+  enddo
   if (ap .eq. apgrid(i)) then
     ap_to_kp = kpgrid(i)
   else
     ap_to_kp = kpgrid(i - 1) + (ap - apgrid(i - 1))/(3.0*(apgrid(i) - apgrid(i - 1)))
-  end if
+  endif
 
   return
 

--- a/src/ModHwm14.f90
+++ b/src/ModHwm14.f90
@@ -82,7 +82,7 @@ subroutine hwm14(iyd, sec, alt, glat, glon, stl, f107a, f107, ap, path, w)
   if (ap(2) .ge. 0.0) then
     call dwm07(iyd, sec, alt, glat, glon, ap, dw)
     w = w + dw
-  end if
+  endif
 
   return
 
@@ -135,17 +135,17 @@ contains
         P(n, m) = y*en(n)*W(n, m)
         V(n, m) = narr(n)*x*W(n, m) - dnm(n, m)*W(n - 1, m)
         W(n - 2, m) = marr(m)*W(n - 2, m)
-      end do
+      enddo
       W(nmax - 1, m) = marr(m)*W(nmax - 1, m)
       W(nmax, m) = marr(m)*W(nmax, m)
       V(m, m) = x*W(m, m)
-    end do
+    enddo
     P(1, 0) = anm(1, 0)*x*P(0, 0)
     V(1, 0) = -P(1, 1)
     do n = 2, nmax
       P(n, 0) = anm(n, 0)*x*P(n - 1, 0) - bnm(n, 0)*P(n - 2, 0)
       V(n, 0) = -P(n, 1)
-    end do
+    enddo
 
     return
 
@@ -179,7 +179,7 @@ contains
       en(n) = dsqrt(dble(n*(n + 1)))
       anm(n, 0) = dsqrt(dble((2*n - 1)*(2*n + 1)))/narr(n)
       bnm(n, 0) = dsqrt(dble((2*n + 1)*(n - 1)*(n - 1))/dble(2*n - 3))/narr(n)
-    end do
+    enddo
     do m = 1, mmax0
       marr(m) = dble(m)
       cm(m) = dsqrt(dble(2*m + 1)/dble(2*m*m*(m + 1)))
@@ -188,8 +188,8 @@ contains
         bnm(n, m) = dsqrt(dble((2*n + 1)*(n + m - 1)*(n - m - 1)*(n - 2)*(n - 1)) &
                           /dble((n - m)*(n + m)*(2*n - 3)*n*(n + 1)))
         dnm(n, m) = dsqrt(dble((n - m)*(n + m)*(2*n + 1)*(n - 1))/dble((2*n - 1)*(n + 1)))
-      end do
-    end do
+      enddo
+    enddo
 
     return
 
@@ -345,7 +345,7 @@ subroutine initqwm(filename)
   if (allocated(vnode)) then
     deallocate(order, nb, vnode, mparm, tparm)
     deallocate(fs, fm, fl, zwght, bz, bm)
-  end if
+  endif
 
   call findandopen(filename, 23)
   read(23) nbf, maxs, maxm, maxl, maxn, ncomp
@@ -360,7 +360,7 @@ subroutine initqwm(filename)
     read(23) order(1:ncomp, i)
     read(23) nb(i)
     read(23) mparm(1:nbf, i)
-  end do
+  enddo
   read(23) e1, e2
   close(23)
 
@@ -369,7 +369,7 @@ subroutine initqwm(filename)
   allocate(tparm(nbf, 0:nlev))
   do i = 0, nlev - p + 1 - 2
     call parity(order(:, i), nb(i), mparm(:, i), tparm(:, i))
-  end do
+  enddo
 
   ! Set transition levels
 
@@ -431,7 +431,7 @@ contains
       tparm(c + 1) = -mparm(c + 1)
       mparm(c + 1) = 0.0
       c = c + 2
-    end do
+    enddo
     do s = 1, amaxs
       do n = 1, amaxn
         tparm(c) = 0.0
@@ -441,8 +441,8 @@ contains
         mparm(c + 2) = 0.0
         mparm(c + 3) = 0.0
         c = c + 4
-      end do
-    end do
+      enddo
+    enddo
 
     do m = 1, pmaxm
       do n = m, pmaxn
@@ -451,7 +451,7 @@ contains
         tparm(c + 2) = -mparm(c)
         tparm(c + 3) = -mparm(c + 1)
         c = c + 4
-      end do
+      enddo
       do s = 1, pmaxs
         do n = m, pmaxn
           tparm(c) = mparm(c + 2)
@@ -463,10 +463,10 @@ contains
           tparm(c + 6) = -mparm(c + 4)
           tparm(c + 7) = -mparm(c + 5)
           c = c + 8
-        end do
-      end do
+        enddo
+      enddo
 
-    end do
+    enddo
 
     do l = 1, tmaxl
       do n = l, tmaxn
@@ -475,7 +475,7 @@ contains
         tparm(c + 2) = -mparm(c)
         tparm(c + 3) = -mparm(c + 1)
         c = c + 4
-      end do
+      enddo
       do s = 1, tmaxs
         do n = l, tmaxn
           tparm(c) = mparm(c + 2)
@@ -487,9 +487,9 @@ contains
           tparm(c + 6) = -mparm(c + 4)
           tparm(c + 7) = -mparm(c + 5)
           c = c + 8
-        end do
-      end do
-    end do
+        enddo
+      enddo
+    enddo
 
     return
 
@@ -557,10 +557,10 @@ subroutine hwmqt(IYD, SEC, ALT, GLAT, GLON, STL, F107A, F107, AP, W)
       BB = dble(s)*AA
       fs(s, 1) = dcos(BB)
       fs(s, 2) = dsin(BB)
-    end do
+    enddo
     refresh(1:5) = .true.
     previous(1) = input(1)
-  end if
+  endif
 
   ! Hourly time changes, tidal variations
 
@@ -571,10 +571,10 @@ subroutine hwmqt(IYD, SEC, ALT, GLAT, GLON, STL, F107A, F107, AP, W)
       CC = dble(l)*BB
       fl(l, 1) = dcos(CC)
       fl(l, 2) = dsin(CC)
-    end do
+    enddo
     refresh(3) = .true.   ! tides
     previous(2) = input(2)
-  end if
+  endif
 
   ! Longitudinal variations, stationary planetary waves
 
@@ -584,10 +584,10 @@ subroutine hwmqt(IYD, SEC, ALT, GLAT, GLON, STL, F107A, F107, AP, W)
       BB = dble(m)*AA
       fm(m, 1) = dcos(BB)
       fm(m, 2) = dsin(BB)
-    end do
+    enddo
     refresh(2) = .true.   ! stationary planetary waves
     previous(3) = input(3)
-  end if
+  endif
 
   ! Latitude
 
@@ -598,14 +598,14 @@ subroutine hwmqt(IYD, SEC, ALT, GLAT, GLON, STL, F107A, F107, AP, W)
     refresh(1:4) = .true.
     glatalf = input(4)
     previous(4) = input(4)
-  end if
+  endif
 
   ! Altitude
 
   if (input(5) .ne. previous(5)) then
     call vertwght(input(5), zwght, lev)
     previous(5) = input(5)
-  end if
+  endif
 
   ! ====================================================================
   ! Calculate the VSH functions
@@ -628,7 +628,7 @@ subroutine hwmqt(IYD, SEC, ALT, GLAT, GLON, STL, F107A, F107, AP, W)
       if (component(0)) u = u + zwght(b)*dot_product(bz(1:c), mparm(1:c, d))
       if (component(1)) v = v + zwght(b)*dot_product(bz(1:c), tparm(1:c, d))
       cycle
-    end if
+    endif
 
     amaxs = order(1, d)
     amaxn = order(2, d)
@@ -648,7 +648,7 @@ subroutine hwmqt(IYD, SEC, ALT, GLAT, GLON, STL, F107A, F107, AP, W)
         bz(c) = -dsin(n*theta)   !
         bz(c + 1) = dsin(n*theta)
         c = c + 2
-      end do
+      enddo
       do s = 1, amaxs                   ! Seasonal variations
         cs = fs(s, 1)
         ss = fs(s, 2)
@@ -659,12 +659,12 @@ subroutine hwmqt(IYD, SEC, ALT, GLAT, GLON, STL, F107A, F107, AP, W)
           bz(c + 2) = sc*cs
           bz(c + 3) = -sc*ss
           c = c + 4
-        end do
-      end do
+        enddo
+      enddo
       cseason = c
     else
       c = cseason
-    end if
+    endif
 
     ! ---------------- Stationary planetary waves --------------------
 
@@ -680,7 +680,7 @@ subroutine hwmqt(IYD, SEC, ALT, GLAT, GLON, STL, F107A, F107, AP, W)
           bz(c + 2) = -wb*sm        ! Br * (sm) * -wb   C
           bz(c + 3) = -wb*cm        ! Bi * (cm) * -wb   D
           c = c + 4
-        end do
+        enddo
         do s = 1, pmaxs
           cs = fs(s, 1)
           ss = fs(s, 2)
@@ -696,13 +696,13 @@ subroutine hwmqt(IYD, SEC, ALT, GLAT, GLON, STL, F107A, F107, AP, W)
             bz(c + 6) = -wb*sm*ss        ! Brs * (smss) * -wb   G
             bz(c + 7) = -wb*cm*ss        ! Bis * (cmss) * -wb   H
             c = c + 8
-          end do
-        end do
+          enddo
+        enddo
         cwave = c
-      end do
+      enddo
     else
       c = cwave
-    end if
+    endif
 
     ! ---------------- Migrating Solar Tides ---------------------
 
@@ -718,7 +718,7 @@ subroutine hwmqt(IYD, SEC, ALT, GLAT, GLON, STL, F107A, F107, AP, W)
           bz(c + 2) = -wb*sl        ! Br * (sl) * -wb
           bz(c + 3) = -wb*cl        ! Bi * (cl) * -wb
           c = c + 4
-        end do
+        enddo
         do s = 1, tmaxs
           cs = fs(s, 1)
           ss = fs(s, 2)
@@ -734,13 +734,13 @@ subroutine hwmqt(IYD, SEC, ALT, GLAT, GLON, STL, F107A, F107, AP, W)
             bz(c + 6) = -wb*sl*ss        ! Brs * (slss) * -wb
             bz(c + 7) = -wb*cl*ss        ! Bis * (clss) * -wb
             c = c + 8
-          end do
-        end do
+          enddo
+        enddo
         ctide = c
-      end do
+      enddo
     else
       c = ctide
-    end if
+    endif
 
     ! ---------------- Non-Migrating Solar Tides ------------------
 
@@ -755,7 +755,7 @@ subroutine hwmqt(IYD, SEC, ALT, GLAT, GLON, STL, F107A, F107, AP, W)
     if (component(0)) u = u + zwght(b)*dot_product(bz(1:c), mparm(1:c, d))
     if (component(1)) v = v + zwght(b)*dot_product(bz(1:c), tparm(1:c, d))
 
-  end do
+  enddo
 
   w(1) = sngl(v)
   w(2) = sngl(u)
@@ -785,7 +785,7 @@ subroutine vertwght(alt, wght, iz)
     wght(3) = bspline(p, nnode, vnode, iz + 2_4, alt)
     wght(4) = bspline(p, nnode, vnode, iz + 3_4, alt)
     return
-  end if
+  endif
   if (alt .gt. alttns) then
     we(0) = 0.0d0
     we(1) = 0.0d0
@@ -798,7 +798,7 @@ subroutine vertwght(alt, wght, iz)
     we(2) = bspline(p, nnode, vnode, iz + 4_4, alt)
     we(3) = 0.0d0
     we(4) = 0.0d0
-  end if
+  endif
   wght(3) = dot_product(we, e1)
   wght(4) = dot_product(we, e2)
 
@@ -824,17 +824,17 @@ contains
     if ((i .eq. 0) .and. (u .eq. V(0))) then
       bspline = 1.d0
       return
-    end if
+    endif
 
     if ((i .eq. (m - p - 1)) .and. (u .eq. V(m))) then
       bspline = 1.d0
       return
-    end if
+    endif
 
     if (u .lt. V(i) .or. u .ge. V(i + p + 1)) then
       bspline = 0.d0
       return
-    end if
+    endif
 
     N = 0.0d0
     do j = 0, p
@@ -842,15 +842,15 @@ contains
         N(j) = 1.0d0
       else
         N(j) = 0.0d0
-      end if
-    end do
+      endif
+    enddo
 
     do k = 1, p
       if (N(0) .eq. 0.d0) then
         saved = 0.d0
       else
         saved = ((u - V(i))*N(0))/(V(i + k) - V(i))
-      end if
+      endif
       do j = 0, p - k
         Vleft = V(i + j + 1)
         Vright = V(i + j + k + 1)
@@ -861,9 +861,9 @@ contains
           temp = N(j + 1)/(Vright - Vleft)
           N(j) = saved + (Vright - u)*temp
           saved = (u - Vleft)*temp
-        end if
-      end do
-    end do
+        endif
+      enddo
+    enddo
 
     bspline = N(0)
 
@@ -887,7 +887,7 @@ contains
     if (u .ge. V(n + 1)) then
       findspan = n
       return
-    end if
+    endif
 
     low = p
     high = n + 1
@@ -898,9 +898,9 @@ contains
         high = mid
       else
         low = mid
-      end if
+      endif
       mid = (low + high)/2
-    end do
+    enddo
 
     findspan = mid
     return
@@ -973,12 +973,12 @@ subroutine dwm07(IYD, SEC, ALT, GLAT, GLON, AP, DW)
   !CONVERT AP TO KP
   if (ap(2) .ne. aplast) then
     kp = ap2kp(ap(2))
-  end if
+  endif
 
   !CONVERT GEO LAT/LON TO QD LAT/LON
   if ((glat .ne. glatlast) .or. (glon .ne. glonlast)) then
     call gd2qd(glat, glon, mlat, mlon, f1e, f1n, f2e, f2n)
-  end if
+  endif
 
   !COMPUTE QD MAGNETIC LOCAL TIME (LOW-PRECISION)
   day = real(mod(iyd, 1000))
@@ -986,7 +986,7 @@ subroutine dwm07(IYD, SEC, ALT, GLAT, GLON, AP, DW)
   if ((day .ne. daylast) .or. (ut .ne. utlast) .or. &
       (glat .ne. glatlast) .or. (glon .ne. glonlast)) then
     mlt = mltcalc(mlat, mlon, day, ut)
-  end if
+  endif
 
   !RETRIEVE DWM WINDS
   call dwm07b(mlt, mlat, kp, mmpwind, mzpwind)
@@ -1039,7 +1039,7 @@ subroutine dwm07b(mlt, mlat, kp, mmpwind, mzpwind)
   if (mlat .ne. mlatlast) then
     theta = (90.d0 - dble(mlat))*dtor
     call alfbasis(nmax, mmax, theta, dpbar, dvbar, dwbar)
-  end if
+  endif
 
   !COMPUTE MLT PART OF VSH TERMS
   if (mlt .ne. mltlast) then
@@ -1048,8 +1048,8 @@ subroutine dwm07b(mlt, mlat, kp, mmpwind, mzpwind)
       mphi = dble(m)*phi
       mltterms(m, 0) = dcos(mphi)
       mltterms(m, 1) = dsin(mphi)
-    end do
-  end if
+    enddo
+  endif
 
   !COMPUTE VSH TERMS
   if ((mlat .ne. mlatlast) .or. (mlt .ne. mltlast)) then
@@ -1071,14 +1071,14 @@ subroutine dwm07b(mlt, mlat, kp, mmpwind, mzpwind)
         vshterms(1, ivshterm + 2) = vshterms(0, ivshterm)
         vshterms(1, ivshterm + 3) = vshterms(0, ivshterm + 1)
         ivshterm = ivshterm + 4
-      end do
-    end do
-  end if
+      enddo
+    enddo
+  endif
 
   !COMPUTE KP TERMS
   if (kp .ne. kplast) then
     call kpspl3(kp, kpterms)
-  end if
+  endif
 
   !COMPUTE LATITUDINAL WEIGHTING TERM
   latwgtterm = latwgt2(mlat, mlt, kp, twidth)
@@ -1090,7 +1090,7 @@ subroutine dwm07b(mlt, mlat, kp, mmpwind, mzpwind)
     if (termarr(1, iterm) .ne. 999) termvaltemp = termvaltemp*kpterms(termarr(1, iterm))
     if (termarr(2, iterm) .ne. 999) termvaltemp = termvaltemp*latwgtterm
     termval(0:1, iterm) = termvaltemp(0:1)
-  end do
+  enddo
 
   !APPLY COEFFICIENTS
   mmpwind = dot_product(coeff, termval(0, 0:nterm - 1))
@@ -1126,12 +1126,12 @@ function ap2kp(ap0)
   i = 1
   do while (ap .gt. apgrid(i))
     i = i + 1
-  end do
+  enddo
   if (ap .eq. apgrid(i)) then
     ap2kp = kpgrid(i)
   else
     ap2kp = kpgrid(i - 1) + (ap - apgrid(i - 1))/(3.0*(apgrid(i) - apgrid(i - 1)))
-  end if
+  endif
 
   return
 
@@ -1184,7 +1184,7 @@ contains
     read(23) nmax, mmax, nterm, epoch, alt
     if (allocated(coeff)) then
       deallocate(coeff, xcoeff, ycoeff, zcoeff, sh, shgradtheta, shgradphi, normadj)
-    end if
+    endif
     allocate(coeff(0:nterm - 1, 0:2))
     read(23) coeff
     close(23)
@@ -1201,11 +1201,11 @@ contains
       xcoeff(iterm) = coeff(iterm, 0)
       ycoeff(iterm) = coeff(iterm, 1)
       zcoeff(iterm) = coeff(iterm, 2)
-    end do
+    enddo
 
     do n = 0, nmax
       normadj(n) = dsqrt(dble(n*(n + 1)))
-    end do
+    enddo
 
     nmaxqdc = nmax
     mmaxqdc = mmax
@@ -1246,7 +1246,7 @@ subroutine gd2qd(glatin, glon, qlat, qlon, f1e, f1n, f2e, f2n)
     theta = (90.d0 - glat)*dtor
     call alfbasis(nmax, mmax, theta, gpbar, gvbar, gwbar)
     glatalf = glat
-  end if
+  endif
   phi = dble(glon)*dtor
 
   i = 0
@@ -1255,7 +1255,7 @@ subroutine gd2qd(glatin, glon, qlat, qlon, f1e, f1n, f2e, f2n)
     shgradtheta(i) = gvbar(n, 0)*normadj(n)
     shgradphi(i) = 0
     i = i + 1
-  end do
+  enddo
   do m = 1, mmax
     mphi = dble(m)*phi
     cosmphi = dcos(mphi)
@@ -1268,8 +1268,8 @@ subroutine gd2qd(glatin, glon, qlat, qlon, f1e, f1n, f2e, f2n)
       shgradphi(i) = -gwbar(n, m)*normadj(n)*sinmphi
       shgradphi(i + 1) = gwbar(n, m)*normadj(n)*cosmphi
       i = i + 2
-    end do
-  end do
+    enddo
+  enddo
 
   x = dot_product(sh, xcoeff)
   y = dot_product(sh, ycoeff)
@@ -1337,7 +1337,7 @@ function mltcalc(qlat, qlon, day, ut)
   do n = 0, nmax
     sh(i) = spbar(n, 0)
     i = i + 1
-  end do
+  enddo
   do m = 1, mmax
     mphi = dble(m)*phi
     cosmphi = dcos(mphi)
@@ -1346,8 +1346,8 @@ function mltcalc(qlat, qlon, day, ut)
       sh(i) = spbar(n, m)*cosmphi
       sh(i + 1) = spbar(n, m)*sinmphi
       i = i + 2
-    end do
-  end do
+    enddo
+  enddo
   x = dot_product(sh, xcoeff)
   y = dot_product(sh, ycoeff)
   asunqlon = sngl(datan2(y, x)/dtor)
@@ -1381,13 +1381,13 @@ subroutine kpspl3(kp, kpterms)
   do i = 0, 6
     kpspl(i) = 0.0
     if ((x .ge. node(i)) .and. (x .lt. node(i + 1))) kpspl(i) = 1.0
-  end do
+  enddo
   do j = 2, 3
     do i = 0, 8 - j - 1
       kpspl(i) = kpspl(i)*(x - node(i))/(node(i + j - 1) - node(i)) &
                  + kpspl(i + 1)*(node(i + j) - x)/(node(i + j) - node(i + 1))
-    end do
-  end do
+    enddo
+  enddo
   kpterms(0) = kpspl(0) + kpspl(1)
   kpterms(1) = kpspl(2)
   kpterms(2) = kpspl(3) + kpspl(4)
@@ -1450,12 +1450,12 @@ subroutine findandopen(datafile, unitid)
       inquire(file=trim(hwmpath)//'/'//trim(datafile), exist=havefile)
       if (havefile) open(unit=unitid, &
                          file=trim(hwmpath)//'/'//trim(datafile), status='old', form='unformatted')
-    end if
+    endif
     if (.not. havefile) then
       inquire(file='../Meta/'//trim(datafile), exist=havefile)
       if (havefile) open(unit=unitid, &
                          file='../Meta/'//trim(datafile), status='old', form='unformatted')
-    end if
+    endif
   else
     inquire(file=trim(datafile), exist=havefile)
     if (havefile) open(unit=unitid, file=trim(datafile), status='old', access='stream')
@@ -1464,19 +1464,19 @@ subroutine findandopen(datafile, unitid)
       inquire(file=trim(hwmpath)//'/'//trim(datafile), exist=havefile)
       if (havefile) open(unit=unitid, &
                          file=trim(hwmpath)//'/'//trim(datafile), status='old', access='stream')
-    end if
+    endif
     if (.not. havefile) then
       inquire(file='../Meta/'//trim(datafile), exist=havefile)
       if (havefile) open(unit=unitid, &
                          file='../Meta/'//trim(datafile), status='old', access='stream')
-    end if
-  end if
+    endif
+  endif
 
   if (havefile) then
     return
   else
     print *, "Can not find file ", trim(datafile)
     stop
-  end if
+  endif
 
 end subroutine findandopen

--- a/src/ModInputs.f90
+++ b/src/ModInputs.f90
@@ -455,7 +455,7 @@ contains
 
     if (IsEarth) then
       PhotoElectronHeatingEfficiency = 0.06
-    end if
+    endif
 
     tSimulation = 0.0
 

--- a/src/ModLimiter.f90
+++ b/src/ModLimiter.f90
@@ -24,14 +24,14 @@ contains
         Limiter_mc = min(BetaLimiter*dUp, BetaLimiter*dDown, (dUp + dDown)*0.5)
       else
         Limiter_mc = 0.0
-      end if
+      endif
     else
       if (dDown < 0.0) then
         Limiter_mc = max(BetaLimiter*dUp, BetaLimiter*dDown, (dUp + dDown)*0.5)
       else
         Limiter_mc = 0.0
-      end if
-    end if
+      endif
+    endif
 
   end function Limiter_mc
 

--- a/src/ModMagTrace.f90
+++ b/src/ModMagTrace.f90
@@ -60,7 +60,7 @@ contains
       MMTaltLoc = -9.; 
       MMTlatLoc = -9.; 
       MMTlonLoc = -9.; 
-    end if
+    endif
 
     if (MMTDebug) write(*, *) iProc, ' MMT_Init:  ', nProcs, '  ', &
       nAlts, nLons, NLats, '  ', nBlocksMax, '  ', MaxMMTPoints
@@ -73,11 +73,11 @@ contains
         if (GeoLat > pi/2.) then
           GeoLat = pi - GeoLat
           GeoLon = mod(GeoLon + pi, twopi)
-        end if
+        endif
         if (GeoLat < -pi/2.) then
           GeoLat = -pi - GeoLat
           GeoLon = mod(GeoLon + pi, twopi)
-        end if
+        endif
         GeoLon = mod(GeoLon + twopi, twopi)
 
         GeoAlt = Altitude_GB(iLon, iLat, 1, iBlock)
@@ -98,7 +98,7 @@ contains
           if (iLoop > MaxMMTPoints) then
             write(*, *) 'ERROR: increase size of MaxMMTPoints, ', MaxMMTPoints
             stop
-          end if
+          endif
 
           ! save values
           LOCalt(iLoop, iLon, iLat, iBlock) = GeoAlt
@@ -108,7 +108,7 @@ contains
           else
             LOClat(iLoop, iLon, iLat, iBlock) = GeoLat
             LOClon(iLoop, iLon, iLat, iBlock) = GeoLon
-          end if
+          endif
 
           ! this "integral" is computed now as the length is the integral of 1.0 along fieldline
           LengthFieldLine(iLon, iLat) = LengthFieldLine(iLon, iLat) + MMTlen
@@ -133,20 +133,20 @@ contains
               if (GeoLat > pi/2.) then
                 GeoLat = pi - GeoLat
                 GeoLon = mod(GeoLon + pi, twopi)
-              end if
+              endif
               if (GeoLat < -pi/2.) then
                 GeoLat = -pi - GeoLat
                 GeoLon = mod(GeoLon + pi, twopi)
-              end if
+              endif
               GeoLon = mod(GeoLon, twopi)
               if (GeoLon < 0.) GeoLon = GeoLon + twopi
 
-            end if
-          end if
+            endif
+          endif
 
-        end do  !! while
+        enddo  !! while
 
-      end do; end do; end do
+      enddo; enddo; enddo
 
     iSize = MaxMMTPoints*(nLons + 4)*(nLats + 4)*nBlocks
     call MPI_ALLGATHER(LOCalt, iSize, MPI_REAL, MMTalt, iSize, MPI_REAL, iCommGITM, iError)
@@ -170,7 +170,7 @@ contains
                     if (IsFound) then
                       write(*, *) 'WARNING, BLOCK FOUND TWICE=] ', i, iLon, iLat, iBlock, k, &
                         '  ', GeoLat*180.0/pi, GeoLon*180.0/pi, GeoALT/1000.0
-                    end if
+                    endif
                     IsFound = .true.
                     iCount = iCount + 1
 
@@ -183,8 +183,8 @@ contains
                                                               (Latitude(m + 1, j) - Latitude(m, j))
                         jLat = m
                         exit
-                      end if
-                    end do
+                      endif
+                    enddo
                     do m = 0, nLons
                       if (GeoLon >= Longitude(m, j) .and. &
                           GeoLon < Longitude(m + 1, j)) then
@@ -193,8 +193,8 @@ contains
                                                               (Longitude(m + 1, j) - Longitude(m, j))
                         jLon = m
                         exit
-                      end if
-                    end do
+                      endif
+                    enddo
                     do m = 1, nAlts
                       if (GeoAlt >= Altitude_GB(jLon, jLat, m, j) .and. &
                           GeoAlt < Altitude_GB(jLon, jLat, m + 1, j)) then
@@ -202,22 +202,22 @@ contains
                           m + (GeoAlt - Altitude_GB(jLon, jLat, m, j))/ &
                           (Altitude_GB(jLon, jLat, m + 1, j) - Altitude_GB(jLon, jLat, m, j))
                         exit
-                      end if
-                    end do
+                      endif
+                    enddo
                     if (MMTlatLoc(i, iLon, iLat, iBlock, k) == -9 .or. &
                         MMTlonLoc(i, iLon, iLat, iBlock, k) == -9 .or. &
                         MMTaltLoc(i, iLon, iLat, iBlock, k) == -9) then
                       write(*, *) 'WARNING, BLOCK VALUE NOT VALID=] ', i, iLon, iLat, iBlock, k, &
                         '  ', GeoLat*180.0/pi, GeoLon*180.0/pi, GeoALT/1000.0
-                    end if
+                    endif
 
-                  end if
-                end do
-              end if
-            end do; end do
-          end do; end do; end do
+                  endif
+                enddo
+              endif
+            enddo; enddo
+          enddo; enddo; enddo
       if (MMTDebug) write(*, *) iProc, ' MMT_Init total processor fieldline length=', iCount*MMTlen
-    end if
+    endif
 
     if (MMTDebug) call MMT_Test
     if (MMTDebug) stop
@@ -275,7 +275,7 @@ contains
                     if (IsFound) then
                       write(*, *) 'WARNING, BLOCK FOUND TWICE=] ', i, iLon, iLat, iBlock, k, &
                         '  ', GeoLat*180.0/pi, GeoLon*180.0/pi, GeoALT/1000.0
-                    end if
+                    endif
                     IsFound = .true.
                     iCount = iCount + 1
 
@@ -288,8 +288,8 @@ contains
                                  (Latitude(m + 1, j) - Latitude(m, j))
                         jLat = m
                         exit
-                      end if
-                    end do
+                      endif
+                    enddo
                     do m = 0, nLons
                       if (GeoLon >= Longitude(m, j) .and. &
                           GeoLon < Longitude(m + 1, j)) then
@@ -298,8 +298,8 @@ contains
                                  (Longitude(m + 1, j) - Longitude(m, j))
                         jLon = m
                         exit
-                      end if
-                    end do
+                      endif
+                    enddo
                     do m = 1, nAlts
                       if (GeoAlt >= Altitude_GB(jLon, jLat, m, j) .and. &
                           GeoAlt < Altitude_GB(jLon, jLat, m + 1, j)) then
@@ -307,19 +307,19 @@ contains
                                  (GeoAlt - Altitude_GB(jLon, jLat, m, j))/ &
                                  (Altitude_GB(jLon, jLat, m + 1, j) - Altitude_GB(jLon, jLat, m, j))
                         exit
-                      end if
-                    end do
+                      endif
+                    enddo
                     if (latLoc == -9 .or. &
                         lonLoc == -9 .or. &
                         altLoc == -9) then
                       write(*, *) 'WARNING, BLOCK VALUE NOT VALID=] ', i, iLon, iLat, iBlock, k, &
                         '  ', GeoLat*180.0/pi, GeoLon*180.0/pi, GeoALT/1000.0
-                    end if
+                    endif
 
-                  end if
-                end do
-              end if
-            end if
+                  endif
+                enddo
+              endif
+            endif
             if (jBlk > 0) then
               !Set location
               i1 = floor(lonLoc)
@@ -349,13 +349,13 @@ contains
 
               PartialIntegral(iLon, iLat, iBlock, k) = &
                 PartialIntegral(iLon, iLat, iBlock, k) + InterpValue
-            end if
-          end do; end do
-        end do; end do; end do
+            endif
+          enddo; enddo
+        enddo; enddo; enddo
 
     if (.not. MMTSaveInterp) then
       if (MMTDebug) write(*, *) iProc, ' MMT_Integrate total processor fieldline length=', iCount*MMTlen
-    end if
+    endif
 
     iSize = (nLons + 4)*(nLats + 4)*nBlocks*nProcs
     call MPI_AllREDUCE(PartialIntegral, FullIntegral, iSize, MPI_REAL, MPI_SUM, iCommGITM, iError)

--- a/src/ModMars.f90
+++ b/src/ModMars.f90
@@ -673,7 +673,7 @@ contains
         InNDensityS(iiAlt, iAr_), &
         InIDensityS(iiAlt, ie_)
 
-    end do
+    enddo
 
     InNDensityS = Alog(inNDensityS)
     close(Unit=UnitTmp_)
@@ -732,7 +732,7 @@ contains
     DO NW = 1, L_NSPECTI
       Qexti(NW) = Qexti(NW)*factor
       Qscati(NW) = Qscati(NW)*factor
-    END DO
+    ENDDO
 
     PTOP = 10.0**PFGASREF(1)
 
@@ -831,7 +831,7 @@ contains
       WNOV(M) = 0.5*(BWNV(M + 1) + BWNV(M))
       DWNV(M) = BWNV(M + 1) - BWNV(M)
       WAVEV(M) = 1.0E+4/WNOV(M)
-    end do
+    enddo
 
 !C     Sum the solar flux, and write out the result.
 
@@ -839,7 +839,7 @@ contains
     do N = 1, L_NSPECTV
       SOLARF(N) = SOLAR(N)
       sum = sum + SOLARF(N)
-    end do
+    enddo
     write(6, '("Solar flux at 1AU = ",f7.2," W/M^2")') sum
 
 !C     Set up the wavelength dependent part of Rayleigh Scattering.
@@ -850,7 +850,7 @@ contains
       WL = WAVEV(N)
       TAURAY(N) = (8.7/grav)*(1.527*(1.0 + 0.013/wl**2)/wl**4)* &
                   scalep/P0
-    end do
+    enddo
 
   END SUBROUTINE SETSPV
 
@@ -951,7 +951,7 @@ contains
       WNOI(M) = 0.5*(BWNI(M + 1) + BWNI(M))
       DWNI(M) = BWNI(M + 1) - BWNI(M)
       WAVEI(M) = 1.0E+4/WNOI(M)
-    end do
+    enddo
 
 !C  For each IR wavelength interval, compute the integral of B(T), the
 !C  Planck function, divided by the wavelength interval, in cm-1.  The
@@ -969,10 +969,10 @@ contains
         do m = 1, 12
           y = bma*x(m) + bpa
           ans = ans + w(m)*c1/(y**5*(exp(c2/(y*T)) - 1.0D0))
-        end do
+        enddo
         planckir(NW, nt - 499) = ans*bma/(PI*DWNI(NW))
-      end do
-    END DO
+      enddo
+    ENDDO
 
   end subroutine setspi
 
@@ -1124,10 +1124,10 @@ contains
       Qscatv(n) = qsv1(n)
       IF (Qscatv(n) .GE. Qextv(n)) then
         Qscatv(n) = 0.99999*Qextv(n)
-      END IF
+      ENDIF
       WV(n) = Qscatv(n)/Qextv(n)
       GV(n) = gv1(n)
-    END DO
+    ENDDO
 
 !C     Fill the (INFRARED) arrays Qexti, Qscati, WI, GI
 
@@ -1136,10 +1136,10 @@ contains
       Qscati(n) = qsi1(n)
       IF (Qscati(n) .GE. Qexti(n)) then
         Qscati(n) = 0.99999*Qexti(n)
-      END IF
+      ENDIF
       WI(n) = Qscati(n)/Qexti(n)
       GI(n) = gi1(n)
-    END DO
+    ENDDO
 
 !C     Get CO2 k coefficients, and interpolate them to the finer
 !C     pressure grid.
@@ -1186,13 +1186,13 @@ contains
 
     do n = 1, L_PINT
       PINT(n) = PIN(n)
-    end do
+    enddo
 
 !C  Take log of the reference pressures
 
     do n = 1, L_NPREF
       pref(n) = LOG10(PGREF(n))
-    end do
+    enddo
 
 !C     Get CO2 k coefficients
 
@@ -1204,15 +1204,15 @@ contains
           DO l = 1, L_NSPECTV
             DO m = 1, L_NGAUSS
               read(25, *) co2v8(i, j, k, l, m)
-            END DO
-          END DO
-        END DO
-      END DO
-    END DO
+            ENDDO
+          ENDDO
+        ENDDO
+      ENDDO
+    ENDDO
 
     DO i = 1, L_NSPECTV
       read(25, *) fzerov(i)
-    END DO
+    ENDDO
     CLOSE(25)
 
     OPEN(unit=35, file='UA/DataIn/CO2H2O_IR_12_95_ASCII', ACTION='READ')
@@ -1223,15 +1223,15 @@ contains
           DO l = 1, L_NSPECTI
             DO m = 1, L_NGAUSS
               read(35, *) co2i8(i, j, k, l, m)
-            END DO
-          END DO
-        END DO
-      END DO
-    END DO
+            ENDDO
+          ENDDO
+        ENDDO
+      ENDDO
+    ENDDO
 
     DO i = 1, L_NSPECTI
       read(35, *) fzeroi(i)
-    END DO
+    ENDDO
     CLOSE(35)
 
 !!$      print*,'co2v8(3,4,1,3,2) = ',co2v8(3,4,1,3,2)
@@ -1254,21 +1254,21 @@ contains
                 co2v8(nt, np, nh, nw, ng) = log10(co2v8(nt, np, nh, nw, ng))
               else
                 co2v8(nt, np, nh, nw, ng) = -200.0
-              end if
-            end do
+              endif
+            enddo
 
             do nw = 1, L_NSPECTI
               if (co2i8(nt, np, nh, nw, ng) .gt. 1.0e-200) then
                 co2i8(nt, np, nh, nw, ng) = log10(co2i8(nt, np, nh, nw, ng))
               else
                 co2i8(nt, np, nh, nw, ng) = -200.0
-              end if
-            end do
+              endif
+            enddo
 
-          end do
-        end do
-      end do
-    end do
+          enddo
+        enddo
+      enddo
+    enddo
 
 !C  Interpolate the values:  first the IR
 
@@ -1292,7 +1292,7 @@ contains
             yi(4) = co2i8(nt, n + 3, nh, nw, ng)
             call lagrange(x, xi, yi, ans)
             co2i(nt, m, nh, nw, ng) = 10.0**ans
-          end do
+          enddo
 
           do n = 2, L_NPREF - 2
             do m = 1, 5
@@ -1308,8 +1308,8 @@ contains
               yi(4) = co2i8(nt, n + 2, nh, nw, ng)
               call lagrange(x, xi, yi, ans)
               co2i(nt, i, nh, nw, ng) = 10.0**ans
-            end do
-          end do
+            enddo
+          enddo
 
 !C  Now, get the last interval (P=1e+3 to 1e+4)
 
@@ -1328,16 +1328,16 @@ contains
             yi(4) = co2i8(nt, n + 1, nh, nw, ng)
             call lagrange(x, xi, yi, ans)
             co2i(nt, i, nh, nw, ng) = 10.0**ans
-          end do
+          enddo
 
 !C  Fill the last pressure point
 
           co2i(nt, L_PINT, nh, nw, ng) = 10.0**co2i8(nt, L_NPREF, nh, nw, ng)
 
-        end do
-      end do
-      end do
-    end do
+        enddo
+      enddo
+      enddo
+    enddo
 
 !C  Interpolate the values:  now the Visual
 
@@ -1361,7 +1361,7 @@ contains
             yi(4) = co2v8(nt, n + 3, nh, nw, ng)
             call lagrange(x, xi, yi, ans)
             co2v(nt, m, nh, nw, ng) = 10.0**ans
-          end do
+          enddo
 
           do n = 2, L_NPREF - 2
             do m = 1, 5
@@ -1377,8 +1377,8 @@ contains
               yi(4) = co2v8(nt, n + 2, nh, nw, ng)
               call lagrange(x, xi, yi, ans)
               co2v(nt, i, nh, nw, ng) = 10.0**ans
-            end do
-          end do
+            enddo
+          enddo
 
 !C  Now, get the last interval (P=1e+3 to 1e+4)
 
@@ -1397,16 +1397,16 @@ contains
             yi(4) = co2v8(nt, n + 1, nh, nw, ng)
             call lagrange(x, xi, yi, ans)
             co2v(nt, i, nh, nw, ng) = 10.0**ans
-          end do
+          enddo
 
 !C  Fill the last pressure point
 
           co2v(nt, L_PINT, nh, nw, ng) = 10.0**co2v8(nt, L_NPREF, nh, nw, ng)
 
-        end do
-      end do
-      end do
-    end do
+        enddo
+      enddo
+      enddo
+    enddo
 
   end subroutine laginterp
 

--- a/src/ModNewell.f90
+++ b/src/ModNewell.f90
@@ -64,7 +64,7 @@ contains
     do iLat = 1, nMLats/2 - 1
       area(:, iLat) = area(:, iLat)*cos((50.0 + 0.5*(iLat - 1))*pi/180.0)
       area(:, iLat + nMLats/2) = area(:, iLat)*cos((50.0 + 0.5*(iLat - 1))*pi/180.0)
-    end do
+    enddo
 
     call report("Newell Aurora Initialized", 2)
 
@@ -159,9 +159,9 @@ contains
         !call smooth(EnergyFluxIons)
         !call smooth(NumberFluxIons)
 
-      end if
+      endif
 
-    end if
+    endif
 
     do iLon = -1, nLons + 2
       do iLat = -1, nLats + 2
@@ -178,7 +178,7 @@ contains
             iMlat2 = iMlat - nMlats/2
           else
             iMlat2 = iMlat + nMlats/2
-          end if
+          endif
 
           iMlat2 = min(max(iMlat2, 1), nMlats)
 
@@ -198,7 +198,7 @@ contains
           else
             ElectronEnergyFlux(iLon, iLat) = &
               EnergyFluxDiff(iMlt, iMlat)
-          end if
+          endif
 
           ! Diffuse Number Flux
 
@@ -215,13 +215,13 @@ contains
 
           else
             numflux = NumberFluxDiff(iMlt, iMlat)
-          end if
+          endif
 
           if (numflux /= 0) then
             ElectronAverageEnergy(iLon, iLat) = &
               ElectronEnergyFlux(iLon, iLat)/numflux* &
               6.242e11/1000.0 ! ergs -> keV
-          end if
+          endif
 
           ! Mono Energy Flux
 
@@ -240,7 +240,7 @@ contains
           else
             ElectronEnergyFluxMono(iLon, iLat) = &
               EnergyFluxMono(iMlt, iMlat)
-          end if
+          endif
 
           ! Mono Number Flux
 
@@ -259,7 +259,7 @@ contains
           else
             ElectronNumberFluxMono(iLon, iLat) = &
               NumberFluxMono(iMlt, iMlat)
-          end if
+          endif
 
           ! Wave Energy Flux
 
@@ -278,7 +278,7 @@ contains
           else
             ElectronEnergyFluxWave(iLon, iLat) = &
               EnergyFluxWave(iMlt, iMlat)
-          end if
+          endif
 
           ! Wave Number Flux
 
@@ -297,11 +297,11 @@ contains
           else
             ElectronNumberFluxWave(iLon, iLat) = &
               NumberFluxWave(iMlt, iMlat)
-          end if
+          endif
 
-        end if
-      end do
-    end do
+        endif
+      enddo
+    enddo
 
     call end_timing("run_newell")
 
@@ -347,10 +347,10 @@ contains
             if (idfp > ndF) idfp = dfBin - 2
             ProbTotal(iMlt, iMlat) = &
               (Prob(idfm, iMlt, iMlat) + Prob(idfp, iMlt, iMlat))/2
-          end if
-        end if
-      end do
-    end do
+          endif
+        endif
+      enddo
+    enddo
 
   end subroutine calc_probability
 
@@ -430,11 +430,11 @@ contains
         if (iHem == 1) then
           iLatStart = nPl + 1
           iLatEnd = nMlats/2 - nPl - 1
-        end if
+        endif
         if (iHem == 2) then
           iLatStart = nMlats/2 + nPl + 1
           iLatEnd = nMlats - nPl - 1
-        end if
+        endif
 
         do iLat = iLatStart, iLatEnd
           if (value(iMlt, iLat) > 0.0) then
@@ -448,9 +448,9 @@ contains
                 if (value(iMa, iLa) > 0.0) then
                   ave = ave + value(iMa, iLa)
                   n = n + 1
-                end if
-              end do
-            end do
+                endif
+              enddo
+            enddo
             if (n > (2*nPL + 1)*(2*nPM + 1)/2) then
               ave = ave/n
               std = 0.0
@@ -461,9 +461,9 @@ contains
                 do iLa = iLat - nPL, iLat + nPL
                   if (value(iMa, iLa) > 0.0) then
                     std = std + (ave - value(iMa, iLa))**2
-                  end if
-                end do
-              end do
+                  endif
+                enddo
+              enddo
               std = sqrt(std/n)
               ! We only want to kill points that are 2 stdev ABOVE the average
               ! value.
@@ -474,12 +474,12 @@ contains
                 valueout(iMlt, iLat) = ave
               else
                 valueout(iMlt, iLat) = value(iMlt, iLat)
-              end if
-            end if
-          end if
-        end do
-      end do
-    end do
+              endif
+            endif
+          endif
+        enddo
+      enddo
+    enddo
 
     value = valueout
 
@@ -503,14 +503,14 @@ contains
     if (iError /= 0) then
       write(*, *) "Error in read_single_regression_file"
       call stop_gitm(trim(cFile)//" cannot be opened")
-    end if
+    endif
 
     read(iInputUnit_, *, iostat=iError) year0, day0, year1, day1, nFiles, sf0
 
     if (iError /= 0) then
       write(*, *) "Error in read_single_regression_file"
       call stop_gitm(trim(cFile)//" cannot read first line")
-    end if
+    endif
 
     do iMlt = 1, nMlts
       do iMlat = 1, nMlats
@@ -519,9 +519,9 @@ contains
         if (iError /= 0) then
           write(*, *) "Error in read_single_regression_file:", iMlt, iMlat
           call stop_gitm(trim(cFile)//" error reading file")
-        end if
-      end do
-    end do
+        endif
+      enddo
+    enddo
 
     close(iInputUnit_)
 
@@ -546,14 +546,14 @@ contains
     if (iError /= 0) then
       write(*, *) "Error in read_single_probability_file"
       call stop_gitm(trim(cFile)//" cannot be opened")
-    end if
+    endif
 
     read(iInputUnit_, *, iostat=iError) year0, day0, year1, day1, nFiles, sf0
 
     if (iError /= 0) then
       write(*, *) "Error in read_single_probability_file"
       call stop_gitm(trim(cFile)//" cannot read first line")
-    end if
+    endif
 
     do iMlt = 1, nMlts
       do iMlat = 1, nMlats
@@ -562,9 +562,9 @@ contains
         if (iError /= 0) then
           write(*, *) "Error in read_single_probability_file:", iMlt, iMlat
           call stop_gitm(trim(cFile)//" error reading file")
-        end if
-      end do
-    end do
+        endif
+      enddo
+    enddo
 
     do iMlt = 1, nMlts
       do iMlat = 1, nMlats
@@ -573,10 +573,10 @@ contains
           if (iError /= 0) then
             write(*, *) "Error in read_single_probability_file:", idF, iMlt, iMlat
             call stop_gitm(trim(cFile)//" error reading file")
-          end if
-        end do
-      end do
-    end do
+          endif
+        enddo
+      enddo
+    enddo
 
     close(iInputUnit_)
 

--- a/src/ModOvationSME.f90
+++ b/src/ModOvationSME.f90
@@ -133,7 +133,7 @@ contains
               6.242e11/1000.0 ! ergs -> keV
             if (ElectronAverageEnergy(iLon, iLat) > 100.0) &
               ElectronAverageEnergy(iLon, iLat) = 100.0
-          end if
+          endif
 
           ElectronEnergyFluxMono(iLon, iLat) = EnergyFluxMono(iMlt, iMlat)
           ElectronNumberFluxMono(iLon, iLat) = NumberFluxMono(iMlt, iMlat)
@@ -141,11 +141,11 @@ contains
           ElectronEnergyFluxWave(iLon, iLat) = EnergyFluxWave(iMlt, iMlat)
           ElectronNumberFluxWave(iLon, iLat) = NumberFluxWave(iMlt, iMlat)
 
-        end if
+        endif
 
-      end do
+      enddo
 
-    end do
+    enddo
 
     call end_timing("run_ovationsme")
 
@@ -221,7 +221,7 @@ contains
     inquire(file=cFile, EXIST=IsThere)
     if (.not. IsThere) then
       write(*, *) trim(cFile)//" cannot be found by read_ovationsm_files"
-    end if
+    endif
 
     iError = 0
 
@@ -239,7 +239,7 @@ contains
           Bsme = 0.0
           Bt1 = 0.0
           Bt2 = 0.0
-        end if
+        endif
 
         VarToRead(1, i + 1, j + 1) = B0
         VarToRead(2, i + 1, j + 1) = Bsme
@@ -247,9 +247,9 @@ contains
         VarToRead(4, i + 1, j + 1) = Bt2
         VarToRead(5, i + 1, j + 1) = npnts
 
-      end if
+      endif
 
-    end do
+    enddo
 
     close(iInputUnit_)
 

--- a/src/ModRCMR.f90
+++ b/src/ModRCMR.f90
@@ -132,7 +132,7 @@ contains
     allocate(index_lz_tec(lz))  !index_lz_tec picks the correct file for TEC assimilation
     do ii = 1, lz
       index_lz_tec(ii) = 1
-    end do
+    enddo
 
     W_Rz = 1.0
     W_Ru = 0.0
@@ -142,7 +142,7 @@ contains
       lv = lz
     ELSE
       lv = lz + lu
-    END IF
+    ENDIF
 
     nf_Nz = 3
     nf_Dz = 3
@@ -175,12 +175,12 @@ contains
 
     Do ii = 1, lz
       Nz(ii, ii) = 1
-    end do
+    enddo
 
     Do kkkk = 1, nf_u
       read(223, *, IOSTAT=TEC_read_IOStatus) Nu(1, kkkk)
       Nphi(1, kkkk + 1) = Nu(1, kkkk)
-    end Do
+    endDo
     write(*, *) 'Gf used in RCMR is', Nu
     close(223)
 
@@ -191,7 +191,7 @@ contains
     ELSE
       ltheta = Nc*lu*(lu + ly)
       lphi = Nc*(lu + ly)
-    END IF
+    ENDIF
 
   !! Regressor buffer initialization
     ALLOCATE(u_h(lu, NC))
@@ -208,7 +208,7 @@ contains
     ELSE
       ALLOCATE(Vphi(ly, NC))
       ALLOCATE(VphiVec(ly*NC, 1))
-    END IF
+    ENDIF
     u_h = 0
     z_h = 0
     y_h = 0
@@ -334,7 +334,7 @@ contains
     R = 0
     DO ii = 1, L
       R(ii, ii) = weight
-    END DO
+    ENDDO
   end subroutine identity
 
   subroutine init_markov_matrix
@@ -355,18 +355,18 @@ contains
       else
         write(*, *) "No Markov matrix for this output type: ", RCMROutType
         RCMRFlag = .false.
-      end if
+      endif
 
     elseif (RCMRInType == "TEC") then
       if (RCMROutType == "EDC") then
         !!write (*,*) "AGB RCMR WARNING: this is a test matrix"
         T = reshape((/0.15/), shape(T))
-      end if
+      endif
     else
       ! Markov matrix has not been established
       write(*, *) "No Markov matrix for this output type: ", RCMROutType
       RCMRFlag = .false.
-    end if
+    endif
   end subroutine init_markov_matrix
 
   subroutine init_rcmr
@@ -397,8 +397,8 @@ contains
         lat_p = 9
         lon_p = 1
         alt_p = 36
-      end if
-    end do
+      endif
+    enddo
 
     u_out = 0.0
     Sat_Proc = 0.0
@@ -417,12 +417,12 @@ contains
 
     do idty = 1, Nc*(ly + lu)
       P1(idty, idty) = reg_val
-    end do
+    enddo
 
     R2 = 0.0
     do idty = 1, lz
       R2(idty, idty) = 1.0
-    end do
+    enddo
 
     !ANKIT: Variables below this line are for EDC RCMR
     TEC_true = 0
@@ -457,12 +457,12 @@ contains
             TEC_lon(kkk, ii), TEC_lat(kkk, ii), TEC_true(kkk, ii)
           if (TEC_read_IOStatus < 0) exit
           kkk = kkk + 1
-        end do
+        enddo
         close(22)
         write(*, *) "TEC data read from ", TEC_file(ii)
         kkk = 1
-      end do
-    end if
+      enddo
+    endif
 
   end subroutine init_rcmr
 
@@ -484,7 +484,7 @@ contains
       read(111111, *, IOSTAT=read_stat) TEC_location(iii, 1), TEC_location(iii, 2)
       TEC_location(iii, 1) = TEC_location(iii, 1)*3.141592653589793/180
       TEC_location(iii, 2) = TEC_location(iii, 2)*3.141592653589793/180
-    end do
+    enddo
     close(111111)
     write(*, *) "> Read locations for TEC calculations"
 
@@ -529,32 +529,32 @@ contains
           write(filenameRCMR1, "(A14,I1,A4)") "tec_data_RCMR_", iii, '.dat'
         else
           write(filenameRCMR1, "(A14,I2,A4)") "tec_data_RCMR_", iii, '.dat'
-        end if
+        endif
 
         inquire(file=filenameRCMR1, exist=exist)
         if (exist) then
           open(unit=111111 + iii, file=trim(filenameRCMR1), status="old", position="append", action='write')
         else
           open(unit=111111 + iii, file=trim(filenameRCMR1), status="new", action='write')
-        end if
+        endif
 
-      end do
+      enddo
     elseif (RCMRrun == 'TRUTH') then
       do iii = 1, points! while (iii < points+1)
         if (iii < 10) then
           write(filename1, "(A9,I1,A4)") "tec_data_", iii, '.dat'
         else
           write(filename1, "(A9,I2,A4)") "tec_data_", iii, '.dat'
-        end if
+        endif
         inquire(file=filename1, exist=exist)
         if (exist) then
           open(unit=111111 + iii, file=trim(filename1), status="old", position="append", action='write')
         else
           open(unit=111111 + iii, file=trim(filename1), status="new", action='write')
-        end if
+        endif
 
-      end do
-    end if
+      enddo
+    endif
 
    !! Ankit 24Jan2015 - Added TEC writing at preset locations
     if ((iproc == TEC_proc) .AND. .true.) then
@@ -568,14 +568,14 @@ contains
           iTimeArray(4), iTimeArray(5), iTimeArray(6), &
           iTimeArray(7), TEC_location(ii_tec, 1)*180/3.141592653589793, &
           TEC_location(ii_tec, 2)*180/3.141592653589793, VTEC_interp, sza_test
-      end do
-    end if
+      enddo
+    endif
 
     !  close TEC files - ANKIT
     do while (ii_tec < points + 1)
       close(111111 + ii_tec)
       ii_tec = ii_tec + 1
-    end do
+    enddo
 
   end subroutine write_TEC_data
 

--- a/src/ModReadGitm3d.f90
+++ b/src/ModReadGitm3d.f90
@@ -128,9 +128,9 @@ contains
 
       else
         OutData(iPoint, :) = -1.0e32
-      end if
+      endif
 
-    end do
+    enddo
 
   end subroutine GitmGetData
 
@@ -167,14 +167,14 @@ contains
             i = 2
             do while (GitmLons(i) <= InLons(iPoint))
               i = i + 1
-            end do
-          end if
+            enddo
+          endif
           GitmLonsIndex(iPoint) = i
           GitmLonsFactor(iPoint) = &
             (GitmLons(i) - InLons(iPoint))/ &
             (GitmLons(i) - GitmLons(i - 1))
-        end if
-      end if
+        endif
+      endif
 
       ! Lats
       if (InLats(iPoint) < GitmLats(1)) then
@@ -189,14 +189,14 @@ contains
             i = 2
             do while (GitmLats(i) <= InLats(iPoint))
               i = i + 1
-            end do
-          end if
+            enddo
+          endif
           GitmLatsIndex(iPoint) = i
           GitmLatsFactor(iPoint) = &
             (GitmLats(i) - InLats(iPoint))/ &
             (GitmLats(i) - GitmLats(i - 1))
-        end if
-      end if
+        endif
+      endif
 
       ! Alts
       if (InAlts(iPoint) < GitmAlts(1)) then
@@ -211,15 +211,15 @@ contains
             i = 2
             do while (GitmAlts(i) <= InAlts(iPoint))
               i = i + 1
-            end do
-          end if
+            enddo
+          endif
           GitmAltsIndex(iPoint) = i
           GitmAltsFactor(iPoint) = &
             (GitmAlts(i) - InAlts(iPoint))/ &
             (GitmAlts(i) - GitmAlts(i - 1))
-        end if
-      end if
-    end do
+        endif
+      endif
+    enddo
 
   end subroutine GitmSetGrid
 
@@ -264,17 +264,17 @@ contains
       iError = 1
       write(*, *) "Requested time is before first file!"
       return
-    end if
+    endif
     if (GitmFileTimes(nGitmFiles) < InputTime) then
       iError = 1
       write(*, *) "Requested time is after last file!"
       return
-    end if
+    endif
 
     iGitmIndex = 1
     do while (GitmFileTimes(iGitmIndex) <= InputTime .and. iGitmIndex < nGitmFiles)
       iGitmIndex = iGitmIndex + 1
-    end do
+    enddo
 
     rGitmFactor = (GitmFileTimes(iGitmIndex) - InputTime)/ &
                   (GitmFileTimes(iGitmIndex) - GitmFileTimes(iGitmIndex - 1))
@@ -293,7 +293,7 @@ contains
 
       iGitmIndexOld = iGitmIndex
 
-    end if
+    endif
 
     GitmDataAtTime = &
       rGitmFactor*GitmDataTwoFiles(1, :, :, :, :) + &
@@ -324,7 +324,7 @@ contains
       read(iGitmUnit, '(a)', iostat=iError) Dummy
       write(*, *) 'dummy : ', dummy
       if (iError == 0) nGitmFiles = nGitmFiles + 1
-    end do
+    enddo
     close(iGitmUnit)
 
     if (nGitmFiles == 0) then
@@ -337,10 +337,10 @@ contains
       do while (iError == 0)
         read(iGitmUnit, '(a)', iostat=iError) Dummy
         if (iError == 0) nGitmFiles = nGitmFiles + 1
-      end do
+      enddo
       close(iGitmUnit)
       iGitmFileType = i3dlst_
-    end if
+    endif
 
     write(*, *) "nGitmFiles : ", nGitmFiles
     write(*, *) "Filetype : ", iGitmFileType
@@ -350,7 +350,7 @@ contains
       read(iGitmUnit, '(a)', iostat=iError) GitmFileList(iFile)
       call GetGitmTime(GitmFileList(iFile), time)
       GitmFileTimes(iFile) = time
-    end do
+    enddo
     close(iGitmUnit)
 
     if (nGitmFiles == 0) iError = 1
@@ -379,7 +379,7 @@ contains
     read(iInputUnit_) nVars
     do iVar = 1, nVars
       read(iInputUnit_) Dummy
-    end do
+    enddo
 
     read(iInputUnit_) iYear, iMonth, iDay, iHour, iMinute, iSecond, iMilli
     iTime = (/iYear, iMonth, iDay, iHour, iMinute, iSecond, iMilli/)
@@ -412,7 +412,7 @@ contains
       read(iInputUnit_) nVarsGitm
       do iVar = 1, nVarsGitm
         read(iInputUnit_) GitmVariables(iVar)
-      end do
+      enddo
 
       read(iInputUnit_) iYear, iMonth, iDay, iHour, iMinute, iSecond, iMilli
 
@@ -442,7 +442,7 @@ contains
       allocate(GitmDataAtTime(nVarsGitm, nLonsGitm, nLatsGitm, nAltsGitm))
       allocate(GitmDataDummy(nVarsGitm, nLonsGitm, nLatsGitm, nAltsGitm))
 
-    end if
+    endif
 
   end subroutine GetGitmGeneralHeaderInfo
 
@@ -475,17 +475,17 @@ contains
       read(iInputUnit_) nVars
       do iVar = 1, nVars
         read(iInputUnit_) Dummy
-      end do
+      enddo
 
       read(iInputUnit_) iYear, iMonth, iDay, iHour, iMinute, iSecond, iMilli
 
       do iVar = 1, nVars
         read(iInputUnit_) GitmDataDummy(iVar, :, :, :)
-      end do
+      enddo
 
       close(iInputUnit_)
 
-    end if
+    endif
 
   end subroutine GitmReadFile
 
@@ -540,8 +540,8 @@ contains
         nyear = itime(1) - 65
       else
         nyear = itime(1) + 100 - 65
-      end if
-    end if
+      endif
+    endif
     nleap = nyear/4
 
     nmonth = itime(2) - 1
@@ -550,7 +550,7 @@ contains
 
     do i = 1, nmonth
       nday = nday + dayofmon(i)
-    end do
+    enddo
 
     nday = nday + itime(3) - 1
     nhour = itime(4)

--- a/src/ModSami.f90
+++ b/src/ModSami.f90
@@ -151,17 +151,17 @@ contains
           SamiVariables(iVar) = trim(line)
           iVar = iVar + 1
           write(*, *) 'Dir:', trim(SamiDir)
-        end do
+        enddo
         nVarsSami = iVar - 2
 
       case ("#VARFILES")
         do iVar = 1, nVarsSami
           read(iSamiUnit, '(a)', iostat=iError) line
           SamiFileList(iVar) = line
-        end do
+        enddo
       end select
 
-    end do
+    enddo
 
     close(iSamiUnit)
 
@@ -169,20 +169,20 @@ contains
       if (trim(SamiVariables(iVar)) == 'time') then
         write(*, *) 'Reading Time File : ', trim(SamiFileList(iVar))
         call ReadSamiTimeFile(SamiFileList(iVar))
-      end if
+      endif
       if (trim(SamiVariables(iVar)) == 'lon') then
         write(*, *) 'Reading Lon File : ', trim(SamiFileList(iVar))
         call ReadSamiLonFile(SamiFileList(iVar))
-      end if
+      endif
       if (trim(SamiVariables(iVar)) == 'lat') then
         write(*, *) 'Reading Lat File : ', trim(SamiFileList(iVar))
         call ReadSamiLatFile(SamiFileList(iVar))
-      end if
+      endif
       if (trim(SamiVariables(iVar)) == 'alt') then
         write(*, *) 'Reading Alt File : ', trim(SamiFileList(iVar))
         call ReadSamiAltFile(SamiFileList(iVar))
-      end if
-    end do
+      endif
+    enddo
 
     allocate(SamiDataDummy(nLatsSami - 2, nAltsSami, nLonsSami - 2))
     allocate(SamiDataOneTime(nVarsSami - 4, nLonsSami, nLatsSami, nAltsSami))
@@ -216,7 +216,7 @@ contains
       SamiTimes(iT) = tHours*3600.0 + SamiStartTime
       iT = iT + 1
 
-    end do
+    enddo
 
     nTimesSami = iT - 1
 
@@ -245,7 +245,7 @@ contains
     do while (iError == 0)
       read(iSamiUnit, *, iostat=iError) lon
       iLon = iLon + 1
-    end do
+    enddo
     ! Need to add a 0 and 360, so add 2 to nLons
     nLonsSami = iLon - 2 + 2
     close(iSamiUnit)
@@ -258,7 +258,7 @@ contains
     do iLon = 2, nLonsSami - 1
       read(iSamiUnit, *, iostat=iError) lon
       SamiLons(iLon) = lon
-    end do
+    enddo
     close(iSamiUnit)
     SamiLons(nLonsSami) = 360.0
 
@@ -284,7 +284,7 @@ contains
     do while (iError == 0)
       read(iSamiUnit, *, iostat=iError) lat
       iLat = iLat + 1
-    end do
+    enddo
     ! Need to add a -90 and 90, so add 2 to nLats
     nLatsSami = iLat - 2 + 2
     close(iSamiUnit)
@@ -297,7 +297,7 @@ contains
     do iLat = 2, nLatsSami - 1
       read(iSamiUnit, *, iostat=iError) lat
       SamiLats(iLat) = lat
-    end do
+    enddo
     close(iSamiUnit)
     SamiLats(nLatsSami) = 90.0
 
@@ -323,7 +323,7 @@ contains
     do while (iError == 0)
       read(iSamiUnit, *, iostat=iError) alt
       iAlt = iAlt + 1
-    end do
+    enddo
     nAltsSami = iAlt - 2
     close(iSamiUnit)
 
@@ -334,7 +334,7 @@ contains
     do iAlt = 1, nAltsSami
       read(iSamiUnit, *, iostat=iError) alt
       SamiAlts(iAlt) = alt
-    end do
+    enddo
     close(iSamiUnit)
 
   end subroutine ReadSamiAltFile
@@ -357,11 +357,11 @@ contains
     iError = 0
     do iT = 1, iTime
       read(iSamiUnit, iostat=iError) SamiDataDummy
-    end do
+    enddo
     if (iError > 0) then
       write(*, *) 'Error Reading Sami File : ', iError
       write(*, *) 'File : ', trim(SamiDir)//'/'//trim(infile)
-    end if
+    endif
     close(iSamiUnit)
 
   end subroutine ReadSami
@@ -382,9 +382,9 @@ contains
         do iAlt = 1, nAltsSami
           SamiDataOneTime(iVar, iLon, iLat, iAlt) = &
             SamiDataDummy(iLat - 1, iAlt, iLon - 1)
-        end do
-      end do
-    end do
+        enddo
+      enddo
+    enddo
 
     ! South Pole - average all longitudes
     iLat = 1
@@ -392,7 +392,7 @@ contains
       SamiDataOneTime(iVar, :, iLat, iAlt) = &
         sum(SamiDataOneTime(iVar, 2:nLonsSami - 1, iLat + 1, iAlt))/ &
         (nLonsSami - 2)
-    end do
+    enddo
 
     ! North Pole - average all longitudes
     iLat = nLatsSami
@@ -400,7 +400,7 @@ contains
       SamiDataOneTime(iVar, :, iLat, iAlt) = &
         sum(SamiDataOneTime(iVar, 2:nLonsSami - 1, iLat - 1, iAlt))/ &
         (nLonsSami - 2)
-    end do
+    enddo
 
     do iLat = 2, nLatsSami - 1
       do iAlt = 1, nAltsSami
@@ -409,8 +409,8 @@ contains
            SamiDataOneTime(iVar, nLonsSami - 1, iLat, iAlt))/2
         SamiDataOneTime(iVar, nLonsSami, iLat, iAlt) = &
           SamiDataOneTime(iVar, 1, iLat, iAlt)
-      end do
-    end do
+      enddo
+    enddo
 
   end subroutine FileSamiData
 
@@ -428,7 +428,7 @@ contains
     do iVar = 5, nVarsSami
       call ReadSami(SamiFileList(iVar), iTime)
       call FileSamiData(iVar - 4)
-    end do
+    enddo
 
   end subroutine ReadSamiOneTime
 
@@ -449,17 +449,17 @@ contains
       iError = 1
       write(*, *) "Requested time is before first file!"
       return
-    end if
+    endif
     if (SamiTimes(nTimesSami) < InputTime) then
       iError = 1
       write(*, *) "Requested time is after last file!"
       return
-    end if
+    endif
 
     iSamiIndex = 1
     do while (SamiTimes(iSamiIndex) <= InputTime .and. iSamiIndex < nTimesSami)
       iSamiIndex = iSamiIndex + 1
-    end do
+    enddo
 
     rSamiFactor = (SamiTimes(iSamiIndex) - InputTime)/ &
                   (SamiTimes(iSamiIndex) - SamiTimes(iSamiIndex - 1))
@@ -477,7 +477,7 @@ contains
 
       iSamiIndexOld = iSamiIndex
 
-    end if
+    endif
 
     SamiDataAtTime = &
       rSamiFactor*SamiDataTwoTimes(1, :, :, :, :) + &
@@ -522,9 +522,9 @@ contains
 
       else
         OutData(iPoint, :) = -1.0e32
-      end if
+      endif
 
-    end do
+    enddo
 
   end subroutine SamiGetData
 
@@ -551,13 +551,13 @@ contains
       if (SamiInLats(iPoint) < -90.0) then
         SamiInLats(iPoint) = -180.0 - SamiInLats(iPoint)
         SamiInLons(iPoint) = SamiInLons(iPoint) + 180.0
-      end if
+      endif
       if (SamiInLats(iPoint) > 90.0) then
         SamiInLats(iPoint) = 180.0 - SamiInLats(iPoint)
         SamiInLons(iPoint) = SamiInLons(iPoint) + 180.0
-      end if
+      endif
       SamiInLons(iPoint) = mod(SamiInLons(iPoint) + 360, 360.0)
-    end do
+    enddo
 
     do iPoint = 1, nPointsToGetSami
 
@@ -574,14 +574,14 @@ contains
             i = 2
             do while (SamiLons(i) <= SamiInLons(iPoint))
               i = i + 1
-            end do
-          end if
+            enddo
+          endif
           SamiLonsIndex(iPoint) = i
           SamiLonsFactor(iPoint) = &
             (SamiLons(i) - SamiInLons(iPoint))/ &
             (SamiLons(i) - SamiLons(i - 1))
-        end if
-      end if
+        endif
+      endif
 
       ! Lats
       if (SamiInLats(iPoint) < SamiLats(1)) then
@@ -596,14 +596,14 @@ contains
             i = 2
             do while (SamiLats(i) <= SamiInLats(iPoint))
               i = i + 1
-            end do
-          end if
+            enddo
+          endif
           SamiLatsIndex(iPoint) = i
           SamiLatsFactor(iPoint) = &
             (SamiLats(i) - SamiInLats(iPoint))/ &
             (SamiLats(i) - SamiLats(i - 1))
-        end if
-      end if
+        endif
+      endif
 
       ! Alts
       if (InAlts(iPoint) < SamiAlts(1)) then
@@ -623,23 +623,23 @@ contains
             i = 2
             do while (SamiAlts(i) <= InAlts(iPoint))
               i = i + 1
-            end do
-          end if
+            enddo
+          endif
           SamiAltsIndex(iPoint) = i
           SamiAltsFactor(iPoint) = &
             (SamiAlts(i) - InAlts(iPoint))/ &
             (SamiAlts(i) - SamiAlts(i - 1))
-        end if
-      end if
+        endif
+      endif
 
       if (SamiAltsIndex(iPoint) < 1) then
         write(*, *) 'bad alt in SamiSetGrid!', &
           SamiInLons(iPoint), SamiInLats(iPoint), InAlts(iPoint)
         write(*, *) 'Sami Alts : ', SamiAlts(1), SamiAlts(nAltsSami)
         stop
-      end if
+      endif
 
-    end do
+    enddo
 
   end subroutine SamiSetGrid
 
@@ -736,8 +736,8 @@ contains
         nyear = itime(1) - 65
       else
         nyear = itime(1) + 100 - 65
-      end if
-    end if
+      endif
+    endif
     nleap = nyear/4
 
     nmonth = itime(2) - 1
@@ -746,7 +746,7 @@ contains
 
     do i = 1, nmonth
       nday = nday + dayofmon(i)
-    end do
+    enddo
 
     nday = nday + itime(3) - 1
     nhour = itime(4)

--- a/src/ModSamiInterp.f90
+++ b/src/ModSamiInterp.f90
@@ -59,7 +59,7 @@ contains
         alt1(iAlt) = baltst_g(iAlt, j, i) - re
         !alt1(iAlt) = baltst_g(iAlt,j,i)
 
-      end do
+      enddo
 
       if (gitm_alt <= maxval(alt1)) then
 
@@ -69,11 +69,11 @@ contains
 
           !print*,'check0', gitm_alt,maxval(alt1),minval(alt1)
           jflag = .false.
-        end if
-      end if
+        endif
+      endif
 
       j = j + 1
-    end do
+    enddo
 
     j = j - 1
 
@@ -102,7 +102,7 @@ contains
           lat_l1 = blatst_g(l + 1, ifl, i)
         else
           lat_l1 = blatst_g(l - 1, ifl, i)
-        end if
+        endif
 
         if (abs(gitm_mlat) <= abs(lat_l0)) then
 
@@ -116,18 +116,18 @@ contains
           if ((abs(gitm_mlat) < abs(lat_k0)) &
               .or. (k < 0)) stop
           jflag2 = .false.
-        end if
+        endif
 
         !l = l0
-      end if
+      endif
 
       ifl = ifl + 1
 
       if (ifl >= nf) then
         jflag2 = .false.
         print *, 'GITM nan', gitm_mlon, gitm_mlat, gitm_alt
-      end if
-    end do
+      endif
+    enddo
 
     j = ifl - 1
 
@@ -334,7 +334,7 @@ contains
 
       data_inp(ivar) = data0*(1.-zd) + data1*zd
       !if (ivar ==1 ) print*,'along z',iproc,data_inp(ivar)
-    end do
+    enddo
 
     return
 
@@ -372,7 +372,7 @@ contains
 
       yi_1jk = blatst_g(1, phi_j0, phi_i1)
       yi_1j_1l = blatst_g(1, phi_j1, phi_i1)
-    end if
+    endif
 
     !print*,'before',iproc,phi_i0,phi_i1,nlt,gitm_x,gitm_y,phi_sami_lon0,phi_sami_lon1
     if ((phi_i0 == 1) .and. (phi_i1 == nlt)) then
@@ -382,9 +382,9 @@ contains
         gitm_x = gitm_x + 360.0
       else if (gitm_x > phi_sami_lon1) then
         phi_sami_lon0 = phi_sami_lon0 + 360.0
-      end if
+      endif
 
-    end if
+    endif
 
     !print*,'after',iproc,phi_i0,phi_i1,nlt,gitm_x,gitm_y,phi_sami_lon0,phi_sami_lon1
     if ((phi_j0 == 1) .and. (phi_j1 == 1)) then
@@ -395,8 +395,8 @@ contains
       else
         yijk = -yijk
         yi_1jk = -yi_1jk
-      end if
-    end if
+      endif
+    endif
 
     xijk = phi_sami_lon0
     xij_1l = phi_sami_lon0
@@ -521,8 +521,8 @@ contains
         inz_i_1j_1l = 1
         inz_i_1j_1l_1 = 1
 
-      end if
-    end if
+      endif
+    endif
 
     yijk = blatst_g(inz_ijk, j0, i0)
     yijk_1 = blatst_g(inz_ijk_1, j0, i0)
@@ -545,11 +545,11 @@ contains
         gitm_x = gitm_x + 360.0
       elseif (gitm_x > sami_lon1) then
         sami_lon0 = sami_lon0 + 360.0
-      end if
+      endif
 
       !print*,'-- gitm_x,sami_lon0,b ',gitm_x,sami_lon0
 
-    end if
+    endif
 
     xijk = sami_lon0
     xijk_1 = sami_lon0
@@ -718,7 +718,7 @@ contains
       yi_1jk_1 = blatst_g(1, j0, i1)
       yi_1j_1l = blatst_g(1, j1, i1)
       yi_1j_1l_1 = blatst_g(1, j1, i1)
-    end if
+    endif
 
     !yijk     = blatst_g(k0,j0,i0)
     !yijk_1   = blatst_g(k1,j0,i0)
@@ -737,9 +737,9 @@ contains
         gitm_x = gitm_x + 360.0
       elseif (gitm_x > sami_lon1) then
         sami_lon0 = sami_lon0 + 360.0
-      end if
+      endif
 
-    end if
+    endif
 
     !if ((j0 == 1).and.(j1==1)) then
     !    if (gitm_mlat <0 ) then
@@ -763,8 +763,8 @@ contains
 
         yi_1jk = -yi_1jk
         yi_1jk_1 = -yi_1jk_1
-      end if
-    end if
+      endif
+    endif
 
     !print*,sami_lon0,gitm_x,sami_lon1,sami_lat0,gitm_y,sami_lat1
 
@@ -1231,7 +1231,7 @@ contains
       alt1(iAlt) = baltst_g(iAlt, j, i) - re
       !alt1(iAlt) = baltst_g(iAlt,j,i)
 
-    end do
+    enddo
 
     !print*, maxval(alt1),minval(alt1)
 
@@ -1248,16 +1248,16 @@ contains
         mm = 1
         do while (phi_gitm_alt >= alt1(mm))
           mm = mm + 1
-        end do
+        enddo
         k = mm - 1
       else
         mm = nz
         do while (phi_gitm_alt >= alt1(mm))
           mm = mm - 1
-        end do
+        enddo
         k = mm + 1
-      end if
-    end if
+      endif
+    endif
 
     !print*,'--k 100km',k
     !if (gitm_mlat < 0) then
@@ -1291,7 +1291,7 @@ contains
       alt1(iAlt) = baltst_g(iAlt, j, i) - re
       !alt1(iAlt) = baltst_g(iAlt,j,i)
 
-    end do
+    enddo
 
     !print*, maxval(alt1),minval(alt1)
 
@@ -1308,16 +1308,16 @@ contains
         mm = 1
         do while (gitm_alt >= alt1(mm))
           mm = mm + 1
-        end do
+        enddo
         k = mm - 1
       else
         mm = nz
         do while (gitm_alt >= alt1(mm))
           mm = mm - 1
-        end do
+        enddo
         k = mm + 1
-      end if
-    end if
+      endif
+    endif
 
     !print*,'--k',k
     !if (gitm_mlat < 0) then
@@ -1350,14 +1350,14 @@ contains
 
       do inlt = 1, nlt
         mlon0(inlt) = blonst_g(1, 1, inlt)
-      end do
+      enddo
 
       do inf = 1, nf
         mlat0(inf) = blatst_g(nz, inf, 1)
-      end do
+      enddo
 
       IsFirstTime = .false.
-    end if
+    endif
 
     k = -1
     l = -1
@@ -1373,14 +1373,14 @@ contains
       mm = 1
       do while (phi_gitm_mlon > mlon0(mm))
         mm = mm + 1
-      end do
+      enddo
       i = mm - 1
 
       phi_i0 = i
       phi_i1 = i + 1
 
       !print*, '=blon/i,i+1',i,mlon0(i),mlon0(i+1)
-    end if
+    endif
     !print*, '=blon/i,i+1',phi_i0,phi_i1,mlon0(phi_i0),mlon0(phi_i1)
 
     ! --find field_line_index : j
@@ -1398,12 +1398,12 @@ contains
       mm = 1
       do while (abs(phi_gitm_mlat) > mlat0(mm))
         mm = mm + 1
-      end do
+      enddo
       j = mm - 1
       phi_j0 = j
       phi_j1 = j + 1
       !print*, '=blat/j,j+1',j,mlat0(j),mlat0(j+1)
-    end if
+    endif
 
     !if (phi_j0 > 0) &
     !      print*, '=blat/j,j+1',phi_j0,phi_j1,mlat0(phi_j0),mlat0(phi_j1)
@@ -1416,16 +1416,16 @@ contains
 
       if ((k > 0) .and. (l > 0)) then
         phi_flag = 1
-      end if
+      endif
 
     else if ((phi_j0 == 1) .and. (phi_j1 == 1)) then
 
       call FindAltIndex_phi(phi_i0, phi_j0, k, phi_gitm_alt)
       if ((k > 0)) then
         phi_flag = 1
-      end if
+      endif
 
-    end if
+    endif
 
     if ((phi_j0 > 0) .and. (phi_flag == 1)) then
 
@@ -1438,10 +1438,10 @@ contains
       else
         phi_sami_lat0 = blatst_g(1, phi_j0, 1)
         phi_sami_lat1 = blatst_g(1, phi_j1, 1)
-      end if
+      endif
 
       !print*,phi_flag,phi_sami_lon0,phi_sami_lat0,phi_sami_lon1,phi_sami_lat1
-    end if
+    endif
 
   end subroutine get_index_4points_2
 
@@ -1469,11 +1469,11 @@ contains
 
       do inlt = 1, nlt
         mlon0(inlt) = blonst_g(1, 1, inlt)
-      end do
+      enddo
 
       do inf = 1, nf
         mlat0(inf) = blatst_g(nz, inf, 1)
-      end do
+      enddo
 
       !print*,'-->> sami mlon0'
       !print*,mlon0
@@ -1482,7 +1482,7 @@ contains
       !print*,'>>>>',blatst_g(:,nf,1)
 
       IsFirstTime = .false.
-    end if
+    endif
 
     k = -1
     l = -1
@@ -1497,14 +1497,14 @@ contains
       mm = 1
       do while (gitm_mlon > mlon0(mm))
         mm = mm + 1
-      end do
+      enddo
       i = mm - 1
 
       i0 = i
       i1 = i + 1
 
       !print*, '=blon/i,i+1',i,mlon0(i),mlon0(i+1)
-    end if
+    endif
 
     ! --find field_line_index : j
     if (abs(gitm_mlat) <= mlat0(1)) then
@@ -1521,12 +1521,12 @@ contains
       mm = 1
       do while (abs(gitm_mlat) > mlat0(mm))
         mm = mm + 1
-      end do
+      enddo
       j = mm - 1
       j0 = j
       j1 = j + 1
       !print*, '=blat/j,j+1',j,mlat0(j),mlat0(j+1)
-    end if
+    endif
 
     !if (j0>0) &
     !print*, '=blat/j,j+1',j0,mlat0(j0),mlat0(j1)
@@ -1546,9 +1546,9 @@ contains
         j1 = j0 + 1
 
         flag_eq = 1
-      end if
+      endif
 
-    end if
+    endif
 
     if (gitm_mlat > 0) then
       k1 = k - 1
@@ -1556,7 +1556,7 @@ contains
     else
       k1 = k + 1
       l1 = l + 1
-    end if
+    endif
 
     k0 = k
     l0 = l
@@ -1572,10 +1572,10 @@ contains
       else
         sami_lat0 = blatst_g(1, j0, 1)
         sami_lat1 = blatst_g(1, j1, 1)
-      end if
+      endif
       !print*, '--',sami_lon0,sami_lon1,sami_lat0,sami_lat1
       !print*,i0,j0,k0,l0,i1,j1,k1,l1
-    end if
+    endif
 
     !print*, '--',sami_lat0,sami_lat1
 
@@ -1617,11 +1617,11 @@ contains
 
       do inlt = 1, nlt
         mlon0(inlt) = blonst_g(1, 1, inlt)
-      end do
+      enddo
 
       do inf = 1, nf
         mlat0(inf) = blatst_g(nz, inf, 1)
-      end do
+      enddo
 
       !print*,'-->> sami mlon0'
       !print*,mlon0
@@ -1630,7 +1630,7 @@ contains
       !print*,'>>>>',blatst_g(:,nf,1)
 
       IsFirstTime = .false.
-    end if
+    endif
 
     k = -1
     l = -1
@@ -1645,14 +1645,14 @@ contains
       mm = 1
       do while (gitm_mlon > mlon0(mm))
         mm = mm + 1
-      end do
+      enddo
       i = mm - 1
 
       i0 = i
       i1 = i + 1
 
       !print*, '=blon/i,i+1',i,mlon0(i),mlon0(i+1)
-    end if
+    endif
     !print*, '=blon/i,i+1',i0,mlon0(i0),mlon0(i1)
 
     ! --find field_line_index : j
@@ -1670,12 +1670,12 @@ contains
       mm = 1
       do while (abs(gitm_mlat) > mlat0(mm))
         mm = mm + 1
-      end do
+      enddo
       j = mm - 1
       j0 = j
       j1 = j + 1
       !print*, '=blat/j,j+1',j,mlat0(j),mlat0(j+1)
-    end if
+    endif
 
     !if (j0>0) &
     !print*, '=blat/j,j+1',j0,mlat0(j0),mlat0(j1)
@@ -1690,7 +1690,7 @@ contains
       call FindAltIndex(i0, j0, k)
       if (k > 0) l = nz + 1 - k
 
-    end if
+    endif
 
     if (gitm_mlat > 0) then
       k1 = k - 1
@@ -1698,7 +1698,7 @@ contains
     else
       k1 = k + 1
       l1 = l + 1
-    end if
+    endif
 
     k0 = k
     l0 = l
@@ -1833,10 +1833,10 @@ contains
       else
         sami_lat0 = blatst_g(1, j0, 1)
         sami_lat1 = blatst_g(1, j1, 1)
-      end if
+      endif
       !print*, '--',sami_lon0,sami_lon1,sami_lat0,sami_lat1
       !print*,i0,j0,k0,l0,i1,j1,k1,l1
-    end if
+    endif
 
     !print*, '--',sami_lat0,sami_lat1
 
@@ -1876,11 +1876,11 @@ contains
 
       do inlt = 1, nlt
         mlon0(inlt) = blonst_g(1, 1, inlt)
-      end do
+      enddo
 
       do inf = 1, nf
         mlat0(inf) = blatst_g(nz, inf, 1)
-      end do
+      enddo
 
       !print*,'-->> sami mlon0'
       !print*,mlon0
@@ -1889,7 +1889,7 @@ contains
       !print*,'>>>>',blatst_g(:,nf,1)
 
       IsFirstTime = .false.
-    end if
+    endif
 
     k = -1
     l = -1
@@ -1902,10 +1902,10 @@ contains
       mm = 1
       do while (gitm_mlon >= mlon0(mm))
         mm = mm + 1
-      end do
+      enddo
       i = mm - 1
       !print*, '=blon/i,i+1',i,mlon0(i),mlon0(i+1)
-    end if
+    endif
 
     ! --find field_line_index : j
     if ((abs(gitm_mlat) < mlat0(1)) .or. (abs(gitm_mlat) > mlat0(nf))) then
@@ -1915,10 +1915,10 @@ contains
       mm = 1
       do while (abs(gitm_mlat) >= mlat0(mm))
         mm = mm + 1
-      end do
+      enddo
       j = mm - 1
       !print*, '=blat/j,j+1',j,mlat0(j),mlat0(j+1)
-    end if
+    endif
 
     !print*,'i/j',i,j
 
@@ -1942,7 +1942,7 @@ contains
 
         if (ktmp > 0) nn = nn + 1
 
-      end do
+      enddo
 
       allocate(AltIndex(1:nn))
       allocate(LatIndex(1:nn))
@@ -1962,8 +1962,8 @@ contains
           LatIndex(nn2) = LatIndex0(inn)
           LatsSel(nn2) = LatsSel0(inn)
           nn2 = nn2 + 1
-        end if
-      end do
+        endif
+      enddo
 
       !print*,LatsSel
       !print*,LatIndex
@@ -1981,7 +1981,7 @@ contains
         mm = 1
         do while (abs(gitm_mlat) >= abs(LatsSel(mm)))
           mm = mm + 1
-        end do
+        enddo
 
         ifl_sel = mm - 1
 
@@ -1990,12 +1990,12 @@ contains
         j = LatIndex(ifl_sel)
         k = AltIndex(ifl_sel)
         l = AltIndex(ifl_sel + 1)
-      end if
+      endif
 
       deallocate(AltIndex, LatIndex, LatsSel)
 
       !print*,'j b',j
-    end if
+    endif
 
     if (gitm_mlat > 0) then
       k1 = k - 1
@@ -2003,7 +2003,7 @@ contains
     else
       k1 = k + 1
       l1 = l + 1
-    end if
+    endif
 
     i1 = i + 1
     j1 = j + 1
@@ -2043,7 +2043,7 @@ contains
     mm = 2
     do while (gitm_mlon >= mlon0(mm))
       mm = mm + 1
-    end do
+    enddo
     i = mm - 1
     !print*, '=blon/i,i+1',mlon0(i),mlon0(i+1)
 
@@ -2052,7 +2052,7 @@ contains
     mm = 2
     do while (abs(gitm_mlat) >= mlat0(mm))
       mm = mm + 1
-    end do
+    enddo
     j = mm - 1
 
     !print*, '=blat/j,j+1',j,mlat0(j),mlat0(j+1)
@@ -2072,14 +2072,14 @@ contains
       LatsSel(ifl - j + 1) = blatst_g(ktmp, ifl, i)
       LatIndex(ifl - j + 1) = ifl
 
-    end do
+    enddo
 
     ! print*,LatsSel
 
     mm = 1
     do while (abs(gitm_mlat) >= abs(LatsSel(mm)))
       mm = mm + 1
-    end do
+    enddo
 
     ifl_sel = mm - 1
 
@@ -2093,7 +2093,7 @@ contains
     else
       k1 = k + 1
       l1 = l + 1
-    end if
+    endif
 
     i1 = i + 1
     j1 = j + 1

--- a/src/ModSatellites.f90
+++ b/src/ModSatellites.f90
@@ -86,7 +86,7 @@ contains
         nSatPos(nMaxSats, nMaxSatInputLines), &
         SatDat(nMaxSats, nMaxSatInputLines), &
         SatCurrentDat(nMaxSats), SatAltDat(nMaxSats))
-    end if
+    endif
 
   end subroutine init_mod_satellites_rcmr
 

--- a/src/ModSphereInterface.f90
+++ b/src/ModSphereInterface.f90
@@ -162,7 +162,7 @@ contains
       call AB_ERROR_set("UAM_module_setup", &
                         "too many cells per block")
       return
-    end if
+    endif
 
     cpb_lat = cells_lat  ! /blks_lat
     if (cpb_lat .gt. nLats) then
@@ -170,7 +170,7 @@ contains
       call AB_ERROR_set("UAM_module_setup", &
                         "too many cells per block")
       return
-    end if
+    endif
 
     cpb_alt = cells_alt
     if (cpb_alt .gt. nAlts) then
@@ -178,7 +178,7 @@ contains
       call AB_ERROR_set("UAM_module_setup", &
                         "too many cells per block")
       return
-    end if
+    endif
 
     ! setup various handy constants
     alt_cell_width = thickness/cpb_alt
@@ -194,14 +194,14 @@ contains
     if (.not. tmp_ok) then
       if (present(ok)) ok = .false.
       return
-    end if
+    endif
 
     ! create AB_GRP
     call AB_GRP_create(uam_grp, nBlocksMax, tmp_ok)
     if (.not. tmp_ok) then
       if (present(ok)) ok = .false.
       return
-    end if
+    endif
 
     ! allocate AB sphere
     call AB_SPH_create(uam_sph, uam_grp, cpb_long, cpb_lat, cpb_alt, gcn, &
@@ -211,7 +211,7 @@ contains
     if (.not. tmp_ok) then
       if (present(ok)) ok = .false.
       return
-    end if
+    endif
 
     ! Initialize stuff for sphere
     call AB_ITER_create(iter, uam_grp)
@@ -228,7 +228,7 @@ contains
 
       call AB_ITER_next(iter, index, done)
 
-    end do
+    enddo
 
   end subroutine UAM_module_setup
 
@@ -269,7 +269,7 @@ contains
     if (UseIonAdvection) then
       call AB_1blk4_gc_add_size(nLons, nLats, nAlts, nIons, 2, size)
       call AB_1blk4_gc_add_size(nLons, nLats, nAlts, 3, 2, size)
-    end if
+    endif
 
   end subroutine size_vars_1blk
 
@@ -314,10 +314,10 @@ contains
         iVelTmp = IVelocity(:, :, 1:nAlts, :, index)
       else
         iVelTmp = IVelocityPar(:, :, 1:nAlts, :, index)
-      end if
+      endif
       call AB_1blk4_gc_pack(nLons, nLats, nAlts, 3, 2, &
                             iVelTmp, dir, pole, p, out_array)
-    end if
+    endif
   end subroutine pack_vars_1blk
 
   subroutine unpack_vars_1blk(index, dir, in_array)
@@ -357,8 +357,8 @@ contains
       else
         call AB_1blk4_gc_unpack(nLons, nLats, nAlts, 3, 2, &
                                 IVelocityPar(:, :, 1:nAlts, :, index), dir, p, in_array)
-      end if
-    end if
+      endif
+    endif
 
   end subroutine unpack_vars_1blk
 
@@ -383,7 +383,7 @@ contains
     if (UseIonAdvection) then
       call AB_array4_gc_add_size(nLons, nLats, nAlts, nIons, 2, size)
       call AB_array4_gc_add_size(nLons, nLats, nAlts, 3, 2, size)
-    end if
+    endif
 
   end subroutine size_vars_nblk
 
@@ -424,21 +424,21 @@ contains
     if (UseIonAdvection) then
       do iIon = 1, nIons
         tmpI(:, :, :, iIon) = IDensityS(:, :, 1:nAlts, iIon, index)
-      end do
+      enddo
       call AB_array4_gc_pack(nLons, nLats, nAlts, nIons, 2, &
                              tmpI, dir, pole, p, out_array)
       if (NonMagnetic) then
         do iComp = 1, 3
           tmpV(:, :, :, iComp) = IVelocity(:, :, 1:nAlts, iComp, index)
-        end do
+        enddo
       else
         do iComp = 1, 3
           tmpV(:, :, :, iComp) = IVelocityPar(:, :, 1:nAlts, iComp, index)
-        end do
-      end if
+        enddo
+      endif
       call AB_array4_gc_pack(nLons, nLats, nAlts, 3, 2, &
                              tmpV, dir, pole, p, out_array)
-    end if
+    endif
   end subroutine pack_vars_nblk
 
   subroutine unpack_vars_nblk(index, dir, in_array)
@@ -479,20 +479,20 @@ contains
     if (UseIonAdvection) then
       do iIon = 1, nIons
         tmpI(:, :, :, iIon) = IDensityS(:, :, 1:nAlts, iIon, index)
-      end do
+      enddo
       call AB_array4_gc_unpack(nLons, nLats, nAlts, nIons, 2, &
                                tmpI, dir, p, in_array)
       do iIon = 1, nIons
         IDensityS(:, :, 1:nAlts, iIon, index) = tmpI(:, :, :, iIon)
-      end do
+      enddo
 
       do iComp = 1, 3
         if (NonMagnetic) then
           tmpV(:, :, :, iComp) = IVelocity(:, :, 1:nAlts, iComp, index)
         else
           tmpV(:, :, :, iComp) = IVelocityPar(:, :, 1:nAlts, iComp, index)
-        end if
-      end do
+        endif
+      enddo
       call AB_array4_gc_unpack(nLons, nLats, nAlts, 3, 2, &
                                tmpV, dir, p, in_array)
       do iComp = 1, 3
@@ -500,9 +500,9 @@ contains
           IVelocity(:, :, 1:nAlts, iComp, index) = tmpV(:, :, :, iComp)
         else
           IVelocityPar(:, :, 1:nAlts, iComp, index) = tmpV(:, :, :, iComp)
-        end if
-      end do
-    end if
+        endif
+      enddo
+    endif
 
   end subroutine unpack_vars_nblk
 
@@ -546,9 +546,9 @@ contains
                         from(ind_ph + 1, ind_th + 1), &
                         p, t, tmp_to)
           to(j, i) = tmp_to
-        end if
-      end do
-    end do
+        endif
+      enddo
+    enddo
 
   contains
 
@@ -570,14 +570,14 @@ contains
           out_ind = i
           fnd = .true.
           return
-        end if
-      end do
+        endif
+      enddo
 
       ! take care of the case where the point is on the upper edge
       if (x == list(num_list)) then
         out_ind = num_list - 1
         fnd = .true.
-      end if
+      endif
 
     end subroutine find_in_list
 
@@ -622,9 +622,9 @@ contains
                         from(ind_ph + 1, ind_th + 1), &
                         ph, th, tmp_to)
           to(j, i) = tmp_to
-        end if
-      end do
-    end do
+        endif
+      enddo
+    enddo
 
   end subroutine map_reg_grid
 
@@ -787,7 +787,7 @@ contains
       call size_vars_1blk(size)
     else
       call size_vars_nblk(size)
-    end if
+    endif
 
     ! create XFER structure
     call AB_XFER_create(uam_xfer, uam_grp, size, 0, tmp_ok)
@@ -818,7 +818,7 @@ contains
     else
       call AB_XFER_start(uam_xfer, pack_vars_nblk, pack_vars_nblk, &
                          tmp_ok)
-    end if
+    endif
 
     if (present(ok)) ok = tmp_ok
 
@@ -850,7 +850,7 @@ contains
     else
       call AB_XFER_finish(uam_xfer, unpack_vars_nblk, unpack_vars_nblk, &
                           tmp_ok)
-    end if
+    endif
 
     if (present(ok)) ok = tmp_ok
 
@@ -882,12 +882,12 @@ contains
     else
       call AB_XFER_start(uam_xfer, pack_vars_nblk, pack_vars_nblk, &
                          tmp_ok)
-    end if
+    endif
 
     if (.not. tmp_ok) then
       if (present(ok)) ok = .false.
       return
-    end if
+    endif
 
     if (blks_long == 1) then
       call AB_XFER_finish(uam_xfer, unpack_vars_1blk, unpack_vars_1blk, &
@@ -895,12 +895,12 @@ contains
     else
       call AB_XFER_finish(uam_xfer, unpack_vars_nblk, unpack_vars_nblk, &
                           tmp_ok)
-    end if
+    endif
 
     if (.not. tmp_ok) then
       if (present(ok)) ok = .false.
       return
-    end if
+    endif
 
   end subroutine UAM_XFER_at_once
 
@@ -980,7 +980,7 @@ contains
                         Rho(:, :, alt, ind))
 
       call AB_ITER_next(iter, ind, done)
-    end do
+    enddo
 
   end subroutine UAM_map_reg_grid_to_Eta
 
@@ -1035,7 +1035,7 @@ contains
                     Rho(:, :, alt, ind))
 
       call AB_ITER_next(iter, ind, done)
-    end do
+    enddo
 
   end subroutine UAM_map_grid_to_Eta
 

--- a/src/ModTitan.f90
+++ b/src/ModTitan.f90
@@ -597,7 +597,7 @@ contains
         pmat(iline, 7), &
         pmat(iline, 8), &
         pmat(iline, 9)
-    end do
+    enddo
     close(Unit=UnitTmp_)
 
     open(UNIT=UnitTmp_, FILE='DataIn/New116HCNLines_Minimal.txt', STATUS='OLD', &
@@ -614,7 +614,7 @@ contains
         Eref(iline), &
         ALPHALExp(iline)
       freqhz(iline) = Speed_Light*100.0*freqw(iline)
-    end do
+    enddo
     close(Unit=UnitTmp_)
 
     Qd(1, 1) = 1.0e0

--- a/src/ModVenus.f90
+++ b/src/ModVenus.f90
@@ -910,7 +910,7 @@ contains
         InNDensityS(iiAlt, iAr_), &
         InIDensityS(iiAlt, ie_)
 
-    end do
+    enddo
 
     InNDensityS = Alog(inNDensityS)
     close(Unit=UnitTmp_)
@@ -971,7 +971,7 @@ contains
     DO NW = 1, L_NSPECTI
       Qexti(NW) = Qexti(NW)*factor
       Qscati(NW) = Qscati(NW)*factor
-    END DO
+    ENDDO
 
     PTOP = 10.0**PFGASREF(1)
 
@@ -1072,7 +1072,7 @@ contains
       WNOV(M) = 0.5*(BWNV(M + 1) + BWNV(M))
       DWNV(M) = BWNV(M + 1) - BWNV(M)
       WAVEV(M) = 1.0E+4/WNOV(M)
-    end do
+    enddo
 
 !C     Sum the solar flux, and write out the result.
 
@@ -1080,7 +1080,7 @@ contains
     do N = 1, L_NSPECTV
       SOLARF(N) = SOLAR(N)
       sum = sum + SOLARF(N)
-    end do
+    enddo
     !write(6,'("Solar flux at 1AU = ",f7.2," W/M^2")') sum
 
 !C     Set up the wavelength dependent part of Rayleigh Scattering.
@@ -1091,7 +1091,7 @@ contains
       WL = WAVEV(N)
       TAURAY(N) = (8.7/grav)*(1.527*(1.0 + 0.013/wl**2)/wl**4)* &
                   scalep/P0
-    end do
+    enddo
 
   END SUBROUTINE SETSPV
 
@@ -1192,7 +1192,7 @@ contains
       WNOI(M) = 0.5*(BWNI(M + 1) + BWNI(M))
       DWNI(M) = BWNI(M + 1) - BWNI(M)
       WAVEI(M) = 1.0E+4/WNOI(M)
-    end do
+    enddo
 
 !C  For each IR wavelength interval, compute the integral of B(T), the
 !C  Planck function, divided by the wavelength interval, in cm-1.  The
@@ -1210,10 +1210,10 @@ contains
         do m = 1, 12
           y = bma*x(m) + bpa
           ans = ans + w(m)*c1/(y**5*(exp(c2/(y*T)) - 1.0D0))
-        end do
+        enddo
         planckir(NW, nt - 499) = ans*bma/(PI*DWNI(NW))
-      end do
-    END DO
+      enddo
+    ENDDO
 
   end subroutine setspi
 
@@ -1365,10 +1365,10 @@ contains
       Qscatv(n) = qsv1(n)
       IF (Qscatv(n) .GE. Qextv(n)) then
         Qscatv(n) = 0.99999*Qextv(n)
-      END IF
+      ENDIF
       WV(n) = Qscatv(n)/Qextv(n)
       GV(n) = gv1(n)
-    END DO
+    ENDDO
 
 !C     Fill the (INFRARED) arrays Qexti, Qscati, WI, GI
 
@@ -1377,10 +1377,10 @@ contains
       Qscati(n) = qsi1(n)
       IF (Qscati(n) .GE. Qexti(n)) then
         Qscati(n) = 0.99999*Qexti(n)
-      END IF
+      ENDIF
       WI(n) = Qscati(n)/Qexti(n)
       GI(n) = gi1(n)
-    END DO
+    ENDDO
 
 !C     Get CO2 k coefficients, and interpolate them to the finer
 !C     pressure grid.
@@ -1427,13 +1427,13 @@ contains
 
     do n = 1, L_PINT
       PINT(n) = PIN(n)
-    end do
+    enddo
 
 !C  Take log of the reference pressures
 
     do n = 1, L_NPREF
       pref(n) = LOG10(PGREF(n))
-    end do
+    enddo
 
 !C     Get CO2 k coefficients
 
@@ -1445,15 +1445,15 @@ contains
           DO l = 1, L_NSPECTV
             DO m = 1, L_NGAUSS
               read(25, *) co2v8(i, j, k, l, m)
-            END DO
-          END DO
-        END DO
-      END DO
-    END DO
+            ENDDO
+          ENDDO
+        ENDDO
+      ENDDO
+    ENDDO
 
     DO i = 1, L_NSPECTV
       read(25, *) fzerov(i)
-    END DO
+    ENDDO
     CLOSE(25)
 
     OPEN(unit=35, file='UA/DataIn/CO2H2O_IR_12_95_ASCII', ACTION='READ')
@@ -1464,15 +1464,15 @@ contains
           DO l = 1, L_NSPECTI
             DO m = 1, L_NGAUSS
               read(35, *) co2i8(i, j, k, l, m)
-            END DO
-          END DO
-        END DO
-      END DO
-    END DO
+            ENDDO
+          ENDDO
+        ENDDO
+      ENDDO
+    ENDDO
 
     DO i = 1, L_NSPECTI
       read(35, *) fzeroi(i)
-    END DO
+    ENDDO
     CLOSE(35)
 
 !!$      print*,'co2v8(3,4,1,3,2) = ',co2v8(3,4,1,3,2)
@@ -1495,21 +1495,21 @@ contains
                 co2v8(nt, np, nh, nw, ng) = log10(co2v8(nt, np, nh, nw, ng))
               else
                 co2v8(nt, np, nh, nw, ng) = -200.0
-              end if
-            end do
+              endif
+            enddo
 
             do nw = 1, L_NSPECTI
               if (co2i8(nt, np, nh, nw, ng) .gt. 1.0e-200) then
                 co2i8(nt, np, nh, nw, ng) = log10(co2i8(nt, np, nh, nw, ng))
               else
                 co2i8(nt, np, nh, nw, ng) = -200.0
-              end if
-            end do
+              endif
+            enddo
 
-          end do
-        end do
-      end do
-    end do
+          enddo
+        enddo
+      enddo
+    enddo
 
 !C  Interpolate the values:  first the IR
 
@@ -1533,7 +1533,7 @@ contains
             yi(4) = co2i8(nt, n + 3, nh, nw, ng)
             call lagrange(x, xi, yi, ans)
             co2i(nt, m, nh, nw, ng) = 10.0**ans
-          end do
+          enddo
 
           do n = 2, L_NPREF - 2
             do m = 1, 5
@@ -1549,8 +1549,8 @@ contains
               yi(4) = co2i8(nt, n + 2, nh, nw, ng)
               call lagrange(x, xi, yi, ans)
               co2i(nt, i, nh, nw, ng) = 10.0**ans
-            end do
-          end do
+            enddo
+          enddo
 
 !C  Now, get the last interval (P=1e+3 to 1e+4)
 
@@ -1569,16 +1569,16 @@ contains
             yi(4) = co2i8(nt, n + 1, nh, nw, ng)
             call lagrange(x, xi, yi, ans)
             co2i(nt, i, nh, nw, ng) = 10.0**ans
-          end do
+          enddo
 
 !C  Fill the last pressure point
 
           co2i(nt, L_PINT, nh, nw, ng) = 10.0**co2i8(nt, L_NPREF, nh, nw, ng)
 
-        end do
-      end do
-      end do
-    end do
+        enddo
+      enddo
+      enddo
+    enddo
 
 !C  Interpolate the values:  now the Visual
 
@@ -1602,7 +1602,7 @@ contains
             yi(4) = co2v8(nt, n + 3, nh, nw, ng)
             call lagrange(x, xi, yi, ans)
             co2v(nt, m, nh, nw, ng) = 10.0**ans
-          end do
+          enddo
 
           do n = 2, L_NPREF - 2
             do m = 1, 5
@@ -1618,8 +1618,8 @@ contains
               yi(4) = co2v8(nt, n + 2, nh, nw, ng)
               call lagrange(x, xi, yi, ans)
               co2v(nt, i, nh, nw, ng) = 10.0**ans
-            end do
-          end do
+            enddo
+          enddo
 
 !C  Now, get the last interval (P=1e+3 to 1e+4)
 
@@ -1638,16 +1638,16 @@ contains
             yi(4) = co2v8(nt, n + 1, nh, nw, ng)
             call lagrange(x, xi, yi, ans)
             co2v(nt, i, nh, nw, ng) = 10.0**ans
-          end do
+          enddo
 
 !C  Fill the last pressure point
 
           co2v(nt, L_PINT, nh, nw, ng) = 10.0**co2v8(nt, L_NPREF, nh, nw, ng)
 
-        end do
-      end do
-      end do
-    end do
+        enddo
+      enddo
+      enddo
+    enddo
 
   end subroutine laginterp
 
@@ -1701,7 +1701,7 @@ contains
     !Figure 4 in Haus et al. 2015
     do iiAlt = 1, 56
       read(UnitTmp_, *) referenceTemperature(iiAlt), referenceAltitude1(iiAlt)
-    end do
+    enddo
 
     close(Unit=UnitTmp_)
 
@@ -1712,7 +1712,7 @@ contains
 
     do iiAlt = 1, 31
       read(UnitTmp_, *) newtonianCoolingRate(iiAlt), referenceAltitude2(iiAlt)
-    end do
+    enddo
 
     close(Unit=UnitTmp_)
 

--- a/src/PostProcess.f90
+++ b/src/PostProcess.f90
@@ -48,20 +48,20 @@ program PostProcess
   if (iStart > 0) then
   else
     iStart = index(FileName, " ") - 1
-  end if
+  endif
 
   inquire(file=FileName(1:iStart)//".header", EXIST=IsThere)
   if (.not. IsThere) then
     write(*, *) "Could not find header file : ", FileName(1:iStart)//".header"
     stop
-  end if
+  endif
 
   ! Xing Meng 2020-03-17: HIME type output requires special treatment
   if (FileName(3:5) == "HME") then
     IsHIMEType = .true.
   else
     IsHIMEType = .false.
-  end if
+  endif
 
   open(iInputUnitH_, file=FileName(1:iStart)//".header", status="old")
 
@@ -89,14 +89,14 @@ program PostProcess
         read(iInputUnitH_, *) nBlocksAlt
         read(iInputUnitH_, *) nBlocksLat
         read(iInputUnitH_, *) nBlocksLon
-      end if
+      endif
 
       if (index(cLine, "NUMERICAL") > 0) then
         read(iInputUnitH_, *) nVars
         read(iInputUnitH_, *) nAlts
         read(iInputUnitH_, *) nLats
         read(iInputUnitH_, *) nLons
-      end if
+      endif
 
       if (index(cLine, "TIME") > 0) then
         read(iInputUnitH_, *) iYear
@@ -106,37 +106,37 @@ program PostProcess
         read(iInputUnitH_, *) iMinute
         read(iInputUnitH_, *) iSecond
         read(iInputUnitH_, *) iMilli
-      end if
+      endif
 
       if (index(cLine, "VERSION") > 0) then
         read(iInputUnitH_, *) Version
-      end if
+      endif
 
       if (index(cLine, "VARIABLE") > 0) then
         do iVar = 1, nVars
           read(iInputUnitH_, "(i7,a40)") i, Variables(iVar)
-        end do
-      end if
+        enddo
+      endif
 
       if (index(cLine, "NGHOSTCELLS") > 0) then
         read(iInputUnitH_, *) nGhostAlts
         read(iInputUnitH_, *) nGhostLats
         read(iInputUnitH_, *) nGhostLons
-      end if
+      endif
 
       if (index(cLine, "NO GHOSTCELLS") > 0) then
         UseGhostCells = .false.
         nGhostLats = 0
         nGhostLons = 0
         nGhostAlts = 0
-      end if
+      endif
 
       if (index(cLine, "END") > 0) then
         iError = 1
         IsEnd = .true.
-      end if
+      endif
 
-    end do
+    enddo
 
     if (nAlts > 0) then
 
@@ -144,7 +144,7 @@ program PostProcess
       if (nLons == 1 .and. nLats == 1) then
         nBlocksLon = 1
         nBlocksLat = 1
-      end if
+      endif
 
       write(*, *) "Inputs :"
       write(*, *) "  nBlocksLon, nBlocksLat, nBlocksAlt : ", &
@@ -160,7 +160,7 @@ program PostProcess
         nLonsTotal = nBlocksLon*nLons
         nLatsTotal = nBlocksLat*nLats
         nAltsTotal = nBlocksAlt*nAlts
-      end if
+      endif
       write(*, *) "  nLonsTotal, nLatsTotal, nAltsTotal : ", &
         nLonsTotal, nLatsTotal, nAltsTotal, " (Predicted Values)"
 
@@ -169,7 +169,7 @@ program PostProcess
       if (IsHIMEType) then
         allocate(IsHIMEBlock(nBlocksLon, nBlocksLat, nBlocksAlt))
         IsHIMEBlock = 0
-      end if
+      endif
 
       if (.not. IsEnd .or. IsFirstTime) then
         open(iOutputUnit_, file=FileName(1:iStart)//".bin", &
@@ -178,7 +178,7 @@ program PostProcess
         write(*, *) "Appending Satellite Files...."
         open(iOutputUnit_, file=FileName(1:iStart)//".bin", &
              status="old", form="unformatted", position="append")
-      end if
+      endif
 
       nAltsTotal = 0
       nLatsTotal = 0
@@ -196,7 +196,7 @@ program PostProcess
             if (.not. IsThere .and. .not. IsHIMEType) then
               write(*, *) "Must be a satellite file...."
               cBlock = ".sat"
-            end if
+            endif
 
             if (IsHIMEType) then
               if (.not. IsThere) then
@@ -206,14 +206,14 @@ program PostProcess
               else
                 ! flag this block
                 IsHIMEBlock(iBlockLon, iBlockLat, iBlockAlt) = 1
-              end if
-            end if
+              endif
+            endif
 
             if (IsFirstTime .or. .not. IsEnd .or. iBlock > 1) then
               open(iInputUnitD_, file=FileName(1:iStart)//cBlock, &
                    status="old", form="unformatted")
               IsFirstTime = .false.
-            end if
+            endif
 
             do iAlt = 1, nAlts
               do iLat = 1, nLats
@@ -242,7 +242,7 @@ program PostProcess
                     if (iBlockAlt /= nBlocksAlt .and. &
                         iAlt > nAlts - nGhostAlts) DoWrite = .false.
 
-                  end if
+                  endif
 
                   if (DoWrite) then
 
@@ -258,7 +258,7 @@ program PostProcess
                       iiLat = (iBlockLat - 1)*(nLats) + iLat
                       iiAlt = (iBlockAlt - 1)*(nAlts) + iAlt
 
-                    end if
+                    endif
 
                     AllData(iiLon, iiLat, iiAlt, 1:nVars) = Data(1:nVars)
 
@@ -266,19 +266,19 @@ program PostProcess
                     if (iiLat > nLatsTotal) nLatsTotal = iiLat
                     if (iiAlt > nAltsTotal) nAltsTotal = iiAlt
 
-                  end if
+                  endif
 
-                end do
-              end do
-            end do
+                enddo
+              enddo
+            enddo
 
             if (.not. IsEnd .or. nBlocksLat > 1) close(iInputUnitD_)
 
             iBlock = iBlock + 1
 
-          end do
-        end do
-      end do
+          enddo
+        enddo
+      enddo
 
       ! Correct nLonsTotal, nLatsTotal, and nAltsTotal for HME
       if (IsHIMEType) then
@@ -296,7 +296,7 @@ program PostProcess
         nLonsTotal = nHIMEBlocksLon*nLons
         nLatsTotal = nHIMEBlocksLat*nLats
         nAltsTotal = nHIMEBlocksAlt*nAlts
-      end if
+      endif
 
       ! Write *bin file
       write(iOutputUnit_) Version
@@ -304,14 +304,14 @@ program PostProcess
       write(iOutputUnit_) nVars
       do iVar = 1, nVars
         write(iOutputUnit_) Variables(iVar)
-      end do
+      enddo
 
       write(iOutputUnit_) iYear, iMonth, iDay, iHour, iMinute, iSecond, iMilli
 
       if (.not. IsHIMEType) then
         do iVar = 1, nVars
           write(iOutputUnit_) AllData(:, :, :, iVar)
-        end do
+        enddo
       else
         do iVar = 1, nVars
           ! Write the data from the HIME output region. The rest should be zeros.
@@ -321,8 +321,8 @@ program PostProcess
                                       (iHIMEBlockStart(2) - 1)*nLats + nLatsTotal, &
                                       (iHIMEBlockStart(3) - 1)*nAlts + 1: &
                                       (iHIMEBlockStart(3) - 1)*nAlts + nAltsTotal, iVar)
-        end do
-      end if
+        enddo
+      endif
 
       write(*, *) "Output :"
       write(*, *) "  nLons, nLats, nAlts : ", nLonsTotal, nLatsTotal, nAltsTotal
@@ -331,9 +331,9 @@ program PostProcess
       deallocate(AllData)
       if (IsHIMEType) deallocate(IsHIMEBlock)
 
-    end if
+    endif
 
-  end do
+  enddo
 
   close(iInputUnitH_)
   close(iInputUnitD_)

--- a/src/PostProcessNetCDF.f90
+++ b/src/PostProcessNetCDF.f90
@@ -33,8 +33,8 @@ subroutine time_int_to_real(itime, timereal)
       nyear = itime(1) - 65
     else
       nyear = itime(1) + 100 - 65
-    end if
-  end if
+    endif
+  endif
   nleap = nyear/4
 
   nmonth = itime(2) - 1
@@ -43,7 +43,7 @@ subroutine time_int_to_real(itime, timereal)
 
   do i = 1, nmonth
     nday = nday + dayofmon(i)
-  end do
+  enddo
 
   nday = nday + itime(3) - 1
   nhour = itime(4)
@@ -120,13 +120,13 @@ program PostProcess
   if (iStart > 0) then
   else
     iStart = index(FileName, " ") - 1
-  end if
+  endif
 
   inquire(file=FileName(1:iStart)//".header", EXIST=IsThere)
   if (.not. IsThere) then
     write(*, *) "Could not find header file : ", FileName(1:iStart)//".header"
     stop
-  end if
+  endif
 
   open(iInputUnitH_, file=FileName(1:iStart)//".header", status="old")
 
@@ -154,14 +154,14 @@ program PostProcess
         read(iInputUnitH_, *) nBlocksAlt
         read(iInputUnitH_, *) nBlocksLat
         read(iInputUnitH_, *) nBlocksLon
-      end if
+      endif
 
       if (index(cLine, "NUMERICAL") > 0) then
         read(iInputUnitH_, *) nVars
         read(iInputUnitH_, *) nAlts
         read(iInputUnitH_, *) nLats
         read(iInputUnitH_, *) nLons
-      end if
+      endif
 
       if (index(cLine, "TIME") > 0) then
         read(iInputUnitH_, *) iYear
@@ -171,11 +171,11 @@ program PostProcess
         read(iInputUnitH_, *) iMinute
         read(iInputUnitH_, *) iSecond
         read(iInputUnitH_, *) iMilli
-      end if
+      endif
 
       if (index(cLine, "VERSION") > 0) then
         read(iInputUnitH_, *) Version
-      end if
+      endif
 
       if (index(cLine, "VARIABLE") > 0) then
         do iVar = 1, nVars
@@ -188,32 +188,32 @@ program PostProcess
                 cSingle(i:i) /= "]") then
               cSingleTemp(j:j) = cSingle(i:i)
               j = j + 1
-            end if
-          end do
+            endif
+          enddo
           write(*, *) cSingleTemp
           Variables(iVar) = cSingleTemp
-        end do
-      end if
+        enddo
+      endif
 
       if (index(cLine, "NGHOSTCELLS") > 0) then
         read(iInputUnitH_, *) nGhostAlts
         read(iInputUnitH_, *) nGhostLats
         read(iInputUnitH_, *) nGhostLons
-      end if
+      endif
 
       if (index(cLine, "NO GHOSTCELLS") > 0) then
         UseGhostCells = .false.
         nGhostLats = 0
         nGhostLons = 0
         nGhostAlts = 0
-      end if
+      endif
 
       if (index(cLine, "END") > 0) then
         iError = 1
         IsEnd = .true.
-      end if
+      endif
 
-    end do
+    enddo
 
     if (nAlts > 0) then
 
@@ -221,7 +221,7 @@ program PostProcess
       if (nLons == 1 .and. nLats == 1) then
         nBlocksLon = 1
         nBlocksLat = 1
-      end if
+      endif
 
       write(*, *) "Inputs :"
       write(*, *) "  nBlocksLon, nBlocksLat, nBlocksAlt : ", &
@@ -237,7 +237,7 @@ program PostProcess
         nLonsTotal = nBlocksLon*nLons
         nLatsTotal = nBlocksLat*nLats
         nAltsTotal = nBlocksAlt*nAlts
-      end if
+      endif
       write(*, *) "  nLonsTotal, nLatsTotal, nAltsTotal : ", &
         nLonsTotal, nLatsTotal, nAltsTotal, " (Predicted Values)"
 
@@ -260,7 +260,7 @@ program PostProcess
 
         iError = nf90_open(FileName(1:iStart)//".nc", nf90_write, ncid)
 
-      end if
+      endif
 
       ! Define the dimensions
       iError = nf90_def_dim(ncid, 'Longitude', nLonsTotal, DimId_iLon)
@@ -283,7 +283,7 @@ program PostProcess
         iError = nf90_def_var(ncid, Variables(iVar), NF90_REAL, &
                               DimIds, VarId(iVar))
         write(*, *) "var ", iVar, Variables(iVar), iError, VarId(iVar)
-      end do
+      enddo
 
       ! We need to do Units and other Attributes here....
       iError = nf90_put_att(ncid, NF90_GLOBAL, "Version", Version)
@@ -307,7 +307,7 @@ program PostProcess
             if (.not. IsThere) then
               write(*, *) "Must be a satellite file...."
               cBlock = ".sat"
-            end if
+            endif
 
             !write(*,*) "Reading File : ",FileName(1:iStart)//cBlock
 
@@ -316,7 +316,7 @@ program PostProcess
               open(iInputUnitD_, file=FileName(1:iStart)//cBlock, &
                    status="old", form="unformatted")
               IsFirstTime = .false.
-            end if
+            endif
 
             do iAlt = 1, nAlts
               do iLat = 1, nLats
@@ -345,7 +345,7 @@ program PostProcess
                     if (iBlockAlt /= nBlocksAlt .and. &
                         iAlt > nAlts - nGhostAlts) DoWrite = .false.
 
-                  end if
+                  endif
 
                   if (DoWrite) then
 
@@ -361,7 +361,7 @@ program PostProcess
                       iiLat = (iBlockLat - 1)*(nLats) + iLat
                       iiAlt = (iBlockAlt - 1)*(nAlts) + iAlt
 
-                    end if
+                    endif
 
                     AllData(iiLon, iiLat, iiAlt, 1:nVars) = Data(1:nVars)
 
@@ -369,19 +369,19 @@ program PostProcess
                     if (iiLat > nLatsTotal) nLatsTotal = iiLat
                     if (iiAlt > nAltsTotal) nAltsTotal = iiAlt
 
-                  end if
+                  endif
 
-                end do
-              end do
-            end do
+                enddo
+              enddo
+            enddo
 
             if (.not. IsEnd .or. nBlocksLat > 1) close(iInputUnitD_)
 
             iBlock = iBlock + 1
 
-          end do
-        end do
-      end do
+          enddo
+        enddo
+      enddo
 
       iTime(1) = iYear
       iTime(2) = iMonth
@@ -401,7 +401,7 @@ program PostProcess
         tmpData = AllData(:, :, :, iVar)
         iError = nf90_put_var(ncid, VarId(iVar), tmpData, &
                               start=start, count=count)
-      end do
+      enddo
 
       close(iOutputUnit_)
       deallocate(AllData)
@@ -409,8 +409,8 @@ program PostProcess
       ! close file
       iError = nf90_close(ncid)
 
-    end if
+    endif
 
-  end do
+  enddo
 
 end program PostProcess

--- a/src/RCMR_routines.f90
+++ b/src/RCMR_routines.f90
@@ -32,7 +32,7 @@ subroutine set_RCMR_estimations
     PhotoElectronHeatingEfficiency = PhotoElectronHeatingEfficiency_est
   else if (RCMROutType == "EDC") then
     EddyDiffusionCoef = EDC_est(1, 1)  !Ankit23May16: Added EDC_est out
-  end if
+  endif
 
 end subroutine set_RCMR_estimations
 
@@ -91,8 +91,8 @@ subroutine run_RCMR
         !TEC_calculated(ii_loop) = dummy_TEC_calculated
         ! call calc_single_vtec_interp(TEC_location(index_lz_tec(ii_loop),1), &
         !                              TEC_location(index_lz_tec(ii_loop) ,2), 0.1)
-      end do
-    end if
+      enddo
+    endif
 
   else
     call MPI_BARRIER(iCommGITM, iError)
@@ -103,10 +103,10 @@ subroutine run_RCMR
       do mm = 0, (nProcs - 1)
         if (Sat_Proc(mm + 1) .ne. 0) then
           SatAltDat(RCMRSat(1)) = Sat_Proc(mm + 1)   !Ankit: what is this doing??
-        end if
-      end do
-    end if
-  end if
+        endif
+      enddo
+    endif
+  endif
 
   !ANKIT: Added MPI_Bcast to update on all processors
   !ANKIT:5Feb15 - Added TEC bcasting from 12 locations
@@ -135,7 +135,7 @@ subroutine run_RCMR
     ulimit = 3000
   else
     write(*, *) "ERROR: unknown RCMR output type", RCMROutType
-  end if
+  endif
 
   ! Begin the first RCMR loop
   if (mod((istep - 1)*Dts, Measure_Dts) == 0.0 .AND. TRUTH_or_ID == 1 .AND. iProc == 0) then
@@ -148,12 +148,12 @@ subroutine run_RCMR
         !zp(ii_loop,ustep) = alpha*(TEC_calculated(ii_loop) - TEC_true(iStep,ii_loop))
         zp(ii_loop, ustep) = alpha*(TEC_calculated(ii_loop) - TEC_true(iStep, index_lz_tec(ii_loop)))
         !Ankit25Feb2015: added choice of tec station
-      end do
+      enddo
       !write(*,*) ustep, iStep, TEC_calculated, TEC_true(istep,1), zp(1,ustep)
       !write(*,*) ustep, iStep, TEC_calculated_P1, TEC_true(istep,2), zp(2,ustep)
     else
       zp(:, uStep) = SatAltDat(RCMRSat(1)) - SatCurrentDat(RCMRSat(1))
-    end if
+    endif
 
     ! Set the averaged error
     if (RCMROutType == "EDC") then          !ANKIT 4 Nov 2014
@@ -165,7 +165,7 @@ subroutine run_RCMR
         zav(:, ustep) = sum(zp(:, 1:uStep))/uStep
       else
         zav(:, ustep) = sum(zp(:, uStep - 120 + 1:uStep))/120
-      end if
+      endif
       z(:, uStep) = zav(:, uStep)           !Ankit 25Jan15 - Adds moving average filter to Z
       z(:, uStep) = zp(:, uStep)            !Ankit 25Jan15 - Removes the averaging from Z
     else
@@ -173,36 +173,36 @@ subroutine run_RCMR
         zav(:, ustep) = sum(zp(:, 1:uStep))/uStep
       else
         zav(:, ustep) = sum(zp(:, uStep - 120 + 1:uStep))/120
-      end if
+      endif
       y(1, uStep) = 1.0e12*zav(1, uStep)
       z(:, uStep) = 1.0e12*zav(1, uStep)
-    end if
+    endif
 
     if (ustep <= l_dim) then
       y_mat(:, l_dim - ustep + 1:l_dim) = y(:, 1:ustep)
       z_mat(:, l_dim - ustep + 1:l_dim) = z(:, 1:ustep)
       if (ustep > 1) then
         u_mat(:, l_dim - ustep + 2:l_dim) = u(:, 1:ustep - 1)
-      end if
+      endif
     else if (ustep > l_dim) then
       y_mat = y(:, ustep - (l_dim) + 1:ustep)
       u_mat = u(:, ustep - (l_dim):ustep - 1)
       z_mat = z(:, ustep - (l_dim) + 1:ustep)
-    end if
+    endif
 
     if (ustep <= Pc) then
       Pcc = ustep - 1
       if (Pcc < 0) then
         Pcc = 0
-      end if
+      endif
     else
       Pcc = Pc
-    end if
+    endif
     lu2 = lu*lu
 
     if (ustep > C_on) then
       control_on = 1
-    end if
+    endif
 
     if (RCMROutType == "EDC") then          ! ANKIT 6 Nov 2014
       !CALL RCMR_onestep(u_out, ustep, EDC_est, zp(:,ustep), y(:,ustep))
@@ -215,17 +215,17 @@ subroutine run_RCMR
       CALL RCMR_Function(llimit, ulimit, Nc, ustep, s_dhat, lz, lu, lu2, ly, &
                          l_dim, Pc, Pcc, control_on, dbuffer, C_on, dhat, eta, lambda, usum, &
                          T, R2, y_mat, z_mat, u_mat, P1, u_out, theta1, UB)
-    end if
+    endif
 
     ! write(*,*) istep, ustep, u_out(1,1)
 
     ! Enforce the realistic physical limitations
     if (u_out(1, 1) < llimit) then
       u_out(1, 1) = llimit
-    end if
+    endif
     if (u_out(1, 1) >= ulimit) then
       u_out(1, 1) = ulimit
-    end if
+    endif
 
     up(1, ustep) = u_out(1, 1)
 
@@ -240,16 +240,16 @@ subroutine run_RCMR
           up(1, uStep) = up(1, uStep - 1) + u_sat_level
         else
           up(1, uStep) = up(1, uStep - 1) - u_sat_level
-        end if
-      end if
+        endif
+      endif
       u(:, ustep) = up(:, uStep)             ! Remove filter
     else
       if (uStep <= uFiltLength) then
         u(:, ustep) = sum(up(:, 1:uStep))/uStep
       else
         u(:, ustep) = sum(up(:, uStep - uFiltLength + 1:uStep))/uFiltLength
-      end if
-    end if
+      endif
+    endif
 
     ! write(*,*) istep, ustep, up(1,ustep), u(1,ustep), output_est
 
@@ -261,7 +261,7 @@ subroutine run_RCMR
       output_est = u(1, ustep)
     else if (ustep <= C_on) then
       u(1, ustep) = output_est(1, 1)
-    end if
+    endif
 
     if (RCMROutType == 'F107') then
       f107_est = output_est(1, 1)
@@ -271,10 +271,10 @@ subroutine run_RCMR
     elseif (RCMROutType == "EDC") then !ANKIT 6 Oct 2014
       EDC_est = output_est
       !write (*,*) "EDC estimate is ", EDC_est, ustep
-    end if
+    endif
 
     ustep = ustep + 1
-  end if
+  endif
 
   ! END of the first RCMR loop
 
@@ -282,7 +282,7 @@ subroutine run_RCMR
   ! AGB Question: why use MPI_SCATTER and not MPI_Bcast?
   if (iProc == 0) then
     scattered(1) = output_est(1, 1)
-  end if
+  endif
 
   call MPI_SCATTER(scattered, 1, mpi_double_precision, scatter, 1, &
                    mpi_double_precision, 0, iCommGITM, iError)
@@ -295,7 +295,7 @@ subroutine run_RCMR
   else if (RCMROutType == 'EDC') then !ANKIT 6 Oct 2014
     EDC_est = scatter
     if (iProc == TEC_proc) call write_TEC_data
-  end if
+  endif
 
 end subroutine run_RCMR
 
@@ -372,7 +372,7 @@ subroutine RCMR_Function(llimit, ulimit, Nc, ustep, s_dhat, lz, lu, lu2, ly, &
   do iii = 1, lu
     Idty(iii, iii) = 1.0
     Inverted(iii, iii) = 1.0
-  end do
+  enddo
 
   ! Initialization
   zmod = 0.0
@@ -390,8 +390,8 @@ subroutine RCMR_Function(llimit, ulimit, Nc, ustep, s_dhat, lz, lu, lu2, ly, &
         lb_z = dhat(1, s_dhat)
         zmod(1 + (iii*lz):1 + (iii*lz) + lz - 1, 1) = z_mat(:, &
                                                             l_dim - (dhat(1, s_dhat) - dhatfl(1, iii + 1)))
-      end do make_zmod
-    end if
+      enddo make_zmod
+    endif
 
     umod(:, 1) = u_mat(:, l_dim - dhat(1, s_dhat) + 1); 
     zr(:, 1) = z_mat(:, size(z_mat, 2)); 
@@ -411,7 +411,7 @@ subroutine RCMR_Function(llimit, ulimit, Nc, ustep, s_dhat, lz, lu, lu2, ly, &
       Us(1, 1) = ulimit
     else if (Us(1, 1) <= llimit) then
       Us(1, 1) = llimit
-    end if
+    endif
 
     if (ustep > dbuffer) then
       !Strictly proper
@@ -424,7 +424,7 @@ subroutine RCMR_Function(llimit, ulimit, Nc, ustep, s_dhat, lz, lu, lu2, ly, &
 
       if (minval(pu) == 0.0) then
         pu = 0.0
-      end if
+      endif
 
       pum = reshape(pu, shape(pum))
 
@@ -453,15 +453,15 @@ subroutine RCMR_Function(llimit, ulimit, Nc, ustep, s_dhat, lz, lu, lu2, ly, &
         u_out = matmul(theta1, H1)
       else
         u_out = 0.0
-      end if
+      endif
     else
       u_out = 0.0
       theta1 = theta1
-    end if
+    endif
   else
     u_out = 0.0
     theta1 = theta1
-  end if
+  endif
 
   return
 end subroutine RCMR_Function
@@ -498,13 +498,13 @@ subroutine RCMR_onestep(u_out1, kk, u_in, z_in, y_in, ESTIMATE)
   y_h(:, 2:NC + 1) = y_h(:, 1:NC)
   DO iii = 1, lu
     u_h(iii, 1) = u_in(iii, 1)
-  END DO
+  ENDDO
   DO iii = 1, lz
     z_h(iii, 1) = z_in(iii, 1)
-  END DO
+  ENDDO
   DO iii = 1, ly
     y_h(iii, 1) = y_in(iii, 1)
-  END DO
+  ENDDO
 
   ! Stack up u's and performance here
   !IF (kk > Nc) THEN
@@ -516,7 +516,7 @@ subroutine RCMR_onestep(u_out1, kk, u_in, z_in, y_in, ESTIMATE)
       Vphi = z_h(:, 2:NC + 1)
     ELSE
       Vphi = y_h(:, 2:NC + 1)
-    END IF
+    ENDIF
     UphiVec = reshape(Uphi, shape(UphiVec))
     VphiVec = reshape(Vphi, shape(VphiVec))
 
@@ -525,14 +525,14 @@ subroutine RCMR_onestep(u_out1, kk, u_in, z_in, y_in, ESTIMATE)
       phi_reg(lu*NC + 1:(lz + lu)*NC, :) = VphiVec
     ELSE
       phi_reg(lu*NC + 1:(ly + lu)*NC, :) = VphiVec
-    END IF
+    ENDIF
      !! call kronecker(PHI, phi_reg)
     DO iii = 1, lu
       DO jjj = 1, lphi
         PHI(iii, jjj + (lu - 1)*lphi) = phi_reg(jjj, 1)
-      END DO
-    END DO
-  END IF
+      ENDDO
+    ENDDO
+  ENDIF
 
 !  write(*,*) "Phi regressor is ", phi_reg
 !  write(*,*) "PHI ", PHI
@@ -545,15 +545,15 @@ subroutine RCMR_onestep(u_out1, kk, u_in, z_in, y_in, ESTIMATE)
   PHIbar(lu + 1:lu*(nf_u + 1), :) = PHIbar(1:lu*nf_Nu, :)   !! Fixed lu
   DO iii = 1, lu
     Ubar(iii, 1) = u_in(iii, 1)
-  END DO
+  ENDDO
   DO iii = 1, lz
     Zbar(iii, 1) = z_in(iii, 1)
-  END DO
+  ENDDO
   DO jjj = 1, lu
     DO iii = 1, ltheta
       PHIbar(jjj, iii) = PHI(jjj, iii)
-    END DO
-  END DO
+    ENDDO
+  ENDDO
 
 !  z_filtered      = reshape(matmul(Nz, reshape(Zbar, (/lz*(nf_z+1)/))) &
 !                             - matmul(Dz, reshape(Zfbar, (/lz*nf_Dz/))), (/lz,1/))
@@ -575,15 +575,15 @@ subroutine RCMR_onestep(u_out1, kk, u_in, z_in, y_in, ESTIMATE)
 
   DO iii = 1, lz
     Ufbar(iii, 1) = u_filtered(iii, 1)
-  END DO
+  ENDDO
   DO iii = 1, lz
     Zfbar(iii, 1) = z_filtered(iii, 1)
-  END DO
+  ENDDO
   DO jjj = 1, lz
     DO iii = 1, ltheta
       PHIfbar(jjj, iii) = PHI_filtered(jjj, iii)
-    END DO
-  END DO
+    ENDDO
+  ENDDO
 
   z_hat = z_filtered + matmul(PHI_filtered, reshape(theta_h(:, 1), (/ltheta, 1/))) - u_filtered
 
@@ -606,17 +606,17 @@ subroutine RCMR_onestep(u_out1, kk, u_in, z_in, y_in, ESTIMATE)
       Rp(lz + 1:lz + lu, lz + 1:lz + lu) = Ru
       DO iii = 1, lz
         Rbarinv(iii, iii) = 1/(W_Rz + W_Ruf)
-      END DO
+      ENDDO
       DO iii = lz + 1, lz + lu
         Rbarinv(iii, iii) = 1/W_Ru
-      END DO
-    END IF
+      ENDDO
+    ENDIF
 
     Ginv = (lambda1*Rbarinv + matmul(matmul(XX, PP), transpose(XX)))
     tau = 0.0
     Do iii = 1, lv
       tau(iii, iii) = 1.0
-    end do
+    enddo
 
     call LAPACK_getrf(lv, lv, Ginv, lv, IPIV, INFO)
     CALL LAPACK_getrs('n', lv, lv, Ginv, lv, IPIV, Tau, lv, INFO)
@@ -656,12 +656,12 @@ subroutine RCMR_onestep(u_out1, kk, u_in, z_in, y_in, ESTIMATE)
       write(*, *) "Rzp \n", Rzp
       write(*, *) "thetaout \n", thetaout
       write(*, *) "PP \n", PP
-    end if
+    endif
 
     theta_h(:, 2) = theta_h(:, 1)
     DO iii = 1, ltheta
       theta_h(iii, 1) = thetaout(iii, 1)
-    END DO
+    ENDDO
     u_out1 = matmul(PHI, thetaout)
 
     !     write(121) kk, transpose(u_in), transpose(z_in), transpose(y_in), transpose(u_out1), transpose(thetaout)
@@ -678,7 +678,7 @@ subroutine RCMR_onestep(u_out1, kk, u_in, z_in, y_in, ESTIMATE)
 
   else
     u_out1 = ESTIMATE
-  END IF
+  ENDIF
 
   !Ankit 5May2015: The following code writes theta to theta.dat
   IF (kk > C_on) THEN
@@ -687,14 +687,14 @@ subroutine RCMR_onestep(u_out1, kk, u_in, z_in, y_in, ESTIMATE)
       open(12345, file="theta.dat", status="old", position="append", action="write")
     else
       open(12345, file="theta.dat", status="new", action="write")
-    end if
+    endif
 
     do iii = 1, ltheta
       write(12345, *) thetaout(iii, 1)
-    end do
+    enddo
 
     close(12345)
-  end if
+  endif
 
 end subroutine RCMR_onestep
 

--- a/src/Titan.f90
+++ b/src/Titan.f90
@@ -236,12 +236,12 @@ subroutine calc_planet_sources(iBlock)
     else
       !write(*,*) 'Call cool to space'
       call calc_cooltospace(iBlock)
-    end if
+    endif
   elseif (maxval(HCNCoolRatio) .eq. 0.0) then
     call calc_radcooling(iBlock)
   else
     call calc_radcooling(iBlock)
-  end if
+  endif
 
   RadCooling(1:nLons, 1:nLats, 1:nAlts, iBlock) = &
     RadCoolingRate(1:nLons, 1:nLats, 1:nAlts, iBlock)/ &
@@ -394,15 +394,15 @@ subroutine calc_planet_sources(iBlock)
 
             call get_glow(iLon, iLat, iBlock)
 
-          end do
-        end do
+          enddo
+        enddo
 
         call end_timing("glow")
 
-      end if
-    end if
+      endif
+    endif
     PhotoElectronDensity(:, :, :, :, iBlock) = PhotoElectronRate(:, :, :, :, iBlock)*dt
-  end if
+  endif
 
 end subroutine calc_planet_sources
 
@@ -462,9 +462,9 @@ subroutine calc_eddy_diffusion_coefficient(iBlock)
 !
 !           endif
 
-      end do
-    end do
-  end do
+      enddo
+    enddo
+  enddo
 
 end subroutine calc_eddy_diffusion_coefficient
 
@@ -683,8 +683,8 @@ subroutine calc_radcooling(iBlock)
                 + pmat(iLine, 8)*(T(iAlt)**7) &
                 + pmat(iLine, 9)*(T(iAlt)**8))
 
-        end do! iLine = 1, NLINES
-      end do !iAlt = -1, nAlts+2
+        enddo! iLine = 1, NLINES
+      enddo !iAlt = -1, nAlts+2
 
 ! ------------------------------------------------------------------------
 ! Frequency Integration Variables TM,VJM,ZM,NHCNM (1:nlines,1:nAlts)
@@ -711,8 +711,8 @@ subroutine calc_radcooling(iBlock)
           ALPHAL(iLine, iAlt) = &
             GammaNew(iLine, iAlt)*(Speed_Light*100.0)   !! This is AlphaL in Hz
 
-        end do  ! End iLine
-      end do ! End iAlt
+        enddo  ! End iLine
+      enddo ! End iAlt
 
 ! ------------------------------------------------------------------------
 ! DOPPLER HALFWIDTHS AT GIVEN TEMPERATURES -------------------------------
@@ -757,7 +757,7 @@ subroutine calc_radcooling(iBlock)
           (FreqQuadAbscissas(k + 1)*(VULIM - VLLIM) + VULIM + VLLIM)*.5
         NewV(MiddleFreqIndex + k, :, :) = &
           (-1.0*FreqQuadAbscissas(k + 1)*(VULIM - VLLIM) + VULIM + VLLIM)*.5
-      end do
+      enddo
 
       DFACT = SQRT(alog(2.0)/PI)
 
@@ -817,9 +817,9 @@ subroutine calc_radcooling(iBlock)
                ((Speed_Light)**2))* &
               (NewV(iFreq, iLine, iAlt)**3)*Bfactor
 
-          end do
-        end do
-      end do
+          enddo
+        enddo
+      enddo
 
 ! ------------------------------------------------------------------------
 ! Cooling CALCULATIONS
@@ -834,7 +834,7 @@ subroutine calc_radcooling(iBlock)
         Y1 = NewBv(MiddleFreqIndex - iFreq, :, :)*NewVOI(MiddleFreqIndex - iFreq, :, :)
         Y2 = NewBv(MiddleFreqIndex + iFreq, :, :)*NewVOI(MiddleFreqIndex + iFreq, :, :)
         NEW = NEW + FreqQuadWeights(iFreq + 1)*(Y1 + Y2)
-      end do
+      enddo
 
       gcool(:, :) = (VULIM(:, :) - VLLIM(:, :))*NEW*0.5
 ! Multiply by the Intensity of the lines and a geometric factor of 4pi
@@ -920,8 +920,8 @@ subroutine calc_radcooling(iBlock)
 
 !   real , Dimension(1:nLons,1:nLats,1:nAlts,nBlocksMax) :: HCNCoolRatio
 
-    end do  ! End Outer Latitude-Loop
-  end do  ! End Outer Longitude-Loop
+    enddo  ! End Outer Latitude-Loop
+  enddo  ! End Outer Longitude-Loop
 
   call end_timing("calc_radcooling")
 
@@ -994,7 +994,7 @@ contains
 
       do iAlt = -1, nAlts + 2
         TauMax(1:NLINES, iAlt) = TauIn(iFreq, 1:NLINES, -1)
-      end do
+      enddo
       DTAU(:, :) = TauMax(:, :) - TauIn(iFreq, :, :)
       call expint1(DTau(:, 0:nAlts + 2), EXPTAU(:, 0:nAlts + 2), nAlts)
 !
@@ -1003,14 +1003,14 @@ contains
         FACTOR20(:, iAlt) = &
           EXP(-DTAU(:, iAlt)) - &
           DTAU(:, iAlt)*EXPTAU(:, iAlt)
-      end do
+      enddo
 
       do iAlt = -1, nAlts + 2
         TOTAL(iFreq, :, iAlt) = &
           FACTOR20(:, iAlt)* &
           PHI(iFreq, :, iAlt)
-      end do
-    end do ! Outer iFreq loop
+      enddo
+    enddo ! Outer iFreq loop
 
     S = 0.0   ! This is our Integral Sum
     S = S + FreqQuadWeights(1)* &
@@ -1021,7 +1021,7 @@ contains
       S = S + FreqQuadWeights(iFreq + 1)* &
           (Planck(MiddleFreqIndex + iFreq, :, :)*TOTAL(MiddleFreqIndex + iFreq, :, :) + &
            Planck(MiddleFreqIndex - iFreq, :, :)*TOTAL(MiddleFreqIndex - iFreq, :, :))
-    end do
+    enddo
 
     gheat1 = (0.5)*(B - A)*S
 
@@ -1101,7 +1101,7 @@ contains
     DO
       IF (2**m .EQ. NPTS) EXIT
       m = m + 1
-    END DO
+    ENDDO
 !      write(*,*) 'm = ', m
 !!!! We integrate from the top downward
 !!!! We can then add each increment to the next
@@ -1117,8 +1117,8 @@ contains
 !!! Store TopDepth in our Optical Depth Array
         ITAU(iFreq, iLine, nAlts + 2) = TopDepth(iFreq, iLine)  !! Top Optical Depth
 !            write(*,*) 'iFreq, iLine, TopDepth = ', iFreq, iLine, TopDepth(iFreq,iLine)
-      end do  ! Rotational Lines Loop
-    end do  ! Frequency Gaussian Points Loop
+      enddo  ! Rotational Lines Loop
+    enddo  ! Frequency Gaussian Points Loop
 
 !!!! Begin Altitude Loop -------- Integrate Downward
     do iAlt = nAlts + 1, -1, -1
@@ -1133,7 +1133,7 @@ contains
       do k = 1, NPTS/2
         x(2*k - 1) = 0.5*(Qf1(k, m)*(B - A) + B + A)
         x(2*k) = 0.5*(-Qf1(k, m)*(B - A) + B + A)
-      end do
+      enddo
 
       ! Do the Middle Frequency (the core of the lineshape)
       NewTotalAbove(1:NLINES) = PHI(MiddleFreqIndex, 1:NLINES, iAlt + 1)* &
@@ -1157,7 +1157,7 @@ contains
 
         DEPTH(n, MiddleFreqIndex, 1:NLINES, iAlt) = &
           exp(InterpLnTotal(1:NLINES))
-      end do
+      enddo
 
 !!! Optical Depth of the Line Center
       TauSum(1:NLINES) = 0.0
@@ -1166,7 +1166,7 @@ contains
           TauSum(1:NLINES) + &
           Qd(k, m)*(DEPTH(2*k - 1, MiddleFreqIndex, 1:NLINES, iAlt) + &
                     DEPTH(2*k, MiddleFreqIndex, 1:NLINES, iAlt))
-      end do ! Loop over Altitude Points
+      enddo ! Loop over Altitude Points
       TauSum(1:NLINES) = 0.5*TauSum(1:NLINES)*(B - A)
 
       ITAU(MiddleFreqIndex, 1:NLINES, iAlt) = &
@@ -1203,7 +1203,7 @@ contains
           DEPTH(n, MiddleFreqIndex - iFreq, 1:NLINES, iAlt) = &
             exp(InterpLnTotal(1:NLINES))
 
-        end do  ! Loop over Altitude Gaussian Points
+        enddo  ! Loop over Altitude Gaussian Points
 
 !!! Now Calculate the Optical Depth of the new layer (iAlt)
 !!! And add the layer above it (iAlt + 1)
@@ -1213,7 +1213,7 @@ contains
             TauSum(1:NLINES) + &
             Qd(k, m)*(DEPTH(2*k - 1, MiddleFreqIndex + iFreq, 1:NLINES, iAlt) + &
                       DEPTH(2*k, MiddleFreqIndex + iFreq, 1:NLINES, iAlt))
-        end do ! Loop over Altitude Points
+        enddo ! Loop over Altitude Points
         TauSum(1:NLINES) = 0.5*TauSum(1:NLINES)*(B - A)
 
         ITAU(MiddleFreqIndex + iFreq, 1:NLINES, iAlt) = &
@@ -1223,8 +1223,8 @@ contains
         ITAU(MiddleFreqIndex - iFreq, 1:NLINES, iAlt) = &
           ITAU(MiddleFreqIndex - iFreq, 1:NLINES, iAlt + 1) + &
           TauSum(1:NLINES)
-      end do !k = 1, iFreq, FreqIndexMax
-    end do !iAlt = nAlts+1, -1, -1
+      enddo !k = 1, iFreq, FreqIndexMax
+    enddo !iAlt = nAlts+1, -1, -1
   end subroutine Sumfgausstau
 
   subroutine Newheat4gauss(V, SJ, ALPHAD, NHCNM, gheat4, TM, &
@@ -1335,7 +1335,7 @@ contains
     DO
       IF (2**m .EQ. NPTS) EXIT
       m = m + 1
-    END DO
+    ENDDO
 
 ! ---------------
 ! FOR LOOP BEGIN-
@@ -1387,7 +1387,7 @@ contains
             !write(*,*) 'GaussPoint(2p), GaussPoint(2p-1)  = ', &
             !           p, LocalXH(2*p-1), LocalXH(2*p)
 
-          end do
+          enddo
           ! At each Gausspoint, we need to do a linear interpolation:
 !              write(*,*) 'Tau(jAlt) and Tau(jAlt+1) = ', &
 !                  TAU(iFreq,35,jAlt), TAU(iFreq,35,jAlt+1)
@@ -1427,7 +1427,7 @@ contains
             ! The Integrand is Bv*E1(Tau(z) - Tau(z'))*dTau
             ! The dTAu is the size of the "slab" of atmosphere between
             ! jAlt + 1 and jAlt
-          end do
+          enddo
 
             !! Add the Altitudes together to get a total contribution from the slab
           ! We need to keep adding each slab to this ConFuncBelow Variable
@@ -1437,7 +1437,7 @@ contains
               0.5*Qd(p, m)*(Integrand(2*p, 1:NLINES) + &
                             Integrand(2*p - 1, 1:NLINES))* &
               (TAU(iFreq, 1:NLINES, jAlt) - TAU(iFreq, 1:NLINES, jAlt + 1))
-          end do ! p loop
+          enddo ! p loop
 
           ! Assume Symmetry around the Central Frequency
           ContFuncBelow(MiddleFreqIndex - k, :, iAlt) = &
@@ -1445,7 +1445,7 @@ contains
           ! This Loop integrates over the Interpolation points,
           ! Which completely accounts for the atmospheric slab
           ! Between jAlt and jAlt+1
-        end do ! Loop over jAlt (Z') Bell et al. [2008]
+        enddo ! Loop over jAlt (Z') Bell et al. [2008]
 
         ! Same as jAlt Loop above, but now for the
         ! Atmosphere above you
@@ -1470,7 +1470,7 @@ contains
 !              write(*,*) 'GaussPoint(2p), GaussPoint(2p-1)  = ', &
 !                         p, LocalXH(2*p-1), LocalXH(2*p)
 
-          end do
+          enddo
 
           ! At each Gausspoint, we need to do a linear interpolation:
 
@@ -1510,7 +1510,7 @@ contains
             ! The Integrand is Bv*E1(Tau(z) - Tau(z'))*dTau
             ! The dTAu is the size of the "slab" of atmosphere between
             ! jAlt + 1 and jAlt
-          end do
+          enddo
 
            !! Add the Altitudes together to get a total contribution from the slab
           ! We need to keep adding each slab to this ConFuncBelow Variable
@@ -1521,16 +1521,16 @@ contains
                             Integrand(2*p - 1, 1:NLINES))* &
               (TAU(iFreq, 1:NLINES, jAlt - 1) - TAU(iFreq, 1:NLINES, jAlt))
 
-          end do ! p loop
+          enddo ! p loop
           ContFuncAbove(MiddleFreqIndex - k, :, iAlt) = &
             ContFuncAbove(iFreq, :, iAlt)
           ! This Loop integrates over the Interpolation points,
           ! Which completely accounts for the atmospheric slab
           ! Between jAlt and jAlt+1
-        end do ! Loop over jAlt (Z') Bell et al. [2008]
+        enddo ! Loop over jAlt (Z') Bell et al. [2008]
 
-      end do !iAlt  Outer Integration Loop
-    end do !k = 0,FreqIndexMax
+      enddo !iAlt  Outer Integration Loop
+    enddo !k = 0,FreqIndexMax
 
     ! NewNFreqs, NLines, -1:nAlts+2
     QTOT(:, :, 1:nAlts) = &
@@ -1548,7 +1548,7 @@ contains
       S = S + FreqQuadWeights(iFreq + 1)* &
           (QTOT(MiddleFreqIndex + iFreq, :, :)*PHI(MiddleFreqIndex + iFreq, :, :) + &
            QTOT(MiddleFreqIndex - iFreq, :, :)*PHI(MiddleFreqIndex - iFreq, :, :))
-    end do
+    enddo
     gheat4 = 0.5*(VULIM - VLLIM)*S
 
   end subroutine Newheat4gauss
@@ -1601,7 +1601,7 @@ contains
       del = c*d
       h = h*del
       IF (MAXVAL(ABS(del) - 1.0) <= EPS*1.0D13) EXIT
-    END DO
+    ENDDO
 
     EXPH = h*exp(-x)
 
@@ -1619,7 +1619,7 @@ contains
       del = -fact/i
       EXPL = EXPL + del
       IF (MAXVAL(ABS(del)) <= MAXVAL(ABS(EXPL))*EPS) EXIT
-    END DO
+    ENDDO
 
     WHERE (x < 1.0D0)
       ans = EXPL
@@ -1675,7 +1675,7 @@ contains
       del = c*d
       h = h*del
       IF (MAXVAL(ABS(del) - 1.0) <= EPS*1.0e13) EXIT
-    END DO
+    ENDDO
 
     EXPH = h*exp(-x)
 
@@ -1693,7 +1693,7 @@ contains
       del = -fact/i
       EXPL = EXPL + del
       IF (MAXVAL(ABS(del)) <= MAXVAL(ABS(EXPL))*EPS) EXIT
-    END DO
+    ENDDO
 
     WHERE (x < 1.0)
       ans = EXPL
@@ -1797,9 +1797,9 @@ subroutine calc_saturn_tides(iBlock)
           (6.0*e_titan*cos(Latitude(iLat, iBlock))*cos(2.0*Longitude(iLon, iBlock)))* &
           sin(OmegaBodyInput*tSimulation)
 
-      end do !iLon = -1, nLons+2
-    end do !iLat = -1, nLats+2
-  end do !iAlt = -1, nAlts+2
+      enddo !iLon = -1, nLons+2
+    enddo !iLat = -1, nLats+2
+  enddo !iAlt = -1, nAlts+2
 
   ! Remove the tides for now
   TideADep = 0.0
@@ -1977,8 +1977,8 @@ subroutine calc_cooltospace(iBlock)
                 + pmat(iLine, 8)*(T(iAlt)**7) &
                 + pmat(iLine, 9)*(T(iAlt)**8))
 
-        end do! iLine = 1, NLINES
-      end do !iAlt = -1, nAlts+2
+        enddo! iLine = 1, NLINES
+      enddo !iAlt = -1, nAlts+2
 
 ! ------------------------------------------------------------------------
 ! Frequency Integration Variables TM,VJM,ZM,NHCNM (1:nlines,1:nAlts)
@@ -2005,8 +2005,8 @@ subroutine calc_cooltospace(iBlock)
           ALPHAL(iLine, iAlt) = &
             GammaNew(iLine, iAlt)*(Speed_Light*100.0)   !! This is AlphaL in Hz
 
-        end do  ! End iLine
-      end do ! End iAlt
+        enddo  ! End iLine
+      enddo ! End iAlt
 
 ! ------------------------------------------------------------------------
 ! DOPPLER HALFWIDTHS AT GIVEN TEMPERATURES -------------------------------
@@ -2051,7 +2051,7 @@ subroutine calc_cooltospace(iBlock)
           (FreqQuadAbscissas(k + 1)*(VULIM - VLLIM) + VULIM + VLLIM)*.5
         NewV(MiddleFreqIndex + k, :, :) = &
           (-1.0*FreqQuadAbscissas(k + 1)*(VULIM - VLLIM) + VULIM + VLLIM)*.5
-      end do
+      enddo
 
       DFACT = SQRT(alog(2.0)/PI)
 
@@ -2111,9 +2111,9 @@ subroutine calc_cooltospace(iBlock)
                ((Speed_Light)**2))* &
               (NewV(iFreq, iLine, iAlt)**3)*Bfactor
 
-          end do
-        end do
-      end do
+          enddo
+        enddo
+      enddo
 
 ! ------------------------------------------------------------------------
 ! Cooling CALCULATIONS
@@ -2128,7 +2128,7 @@ subroutine calc_cooltospace(iBlock)
         Y1 = NewBv(MiddleFreqIndex - iFreq, :, :)*NewVOI(MiddleFreqIndex - iFreq, :, :)
         Y2 = NewBv(MiddleFreqIndex + iFreq, :, :)*NewVOI(MiddleFreqIndex + iFreq, :, :)
         NEW = NEW + FreqQuadWeights(iFreq + 1)*(Y1 + Y2)
-      end do
+      enddo
 
       gcool(:, :) = (VULIM(:, :) - VLLIM(:, :))*NEW*0.5
 ! Multiply by the Intensity of the lines and a geometric factor of 4pi
@@ -2147,8 +2147,8 @@ subroutine calc_cooltospace(iBlock)
       RadCoolingRate(iLon, iLat, 1:nAlts, iBlock) = &
         COOL(1:nAlts)*HCNCoolRatio(iLon, iLat, 1:nAlts, iBlock)
 
-    end do ! iLat
-  end do ! iLon
+    enddo ! iLat
+  enddo ! iLon
 
 end subroutine !calc_cooltospace(iBlock)
 

--- a/src/add_sources.f90
+++ b/src/add_sources.f90
@@ -25,9 +25,9 @@ subroutine add_sources
       call UA_calc_electrodynamics(iLon, iLat)
     else
       call UA_calc_electrodynamics_1d
-    end if
+    endif
     IsFirstTime = .false.
-  end if
+  endif
 
   do iBlock = 1, nBlocks
 
@@ -91,7 +91,7 @@ subroutine add_sources
       Velocity(1:nLons, 1:nLats, 0:nAlts + 1, iDir, iBlock) = &
         Velocity(1:nLons, 1:nLats, 0:nAlts + 1, iDir, iBlock) + &
         Viscosity(1:nLons, 1:nLats, 0:nAlts + 1, iDir)
-    end do
+    enddo
 
      !! To turn off NeutralFriction, turn UseNeutralFriction=.false. in UAM.in
     do iSpecies = 1, nSpecies
@@ -104,7 +104,7 @@ subroutine add_sources
       VerticalVelocity(1:nLons, 1:nLats, 0:nAlts + 1, iSpecies, iBlock) = &
         VerticalVelocity(1:nLons, 1:nLats, 0:nAlts + 1, iSpecies, iBlock) + &
         VerticalViscosityS(1:nLons, 1:nLats, 0:nAlts + 1, iSpecies)
-    end do
+    enddo
 
     !-------------------------------------------------------------------------
     ! Electron Temperatures
@@ -123,7 +123,7 @@ subroutine add_sources
       IDensityS(:, :, :, ie_, iBlock) = &
         IDensityS(:, :, :, ie_, iBlock) + &
         IDensityS(:, :, :, iIon, iBlock)
-    end do
+    enddo
 
     Rho(1:nLons, 1:nLats, 1:nAlts, iBlock) = 0.0
     NDensity(1:nLons, 1:nLats, 1:nAlts, iBlock) = 0.0
@@ -137,7 +137,7 @@ subroutine add_sources
       NDensity(1:nLons, 1:nLats, 1:nAlts, iBlock) = &
         NDensity(1:nLons, 1:nLats, 1:nAlts, iBlock) + &
         NDensityS(1:nLons, 1:nLats, 1:nAlts, iSpecies, iBlock)
-    end do
+    enddo
 
     ! Have to do this separately, since depends on Rho
     do iSpecies = 1, nSpecies
@@ -147,14 +147,14 @@ subroutine add_sources
         Mass(iSpecies)* &
         NDensityS(1:nLons, 1:nLats, 1:nAlts, iSpecies, iBlock)/ &
         Rho(1:nLons, 1:nLats, 1:nAlts, iBlock)
-    end do
+    enddo
 
-  end do
+  enddo
 
   if (DoCheckForNans) then
     call check_for_nans_ions("After Sources")
     call check_for_nans_neutrals("After Sources")
     call check_for_nans_temps("After Sources")
-  end if
+  endif
 
 end subroutine add_sources

--- a/src/advance.f90
+++ b/src/advance.f90
@@ -45,7 +45,7 @@ subroutine advance
 
   else
     dt = DtStatisticalModels
-  end if
+  endif
 
   ! Increment time and all the time associated variables
   call update_time
@@ -56,7 +56,7 @@ subroutine advance
     call init_msis
     call init_iri
     call init_b0
-  end if
+  endif
 
   call end_timing("advance")
 

--- a/src/advance_horizontal.f90
+++ b/src/advance_horizontal.f90
@@ -28,7 +28,7 @@ subroutine advance_horizontal_all
 
     call advance_horizontal(iBlock)
 
-  end do
+  enddo
 
   ! Sync everything up again.
 
@@ -36,13 +36,13 @@ subroutine advance_horizontal_all
 
   do iBlock = 1, nBlocks
     if (.not. IsFullSphere) call set_horizontal_bcs(iBlock)
-  end do
+  enddo
 
   if (DoCheckForNans) then
     call check_for_nans_ions("After Horizontal")
     call check_for_nans_neutrals("After Horizontal")
     call check_for_nans_temps("After Horizontal")
-  end if
+  endif
 
   call end_timing("horizontal_all")
 
@@ -362,19 +362,19 @@ subroutine advance_horizontal(iBlock)
               stop
               NewNum_CV(iLon, iLat, iSpecies) = 1.0
               IsFound = .true.
-            end if
-          end do
+            endif
+          enddo
           If (IsFound) then
             Rho(iLon, iLat, iAlt, iBlock) = 0.0
             do iSpecies = 1, nSpecies
               Rho(iLon, iLat, iAlt, iBlock) = &
                 Rho(iLon, iLat, iAlt, iBlock) + &
                 NewNum_CV(iLon, iLat, iSpecies)*Mass(iSpecies)
-            end do
-          end if
-        end do
-      end do
-    end if
+            enddo
+          endif
+        enddo
+      enddo
+    endif
 
     NDensityS(1:nLons, 1:nLats, iAlt, 1:nSpecies, iBlock) = NewNum_CV
 
@@ -384,10 +384,10 @@ subroutine advance_horizontal(iBlock)
           do iDir = 1, 3
             if (ieee_is_nan(Velocity(iLon, iLat, iAlt, iDir, 1))) &
               write(*, *) 'Velocity is nan : ', iLon, iLat, iAlt, iDir
-          end do
-        end do
-      end do
-    end if
+          enddo
+        enddo
+      enddo
+    endif
 
     if (UseIonAdvection) then
 
@@ -403,11 +403,11 @@ subroutine advance_horizontal(iBlock)
 !                            Latitude(iLon,iBlock)*180/pi, &
 !                            Altitude(iAlt)/1000.0, iIon
                 NewINum_CV(iLon, iLat, iIon) = 1.0e2
-              end if
-            end do
-          end do
-        end do
-      end if
+              endif
+            enddo
+          enddo
+        enddo
+      endif
 
       IDensityS(1:nLons, 1:nLats, iAlt, 1:nIonsAdvect, iBlock) = NewINum_CV
       !\
@@ -418,10 +418,10 @@ subroutine advance_horizontal(iBlock)
         IDensityS(1:nLons, 1:nLats, iAlt, ie_, iBlock) = &
           IDensityS(1:nLons, 1:nLats, iAlt, ie_, iBlock) + &
           IDensityS(1:nLons, 1:nLats, iAlt, iIon, iBlock)
-      end do
-    end if
+      enddo
+    endif
 
-  end do
+  enddo
 
   if (UseIonAdvection .and. UseImprovedIonAdvection) then
 
@@ -437,7 +437,7 @@ subroutine advance_horizontal(iBlock)
         Vi = iVelocity(:, :, :, iDir, iBlock)
       else
         Vi = iVelocityPar(:, :, :, iDir, iBlock)
-      end if
+      endif
 
       ! Calculate Gradient First:
       call UAM_Gradient(Vi, IVelGradient, iBlock)
@@ -466,10 +466,10 @@ subroutine advance_horizontal(iBlock)
                 DivIVelocityLocal(iLon, iLat, iAlt) - &
                 TanLat*Vi(iLon, iLat, iAlt)* &
                 InvRadialDistance_GB(iLon, iLat, iAlt, iBlock)
-            end do
-          end do
-        end do
-      end if
+            enddo
+          enddo
+        enddo
+      endif
 
       if (iDir == 3) then
         ! Add to divergence for radial:
@@ -482,19 +482,19 @@ subroutine advance_horizontal(iBlock)
                 2*Vi(iLon, iLat, iAlt)* &
                 InvRadialDistance_GB(iLon, iLat, iAlt, iBlock)
 
-            end do
-          end do
-        end do
-      end if
+            enddo
+          enddo
+        enddo
+      endif
 
-    end do
+    enddo
 
     ! supress near the poles:
     do iLat = 1, nLats
       DivIVelocityLocal(1:nLons, iLat, 1:nAlts) = &
         DivIVelocityLocal(1:nLons, iLat, 1:nAlts)* &
         CosLatitude(iLat, iBlock)
-    end do
+    enddo
 
     ! New Source Term for the ion density:
 
@@ -502,17 +502,17 @@ subroutine advance_horizontal(iBlock)
       change = dt*DivIVelocityLocal
       IDensityS(1:nLons, 1:nLats, 1:nAlts, iIon, iBlock) = &
         IDensityS(1:nLons, 1:nLats, 1:nAlts, iIon, iBlock)/(1 + change)
-    end do
+    enddo
 
     IDensityS(:, :, :, ie_, iBlock) = 0.0
     do iIon = 1, nIons - 1
       IDensityS(:, :, :, ie_, iBlock) = &
         IDensityS(:, :, :, ie_, iBlock) + IDensityS(:, :, :, iIon, iBlock)
-    end do
+    enddo
 
     if (DoCheckForNans) call check_for_nans_ions('After divergence')
 
-  end if
+  endif
 
   if (iDebugLevel > 2) &
     write(*, *) "===> advance_horizontal, MaxDiff, IVel, IDens, Dt : ", &
@@ -573,7 +573,7 @@ contains
       dVarDAlt_C = HalfInvDAlt_C* &
                    (Rho(1:nLons, 1:nLats, iAlt + 1, iBlock) &
                     - Rho(1:nLons, 1:nLats, iAlt - 1, iBlock))
-    end if
+    endif
     call calc_rusanov_lons(Rho_C, GradLonRho_C, DiffLonRho_C)
     call calc_rusanov_lats(Rho_C, GradLatRho_C, DiffLatRho_C)
 
@@ -597,7 +597,7 @@ contains
                              GradLonIVel_CD(:, :, iDim), DiffLonIVel_CD(:, :, iDim))
       call calc_rusanov_lats(IVel_CD(:, :, iDim), &
                              GradLatIVel_CD(:, :, iDim), DiffLatIVel_CD(:, :, iDim))
-    end do
+    enddo
 
     do iLat = 1, nLats
       DivVel_C(:, iLat) = &
@@ -618,7 +618,7 @@ contains
 !          DivIVel_C(:,iLat) = 0.0
 !       endif
 
-    end do
+    enddo
 
     do iSpc = 1, nSpecies
       if (UseTopography) dVarDAlt_C = HalfInvDAlt_C* &
@@ -637,7 +637,7 @@ contains
       call calc_rusanov_lats(VertVel_CV(:, :, iSpc), &
                              GradLatVertVel_CV(:, :, iSpc), DiffLatVertVel_CV(:, :, iSpc))
 
-    end do
+    enddo
 
     do iSpc = 1, nIonsAdvect
       if (UseTopography) dVarDAlt_C = HalfInvDAlt_C* &
@@ -647,7 +647,7 @@ contains
                              GradLonINum_CV(:, :, iSpc), DiffLonINum_CV(:, :, iSpc))
       call calc_rusanov_lats(INum_CV(:, :, iSpc), &
                              GradLatINum_CV(:, :, iSpc), DiffLatINum_CV(:, :, iSpc))
-    end do
+    enddo
 
     SinLat = sin(Latitude(1:nLats, iBlock))
     CosLat = CosLatitude(1:nLats, iBlock)
@@ -680,7 +680,7 @@ contains
                                         + GradLonNum_CV(iLon, iLat, iSpc)*Vel_CD(iLon, iLat, iEast_)) &
                                         + Dt*( &
                                         DiffLonNum_CV(iLon, iLat, iSpc) + DiffLatNum_CV(iLon, iLat, iSpc))
-        end do
+        enddo
 
 !...........add divergence term to the horizontal solver of the IONS...........
 !...........below is the original codes -chen
@@ -712,7 +712,7 @@ contains
                                          DiffLonINum_CV(iLon, iLat, iSpc) + &
                                          DiffLatINum_CV(iLon, iLat, iSpc))
 !             endif
-        end do
+        enddo
 
         RhoTest = sum(Mass(1:nSpecies)*NewNum_CV(iLon, iLat, 1:nSpecies))
 
@@ -776,7 +776,7 @@ contains
             + Dt*( &
             DiffLatVertVel_CV(iLon, iLat, iSpc) + &
             DiffLonVertVel_CV(iLon, iLat, iSpc))
-        end do
+        enddo
 
         if (UseCoriolis) then
 
@@ -789,7 +789,7 @@ contains
                                            CentrifugalParameter &
                                            *RadialDistance_GB(iLon, iLat, iAlt, iBlock) &
                                            + CoriolisSin*Vel_CD(iLon, iLat, iEast_))
-        end if
+        endif
 
         ! dT/dt = -(V.grad T + (gamma - 1) T div V
 
@@ -801,8 +801,8 @@ contains
           + GradLonTemp_C(iLon, iLat)*Vel_CD(iLon, iLat, iEast_)) &
           + Dt*(DiffLonTemp_C(iLon, iLat) + DiffLatTemp_C(iLon, iLat))
 
-      end do
-    end do
+      enddo
+    enddo
 
   end subroutine horizontal_solver
 
@@ -854,7 +854,7 @@ contains
         (DiffFlux(2:nLats + 1) - DiffFlux(1:nLats))* &
         InvdLat
 
-    end do
+    enddo
 
     if (UseTopography) &
       GradVar = GradVar - dVarDAlt_C*dAltDLat_CB(:, :, iAlt, iBlock)
@@ -903,7 +903,7 @@ contains
       DiffVar(:, iLat) = &
         (DiffFlux(2:nLons + 1) - DiffFlux(1:nLons))*InvdLon
 
-    end do
+    enddo
 
     if (UseTopography) &
       GradVar = GradVar - dVarDAlt_C*dAltDLon_CB(:, :, iAlt, iBlock)
@@ -954,7 +954,7 @@ subroutine calc_facevalues_lats(iLon, iAlt, iBlock, Var, VarLeft, VarRight)
 !     dVarDown = (Var(i)   - Var(i-1)) * InvDLatDist_FB(iLon,i  ,iAlt,iBlock)
 
     dVarLimited(i) = Limiter_mc(dVarUp, dVarDown)
-  end do
+  enddo
 
   i = nLats + 1
   dVarUp = (Var(i + 1) - Var(i))*InvDLatDist_FB(iLon, i + 1, iAlt, iBlock)
@@ -966,7 +966,7 @@ subroutine calc_facevalues_lats(iLon, iAlt, iBlock, Var, VarLeft, VarRight)
   do i = 1, nLats + 1
     VarLeft(i) = Var(i - 1) + 0.5*dVarLimited(i - 1)*dLatDist_FB(iLon, i, iAlt, iBlock)
     VarRight(i) = Var(i) - 0.5*dVarLimited(i)*dLatDist_FB(iLon, i, iAlt, iBlock)
-  end do
+  enddo
 
 end subroutine calc_facevalues_lats
 
@@ -1006,7 +1006,7 @@ subroutine calc_facevalues_lons(iLat, iAlt, iBlock, Var, VarLeft, VarRight)
 !     dVarUp   = (Var(i+1) - Var(i))  *InvDLonDist_FB(i+1,iLat,iAlt,iBlock)
 !     dVarDown = (Var(i)   - Var(i-1))*InvDLonDist_FB(i  ,iLat,iAlt,iBlock)
     dVarLimited(i) = Limiter_mc(dVarUp, dVarDown)
-  end do
+  enddo
 
   i = nLons + 1
 
@@ -1018,7 +1018,7 @@ subroutine calc_facevalues_lons(iLat, iAlt, iBlock, Var, VarLeft, VarRight)
   do i = 1, nLons + 1
     VarLeft(i) = Var(i - 1) + 0.5*dVarLimited(i - 1)*dLonDist_FB(i, iLat, iAlt, iBlock)
     VarRight(i) = Var(i) - 0.5*dVarLimited(i)*dLonDist_FB(i, iLat, iAlt, iBlock)
-  end do
+  enddo
 
 end subroutine calc_facevalues_lons
 

--- a/src/advance_old.f90
+++ b/src/advance_old.f90
@@ -69,9 +69,9 @@ subroutine advance
                                             DivVel(iLon, iLat, iAlt)) &
                                       + Dt*DiffTemp(iLon, iLat, iAlt)
 
-        end do
-      end do
-    end do
+        enddo
+      enddo
+    enddo
 
     iLon = 3
     iLat = 3
@@ -88,7 +88,7 @@ subroutine advance
     do iAlt = 1, nAlts
       NewTemp(1:nLons, 1:nLats, iAlt) = NewTemp(1:nLons, 1:nLats, iAlt) + &
                                         dt*EuvHeating(1:nLons, 1:nLats, iAlt, iBlock)
-    end do
+    enddo
 
     ! Conduction (1/rho)*d(kappa dT/dZ)/dZ
     do iAlt = 1, nAlts + 1
@@ -96,7 +96,7 @@ subroutine advance
                                (Temperature(1:nLons, 1:nLats, iAlt, iBlock) - &
                                 Temperature(1:nLons, 1:nLats, iAlt - 1, iBlock))/ &
                                dAlt(iAlt)
-    end do
+    enddo
     do iAlt = 1, nAlts
 
       NewTemp(1:nLons, 1:nLats, iAlt) = NewTemp(1:nLons, 1:nLats, iAlt) + &
@@ -105,7 +105,7 @@ subroutine advance
                                          Conduction(1:nLons, 1:nLats, iAlt))/ &
                                         (dAlt(iAlt)*exp(LogRho(1:nLons, 1:nLats, iAlt, iBlock)))
 
-    end do
+    enddo
 
     LogRho(1:nLons, 1:nLats, 1:nAlts, iBlock) = &
       NewLogRho(1:nLons, 1:nLats, 1:nAlts)
@@ -117,7 +117,7 @@ subroutine advance
 !     write(*,*) "logrho : ", minval(NewLogRho(1:nLons,1:nLats,1:nAlts)), &
 !          maxval(NewLogRho(1:nLons,1:nLats,1:nAlts))
 
-  end do
+  enddo
 
 !  if (iProc == 0) then
 !     write(*,*) "mm(velocity) : ",&

--- a/src/advance_vertical.f90
+++ b/src/advance_vertical.f90
@@ -24,15 +24,15 @@ subroutine advance_vertical_all
 
     do iLon = 1, nLons; do iLat = 1, nLats
         call advance_vertical(iLon, iLat, iBlock)
-      end do; end do
+      enddo; enddo
 
-  end do
+  enddo
 
   if (DoCheckForNans) then
     call check_for_nans_ions("After Vertical")
     call check_for_nans_neutrals("After Vertical")
     call check_for_nans_temps("After Vertical")
-  end if
+  endif
 
   call end_timing("vertical_all")
 
@@ -96,7 +96,7 @@ subroutine advance_vertical(iLon, iLat, iBlock)
     write(*, *) "negative density found!"
     write(*, *) NDensityS(iLon, iLat, 1, 1:nSpecies, iBlock)
     call stop_gitm("Can't Continue")
-  end if
+  endif
 
   Heating = EuvHeating(iLon, iLat, :, iBlock)
   Centrifugal = (CosLatitude(iLat, iBlock)*OmegaBodyInput)**2
@@ -104,7 +104,7 @@ subroutine advance_vertical(iLon, iLat, iBlock)
   LogRho = log(Rho(iLon, iLat, :, iBlock))
   do iDim = 1, 3
     Vel_GD(:, iDim) = Velocity(iLon, iLat, :, iDim, iBlock)
-  end do
+  enddo
 
   !!!! CHANGE !!!!
 
@@ -112,21 +112,21 @@ subroutine advance_vertical(iLon, iLat, iBlock)
   do iSpecies = 1, nSpecies
     LogNS1(:, iSpecies) = log(NDensityS(iLon, iLat, :, iSpecies, iBlock))
     VertVel(:, iSpecies) = VerticalVelocity(iLon, iLat, :, iSpecies, iBlock)
-  end do
+  enddo
 
   cMax1 = cMax_GDB(iLon, iLat, :, iUp_, iBlock)
 
   do iDim = 1, 3
     IVel(:, iDim) = IVelocity(iLon, iLat, :, iDim, iBlock)
-  end do
+  enddo
 
   do iSpecies = 1, nIons - 1 !Advect
     if (UseImprovedIonAdVection) then
       LogINS(:, iSpecies) = IDensityS(iLon, iLat, :, iSpecies, iBlock)
     else
       LogINS(:, iSpecies) = log(IDensityS(iLon, iLat, :, iSpecies, iBlock))
-    end if
-  end do
+    endif
+  enddo
 
   MeanMajorMass_1d = MeanMajorMass(iLon, iLat, :)
   gamma_1d = gamma(ilon, ilat, :, iBlock)
@@ -157,31 +157,31 @@ subroutine advance_vertical(iLon, iLat, iBlock)
     call advance_vertical_1d_ausm
   else
     call advance_vertical_1d_rusanov
-  end if
+  endif
 
   Rho(iLon, iLat, :, iBlock) = exp(LogRho)
 
   do iDim = 1, 3
     Velocity(iLon, iLat, :, iDim, iBlock) = Vel_GD(:, iDim)
-  end do
+  enddo
 
   Temperature(iLon, iLat, :, iBlock) = Temp/TempUnit(iLon, iLat, :)
 
   do iSpecies = 1, nSpecies
     LogNS(iLon, iLat, :, iSpecies, iBlock) = LogNS1(:, iSpecies)
     VerticalVelocity(iLon, iLat, :, iSpecies, iBlock) = VertVel(:, iSpecies)
-  end do
+  enddo
 
   do iSpecies = nSpecies + 1, nSpecies
     LogNS(iLon, iLat, :, iSpecies, iBlock) = LogNS1(:, iSpecies)
-  end do
+  enddo
 
   nDensity(iLon, iLat, :, iBlock) = 0.0
   do iSpecies = 1, nSpecies
     nDensityS(iLon, iLat, :, iSpecies, iBlock) = exp(LogNS1(:, iSpecies))
     nDensity(iLon, iLat, :, iBlock) = nDensity(iLon, iLat, :, iBlock) + &
                                       nDensityS(iLon, iLat, :, iSpecies, iBlock)
-  end do
+  enddo
 
   if (UseIonAdvection) then
 
@@ -192,12 +192,12 @@ subroutine advance_vertical(iLon, iLat, iBlock)
         do iAlt = 1, nAlts
           if (IDensityS(iLon, iLat, iAlt, iIon, iBlock) < 1) then
             IDensityS(iLon, iLat, iAlt, iIon, iBlock) = 1.0
-          end if
-        end do
+          endif
+        enddo
       else
         IDensityS(iLon, iLat, :, iIon, iBlock) = exp(LogINS(:, iIon))
-      end if
-    end do
+      endif
+    enddo
 
     !\
     ! New Electron Density
@@ -207,8 +207,8 @@ subroutine advance_vertical(iLon, iLat, iBlock)
       IDensityS(iLon, iLat, :, ie_, iBlock) = &
         IDensityS(iLon, iLat, :, ie_, iBlock) + &
         IDensityS(iLon, iLat, :, iIon, iBlock)
-    end do
-  end if
+    enddo
+  endif
 
   SpeciesDensity(iLon, iLat, :, 1:nSpeciesTotal, iBlock) = &
     NDensityS(iLon, iLat, :, :, iBlock)

--- a/src/apex_more.f90
+++ b/src/apex_more.f90
@@ -32,13 +32,13 @@ subroutine cofrm(date)
   if (date < 1900. .or. date > 2030.) then
     write(6, "('>>> cofrm: date=',f8.2,' Date must be >= 1900 and <= 2030')") date
     stop 'cofrm'
-  end if
+  endif
   if (date > 2025.) then
     write(6, "('>>> WARNING cofrm:')")
     write(6, "(/,'   This version of IGRF is intended for use up to ')")
     write(6, "('     2025. Values for ',f9.3,' will be computed but')") date
     write(6, "('     may be of reduced accuracy.',/)")
-  end if
+  endif
 
   g1(:, 1) = (/ & ! 1900
              -31543., -2298., 5922., -677., 2905., -1061., 924., 1121., &
@@ -577,12 +577,12 @@ subroutine cofrm(date)
     i = (n - 1)*n1
     gh(i + 1:i + n1) = g1(:, n)
 !   write(6,"('cofrm: n=',i3,' i+1:i+n1=',i4,':',i4)") n,i+1,i+n1
-  end do
+  enddo
   do n = 1, ncn2
     i = n1*ncn1 + (n - 1)*n2
     gh(i + 1:i + n2) = g2(:, n)
 !   write(6,"('cofrm: n=',i3,' i+1:i+n2=',i4,':',i4)") n,i+1,i+n2
-  end do
+  enddo
   gh(ngh) = 0. ! not sure why gh is dimensioned with the extra element, so set it to 0.
 
   if (date < 2020.) then
@@ -601,24 +601,24 @@ subroutine cofrm(date)
       ll = 0.2*(date - 1995.0)
       ll = 120*19 + nc*ll
       kmx = (nmx + 1)*(nmx + 2)/2
-    end if
+    endif
     tc = 1.0 - t
     if (isv .eq. 1) then
       tc = -0.2
       t = 0.2
-    end if
+    endif
   else ! date >= 2020
     t = date - 2020.0
     tc = 1.0
     if (isv .eq. 1) then
       t = 1.0
       tc = 0.0
-    end if
+    endif
     ll = 3255
     nmx = 13
     nc = nmx*(nmx + 2)
     kmx = (nmx + 1)*(nmx + 2)/2
-  end if ! date < 2020
+  endif ! date < 2020
   r = alt
   l = 1
   m = 1
@@ -634,7 +634,7 @@ subroutine cofrm(date)
     if (n < m) then
       m = 0
       n = n + 1
-    end if ! n < m
+    endif ! n < m
     lm = ll + l
     if (m == 0) f0 = f0*float(n)/2.
     if (m == 0) f = f0/sqrt(2.0)
@@ -646,7 +646,7 @@ subroutine cofrm(date)
       gb(l + 1) = (tc*gh(lm) + t*gh(lm + nc))*f
     else
       gb(l + 1) = (tc*gh(lm) + t*gh(lm + nc))*f0
-    end if
+    endif
     gv(l + 1) = gb(l + 1)/float(nn)
     if (m /= 0) then
       gb(l + 2) = (tc*gh(lm + 1) + t*gh(lm + nc + 1))*f
@@ -654,9 +654,9 @@ subroutine cofrm(date)
       l = l + 2
     else
       l = l + 1
-    end if
+    endif
     m = m + 1
-  end do
+  enddo
 
 ! write(6,"('cofrm: ncoef=',i4,' gb=',/,(6f12.3))") ncoef,gb
 ! write(6,"('cofrm: ncoef=',i4,' gv=',/,(6f12.3))") ncoef,gv
@@ -751,7 +751,7 @@ subroutine feldg(iflag, glat, glon, alt, bnrth, beast, bdown, babs)
     xxx = glat
     yyy = glon
     zzz = alt
-  end if
+  endif
   rq = 1./(xxx**2 + yyy**2 + zzz**2)
   xi(1) = xxx*rq
   xi(2) = yyy*rq
@@ -763,16 +763,16 @@ subroutine feldg(iflag, glat, glon, alt, bnrth, beast, bdown, babs)
   if (iflag /= 3) then
     do i = 1, last
       g(i) = gb(i) ! gb is module data from cofrm
-    end do
+    enddo
   else
     do i = 1, last
       g(i) = gv(i) ! gv is module data from cofrm
-    end do
-  end if
+    enddo
+  endif
 
   do i = ihmax, last
     h(i) = g(i)
-  end do
+  enddo
 
   mk = 3
   if (imax == 1) mk = 1
@@ -803,15 +803,15 @@ subroutine feldg(iflag, glat, glon, alt, bnrth, beast, bdown, babs)
                      y*(h(ihm + 2) + h(ihm - 2))
         h(ilm) = g(ilm) + z*h(ihm) + x*(h(ihm + 2) - h(ihm - 2)) + &
                  y*(h(ihm + 3) + h(ihm - 1))
-      end do
+      enddo
       h(il + 2) = g(il + 2) + z*h(ih + 2) + x*h(ih + 4) - y*(h(ih + 3) + h(ih))
       h(il + 1) = g(il + 1) + z*h(ih + 1) + y*h(ih + 4) + x*(h(ih + 3) - h(ih))
       h(il) = g(il) + z*h(ih) + 2.*(x*h(ih + 1) + y*h(ih + 2))
-    end if
+    endif
 
     ih = il
     if (i >= k) goto 100
-  end do ! k=1,mk,2
+  enddo ! k=1,mk,2
 
   s = .5*h(1) + 2.*(h(2)*xi(3) + h(3)*xi(1) + h(4)*xi(2))
   t = (rq + rq)*sqrt(rq)
@@ -828,7 +828,7 @@ subroutine feldg(iflag, glat, glon, alt, bnrth, beast, bdown, babs)
     bnrth = bxxx
     beast = byyy
     bdown = bzzz
-  end if
+  endif
 !
 ! Magnetic potential computation (V) makes use of the fact that the
 ! calculation of V is identical to that for r*Br, if coefficients

--- a/src/apexsh.f90
+++ b/src/apexsh.f90
@@ -183,7 +183,7 @@ subroutine loadapxsh(datafilenew, epochnew)
     call allocatearrays
     read(23) epochgrid, coeff0
     close(23)
-  end if
+  endif
 
   !LOAD COEFFICIENTS AND INTEPOLATE TO SELECTED EPOCH
   if ((epochnew .ne. epochlast) .or. (datafilenew .ne. datafilelast) .or. (loadflag)) then
@@ -200,20 +200,20 @@ subroutine loadapxsh(datafilenew, epochnew)
       iepoch0 = nepoch - 1
       do while ((epochgrid(iepoch0) .ge. epoch) .and. (iepoch0 .gt. 0))
         iepoch0 = iepoch0 - 1
-      end do
+      enddo
       iepoch1 = iepoch0 + 1
       we0 = dble((epochgrid(iepoch1) - epoch)/(epochgrid(iepoch1) - epochgrid(iepoch0)))
       we1 = 1D0 - we0
-    end if
+    endif
     do icoord = 0, 2
     do iterm = 0, nterm - 1
       qcoeff0(iterm, icoord) = we0*coeff0(iterm, iepoch0, icoord) + we1*coeff0(iterm, iepoch1, icoord)
       gcoeff0(iterm, icoord) = we0*coeff0(iterm, iepoch0, icoord + 3) + we1*coeff0(iterm, iepoch1, icoord + 3)
-    end do
-    end do
+    enddo
+    enddo
     altlastq = -999.0
     altlastg = -999.0
-  end if
+  endif
 
   !UPDATE LOAD VARIABLES
   loadflag = .false.
@@ -322,7 +322,7 @@ subroutine apxg2q(glat, glon, alt, vecflagin, qlatout, qlonout, f1, f2, f)
   if (loadflag) then
     print *, 'No coefficients loaded. Call LOADAPXSH first.'
     return
-  end if
+  endif
 
   !COPY INPUT FLAG
   vecflag = vecflagin
@@ -335,7 +335,7 @@ subroutine apxg2q(glat, glon, alt, vecflagin, qlatout, qlonout, f1, f2, f)
     do l = 1, lmax
       polynomq(l) = polynomq(l - 1)*rho
       dpolynomq(l) = dble(l)*polynomq(l - 1)
-    end do
+    enddo
     xqcoeff = 0
     yqcoeff = 0
     zqcoeff = 0
@@ -351,10 +351,10 @@ subroutine apxg2q(glat, glon, alt, vecflagin, qlatout, qlonout, f1, f2, f)
         dxqdrhocoeff(itermsh) = dxqdrhocoeff(itermsh) + qcoeff0(iterm, 0)*dpolynomq(l)
         dyqdrhocoeff(itermsh) = dyqdrhocoeff(itermsh) + qcoeff0(iterm, 1)*dpolynomq(l)
         dzqdrhocoeff(itermsh) = dzqdrhocoeff(itermsh) + qcoeff0(iterm, 2)*dpolynomq(l)
-      end do
-    end do
+      enddo
+    enddo
     altlastq = alt
-  end if
+  endif
 
   !COMPUTE SPHERICAL HARMONICS
   theta = (90D0 - dble(glat))*dtor
@@ -405,7 +405,7 @@ subroutine apxg2q(glat, glon, alt, vecflagin, qlatout, qlonout, f1, f2, f)
     f2(2) = sngl(qlongrad(1))
     f = f1(1)*f2(2) - f1(2)*f2(1)
 
-  end if
+  endif
 
   return
 
@@ -433,7 +433,7 @@ subroutine apxg2all(glat, glon, alt, hr, vecflagin, &
   if (loadflag) then
     print *, 'No coordinates loaded. Call LOADAPXSH first.'
     stop
-  end if
+  endif
 
   !INITIALIZE OUTPUT ARGUMENTS
   mlat = missing
@@ -457,7 +457,7 @@ subroutine apxg2all(glat, glon, alt, hr, vecflagin, &
   if (cosmlat .le. 1D0) then
     mlat = sngl(dacos(cosmlat)/dtor)
     if (qlat .lt. 0D0) mlat = -mlat
-  end if
+  endif
 
   !MODIFIED APEX BASE VECTOR CALCULATIONS
   if (vecflag .ne. 0) then
@@ -476,7 +476,7 @@ subroutine apxg2all(glat, glon, alt, hr, vecflagin, &
     do i = 1, 3
       d1(i) = sngl(Rrat*dsqrt(Rrat)*qlongrad(i))
       d2(i) = sngl(-2D0*Rrat*sinqlat*qlatgrad(i)/denom)
-    end do
+    enddo
     d2(3) = d2(3) - sngl(Rrat*cosqlat/denom)
     e3(1) = d1(2)*d2(3) - d1(3)*d2(2)
     e3(2) = d1(3)*d2(1) - d1(1)*d2(3)
@@ -484,7 +484,7 @@ subroutine apxg2all(glat, glon, alt, hr, vecflagin, &
     d = e3(1)**2 + e3(2)**2 + e3(3)**2
     do i = 1, 3
       d3(i) = e3(i)/d
-    end do
+    enddo
     d = sqrt(d)
     e1(1) = d2(2)*d3(3) - d2(3)*d3(2)
     e1(2) = d2(3)*d3(1) - d2(1)*d3(3)
@@ -493,7 +493,7 @@ subroutine apxg2all(glat, glon, alt, hr, vecflagin, &
     e2(2) = d3(3)*d1(1) - d3(1)*d1(3)
     e2(3) = d3(1)*d1(2) - d3(2)*d1(1)
 
-  end if
+  endif
 
   return
 
@@ -524,14 +524,14 @@ subroutine apxq2g(qlat0, qlon0, alt, prec, glatout, glonout, error)
   if (loadflag) then
     print *, 'No coordinates loaded. Call LOADAPXSH first.'
     stop
-  end if
+  endif
 
   !COMPUTE SPATIAL COEFFICIENTS FOR THE SPECIFIED HEIGHT
   if (alt .ne. altlastg) then
     rho = Re/(Re + dble(alt))
     do l = 1, lmax
       polynomg(l) = polynomg(l - 1)*rho
-    end do
+    enddo
     xgcoeff = 0
     ygcoeff = 0
     zgcoeff = 0
@@ -541,10 +541,10 @@ subroutine apxq2g(qlat0, qlon0, alt, prec, glatout, glonout, error)
         xgcoeff(itermsh) = xgcoeff(itermsh) + gcoeff0(iterm, 0)*polynomg(l)
         ygcoeff(itermsh) = ygcoeff(itermsh) + gcoeff0(iterm, 1)*polynomg(l)
         zgcoeff(itermsh) = zgcoeff(itermsh) + gcoeff0(iterm, 2)*polynomg(l)
-      end do
-    end do
+      enddo
+    enddo
     altlastg = alt
-  end if
+  endif
 
   !COMPUTE SPHERICAL HARMONICS
   phi = dble(qlon0)*dtor
@@ -598,7 +598,7 @@ subroutine apxq2g(qlat0, qlon0, alt, prec, glatout, glonout, error)
         errorlast = error
         error = sngl(acos(coserror)/dtor)
         niter = niter + 1
-      end do
+      enddo
       !NEAR QD POLES
     else if (error .gt. prec) then
       cosqlon0 = dcos(phi)
@@ -621,9 +621,9 @@ subroutine apxq2g(qlat0, qlon0, alt, prec, glatout, glonout, error)
         errorlast = error
         error = sngl(acos(coserror)/dtor)
         niter = niter + 1
-      end do
-    end if
-  end if
+      enddo
+    endif
+  endif
 
   return
 
@@ -651,7 +651,7 @@ subroutine shcalc(theta, phi)
     shgradphi(i1) = 0
     i = i + 1
     i1 = i1 + 1
-  end do
+  enddo
   do m = 1, mmax
     mphi = dble(m)*phi
     cosmphi = dcos(mphi)
@@ -660,7 +660,7 @@ subroutine shcalc(theta, phi)
       sh(i) = pbar(n, m)*cosmphi
       sh(i + 1) = pbar(n, m)*sinmphi
       i = i + 2
-    end do
+    enddo
     if (vecflag .ne. 0) then
       do n = m, nmax
         shgradtheta(i1) = vbar(n, m)*cosmphi
@@ -668,9 +668,9 @@ subroutine shcalc(theta, phi)
         shgradphi(i1) = -wbar(n, m)*sinmphi
         shgradphi(i1 + 1) = wbar(n, m)*cosmphi
         i1 = i1 + 2
-      end do
-    end if
-  end do
+      enddo
+    endif
+  enddo
 
 end subroutine shcalc
 
@@ -719,7 +719,7 @@ subroutine alfbasisinit(nmax0in, mmax0in)
     en(n) = dsqrt(dble(n*(n + 1)))
     anm(n, 0) = dsqrt(dble((2*n - 1)*(2*n + 1)))/narr(n)
     bnm(n, 0) = dsqrt(dble((2*n + 1)*(n - 1)*(n - 1))/dble(2*n - 3))/narr(n)
-  end do
+  enddo
   do m = 1, mmax0
     marr(m) = dble(m)
     cm(m) = dsqrt(dble(2*m + 1)/dble(2*m))
@@ -727,8 +727,8 @@ subroutine alfbasisinit(nmax0in, mmax0in)
       anm(n, m) = dsqrt(dble((2*n - 1)*(2*n + 1))/dble((n - m)*(n + m)))
       bnm(n, m) = dsqrt(dble((2*n + 1)*(n + m - 1)*(n - m - 1))/dble((n - m)*(n + m)*(2*n - 3)))
       dnm(n, m) = dsqrt(dble((n - m)*(n + m)*(2*n + 1))/dble(2*n - 1))
-    end do
-  end do
+    enddo
+  enddo
 
   return
 
@@ -763,17 +763,17 @@ subroutine alfbasis(nmax, mmax, theta, P, V, W)
       P(n, m) = y*W(n, m)
       V(n, m) = narr(n)*x*W(n, m) - dnm(n, m)*W(n - 1, m)
       W(n - 2, m) = marr(m)*W(n - 2, m)
-    end do
+    enddo
     W(nmax - 1, m) = marr(m)*W(nmax - 1, m)
     W(nmax, m) = marr(m)*W(nmax, m)
     V(m, m) = x*W(m, m)
-  end do
+  enddo
   P(1, 0) = anm(1, 0)*x*P(0, 0)
   V(1, 0) = -en(1)*P(1, 1)
   do n = 2, nmax
     P(n, 0) = anm(n, 0)*x*P(n - 1, 0) - bnm(n, 0)*P(n - 2, 0)
     V(n, 0) = -en(n)*P(n, 1)
-  end do
+  enddo
 
   return
 

--- a/src/aurora.Earth.f90
+++ b/src/aurora.Earth.f90
@@ -83,11 +83,11 @@ subroutine aurora(iBlock)
         allocate(Fang_Ion_Ci(ED_N_Energies, 12), stat=iErr)
         allocate(Fang_Ion_y(ED_N_Energies, nAlts), stat=iErr)
         allocate(Fang_Ion_f(ED_N_Energies, nAlts), stat=iErr)
-      end if
+      endif
 
       if (iErr /= 0) then
         call stop_gitm("Error allocating Fang arrays in aurora")
-      end if
+      endif
 
       ! Electrons
       do iEnergy = 1, ED_N_Energies
@@ -96,9 +96,9 @@ subroutine aurora(iBlock)
           do j = 0, 3
             Fang_Ci(iEnergy, i) = Fang_Ci(iEnergy, i) + &
                                   Fang_Pij(i, j + 1)*log(ED_Energies(iEnergy)/1000.0)**j
-          end do
-        end do
-      end do
+          enddo
+        enddo
+      enddo
       Fang_Ci = exp(Fang_Ci)
 
       ! Ions
@@ -109,18 +109,18 @@ subroutine aurora(iBlock)
             do j = 0, 3
               Fang_Ion_Ci(iEnergy, i) = Fang_Ion_Ci(iEnergy, i) + &
                                         Fang_Ion_Pij(i, j + 1)*log(ED_Energies(iEnergy)/1000.0)**j
-            end do
-          end do
-        end do
+            enddo
+          enddo
+        enddo
         Fang_Ion_Ci = exp(Fang_Ion_Ci)
-      end if
+      endif
 
-    end if
+    endif
 
   else
     if (floor((tSimulation - dT)/dTAurora) == &
         floor(tSimulation/dTAurora)) return
-  end if
+  endif
 
   AuroralBulkIonRate = 0.0
   AuroralHeatingRate(:, :, :, iBlock) = 0.0
@@ -132,7 +132,7 @@ subroutine aurora(iBlock)
   if (iBlock == 1) then
     HemisphericPowerNorth = 0.0
     HemisphericPowerSouth = 0.0
-  end if
+  endif
 
   ! Let's scale our hemispheric power so it is roughly the same as what
   ! is measured.
@@ -156,12 +156,12 @@ subroutine aurora(iBlock)
             HemisphericPowerSouth = HemisphericPowerSouth + power
           else
             HemisphericPowerNorth = HemisphericPowerNorth + power
-          end if
+          endif
 
-        end if
+        endif
 
-      end do
-    end do
+      enddo
+    enddo
 
     ! Collect all of the powers by summing them together
 
@@ -197,33 +197,33 @@ subroutine aurora(iBlock)
       else
         if (iDebugLevel >= 1) &
           write(*, *) 'auroral normalizing ratio: ', Hpi, avepower, ratio
-      end if
-    end if
+      endif
+    endif
     do i = 1, nLats
       do j = 1, nLons
         if (ElectronEnergyFlux(j, i) > 0.1) then
           ElectronEnergyFlux(j, i) = ElectronEnergyFlux(j, i)*ratio
-        end if
-      end do
-    end do
+        endif
+      enddo
+    enddo
 
-  end if
+  endif
 
   ! Reset the hemispheric power
 
   if (iBlock == 1) then
     HemisphericPowerNorth = 0.0
     HemisphericPowerSouth = 0.0
-  end if
+  endif
 
   if (iProc == 0 .and. AveEFactor /= 1.0) then
     write(*, *) "Auroral Experiments!!!!"
     write(*, *) "AveEFactor : ", AveEFactor
-  end if
+  endif
   if (iProc == 0 .and. IsKappaAurora) then
     write(*, *) "Auroral Experiments!!!!"
     write(*, *) "kappa : ", AuroraKappa
-  end if
+  endif
 
   do i = 1, nLats
     do j = 1, nLons
@@ -239,7 +239,7 @@ subroutine aurora(iBlock)
       else
         ion_eflx_ergs = 0.001
         ion_av_kev = 10.0
-      end if
+      endif
 
       ! For diffuse auroral models
 
@@ -267,7 +267,7 @@ subroutine aurora(iBlock)
           HemisphericPowerSouth = HemisphericPowerSouth + power
         else
           HemisphericPowerNorth = HemisphericPowerNorth + power
-        end if
+        endif
 
         ! Looking at other papers (Fang et al., [2010]), a
         ! Maxwellian is defined as:
@@ -299,7 +299,7 @@ subroutine aurora(iBlock)
             ! This is a Maxwellian from Fang et al. [2010]:
             ED_flux(n) = a*ed_energies(n)*exp(-ed_energies(n)/E0)
             ED_ion_flux(n) = ai*ed_energies(n)*exp(-ed_energies(n)/E0i)
-          end if
+          endif
 
           ED_EnergyFlux(n) = &
             ED_flux(n)* &
@@ -310,9 +310,9 @@ subroutine aurora(iBlock)
             ED_Energies(n)* &
             ED_delta_energy(n)
 
-        end do
+        enddo
 
-      end if
+      endif
 
       UseMono = .false.
       if (UseNewellAurora .and. UseNewellMono) UseMono = .true.
@@ -334,7 +334,7 @@ subroutine aurora(iBlock)
           HemisphericPowerSouth = HemisphericPowerSouth + power
         else
           HemisphericPowerNorth = HemisphericPowerNorth + power
-        end if
+        endif
 
         UserData2d(j, i, 1, 4, iBlock) = av_kev/1000.0
         UserData2d(j, i, 1, 5, iBlock) = ElectronEnergyFluxMono(j, i)
@@ -350,10 +350,10 @@ subroutine aurora(iBlock)
               ED_Energies(n)* &
               ED_delta_energy(n)
             HasSomeAurora = .true.
-          end if
-        end do
+          endif
+        enddo
 
-      end if
+      endif
 
       UseWave = .false.
       if (UseNewellAurora .and. UseNewellWave) UseWave = .true.
@@ -374,7 +374,7 @@ subroutine aurora(iBlock)
           HemisphericPowerSouth = HemisphericPowerSouth + power
         else
           HemisphericPowerNorth = HemisphericPowerNorth + power
-        end if
+        endif
 
         UserData2d(j, i, 1, 6, iBlock) = av_kev/1000.0
         UserData2d(j, i, 1, 7, iBlock) = ElectronEnergyFluxWave(j, i)
@@ -384,8 +384,8 @@ subroutine aurora(iBlock)
         do n = 3, ED_N_Energies - 3
           if (av_kev < ED_energies(n - 1) .and. av_kev >= ED_energies(n)) then
             k = n
-          end if
-        end do
+          endif
+        enddo
         if (k > 3) then
           f1 = 1.0
           f2 = 1.2
@@ -411,11 +411,11 @@ subroutine aurora(iBlock)
 !              ED_flux(k+2) = ED_Flux(k+2) + f5*ElectronNumberFluxWave(j, i) / detotal
           do n = k - 2, n + 2
             ED_EnergyFlux(n) = ED_flux(n)*ED_Energies(n)*ED_delta_energy(n)
-          end do
+          enddo
           HasSomeAurora = .true.
-        end if
+        endif
 
-      end if
+      endif
 
       if (HasSomeAurora) then
 
@@ -476,9 +476,9 @@ subroutine aurora(iBlock)
               AuroralBulkIonRate(j, i, 1:nAlts) = &
                 AuroralBulkIonRate(j, i, 1:nAlts) + 1e6*Fang_Ion_f(iEnergy, :)*fac
 
-            end if
+            endif
 
-          end do
+          enddo
 
           AuroralHeatingRate(j, i, 1:nAlts, iBlock) = 0.0
 
@@ -509,9 +509,9 @@ subroutine aurora(iBlock)
                   IsTop = .true.
                 else
                   iED = iED + 1
-                end if
-              end if
-            end do
+                endif
+              endif
+            enddo
 
             if (.not. IsTop) then
               n = ED_Interpolation_Index(k)
@@ -527,16 +527,16 @@ subroutine aurora(iBlock)
               AuroralHeatingRate(j, i, k, iBlock) = ED_Heating(ED_N_Alts)* &
                                                     factor*Pressure(j, i, k, iBlock)/exp(ED_grid(ED_N_Alts))
 
-            end if
+            endif
 
-          end do
+          enddo
 
-        end if
+        endif
 
-      end if
+      endif
 
-    end do
-  end do
+    enddo
+  enddo
 
   ! From Rees's book:
 
@@ -560,7 +560,7 @@ subroutine aurora(iBlock)
                      rho(1:nLons, 1:nLats, 1:nAlts, iBlock)
   else
     AuroralHeating = 0.0
-  end if
+  endif
 
   IsFirstTime(iBlock) = .false.
 

--- a/src/calc_avesza.f90
+++ b/src/calc_avesza.f90
@@ -38,7 +38,7 @@ subroutine calc_avesza(iLon, iLat, iBlock, SinDec, CosDec)
         X6a = Longitude(iLon, iBlock)/pi + 1.0
       else
         X6a = Longitude(iLon, iBlock)/pi - 1.0
-      end if
+      endif
       X6 = pi*X6a !same as 2*pi*X6a/2
       X3 = SinDec*sin(Latitude(iLat, iBlock))
       X4 = CosDec*cos(Latitude(iLat, iBlock))
@@ -100,7 +100,7 @@ subroutine calc_avesza(iLon, iLat, iBlock, SinDec, CosDec)
 
           IF (TRR .LT. XT1 .OR. TRR .GT. XT2) THEN
             TRR = XT2
-          END IF
+          ENDIF
 
           AveCosSza(iLon, iLat, iBlock) = &
             (X3*(XT2 - TRR) + X4*(SIN(X5*XT2 + X6) - &
@@ -112,19 +112,19 @@ subroutine calc_avesza(iLon, iLat, iBlock, SinDec, CosDec)
 
           IF (TRR .LT. XT1 .OR. TRR .GT. XT2) THEN
             TRR = XT1
-          END IF
+          ENDIF
 
           AveCosSza(iLon, iLat, iBlock) = &
             (X3*(TRR - XT1) + X4*(SIN(X5*TRR + X6) - &
                                   SIN(X5*XT1 + X6))/X5)/NDT
 
-        END IF
+        ENDIF
 
-      END IF
+      ENDIF
 
-    end if
+    endif
 
-  end if
+  endif
   !##########################################################
 
 end subroutine calc_avesza

--- a/src/calc_chemistry.Earth.f90
+++ b/src/calc_chemistry.Earth.f90
@@ -64,8 +64,8 @@ subroutine calc_chemistry(iBlock)
     do iIon = 1, nIons
       write(*, *) "====> start calc_chemistry: Max Ion Density: ", iIon, &
         maxval(IDensityS(1:nLons, 1:nLats, (nAlts*4)/5, iIon, iBlock))
-    end do
-  end if
+    enddo
+  endif
 
   ChemicalHeatingRate = 0.0
   ChemicalHeatingRateIon = 0.0
@@ -111,7 +111,7 @@ subroutine calc_chemistry(iBlock)
     call check_for_nans_ions('before chemistry')
     call check_for_nans_neutrals('before chemistry')
     call check_for_nans_temps('before chemistry')
-  end if
+  endif
 
   u2 = IVelocityPerp(1:nLons, 1:nLats, 1:nAlts, iEast_, iBlock)**2 + &
        IVelocityPerp(1:nLons, 1:nLats, 1:nAlts, iNorth_, iBlock)**2 + &
@@ -129,7 +129,7 @@ subroutine calc_chemistry(iBlock)
     mb = mb + &
          (mass(iNeutral)*Collisions(1:nLons, 1:nLats, 1:nAlts, iVIN_))/ &
          (mass(iNeutral) + MassI(iO_4SP_))
-  end do
+  enddo
 
   mb = mb/mbb
 
@@ -429,7 +429,7 @@ subroutine calc_chemistry(iBlock)
             rr = 5.1e-17*ti3m116
           else
             rr = 1.26e-17*ti10m067
-          end if
+          endif
 
           Reaction = &
             rr* &
@@ -459,7 +459,7 @@ subroutine calc_chemistry(iBlock)
             rr = 1.33e-16*ti3m044
           else
             rr = 6.55e-17*ti15m023
-          end if
+          endif
 
           Reaction = &
             rr* &
@@ -608,7 +608,7 @@ subroutine calc_chemistry(iBlock)
             rr = 1.6e-17*ti3m052
           else
             rr = 9e-18*ti9m092
-          end if
+          endif
 
           Reaction = &
             rr* &
@@ -712,7 +712,7 @@ subroutine calc_chemistry(iBlock)
             rr = 1.925e-16*ti3m045
           else
             rr = 3.325e-16
-          end if
+          endif
 
           Reaction = &
             rr* &
@@ -744,7 +744,7 @@ subroutine calc_chemistry(iBlock)
             rr = 0.825e-16*ti3m045
           else
             rr = 1.425e-16
-          end if
+          endif
 
           Reaction = &
             rr* &
@@ -778,7 +778,7 @@ subroutine calc_chemistry(iBlock)
             rr = 1.95e-13*te3m07
           else
             rr = 7.39e-14*te12m056
-          end if
+          endif
 
           Reaction = &
             rr* &
@@ -819,7 +819,7 @@ subroutine calc_chemistry(iBlock)
               ChemicalHeatingS(io2p_e) + &
               Reaction*5.0
 
-          end if
+          endif
 
           IonLosses(iO2P_) = IonLosses(iO2P_) + Reaction
 
@@ -1031,7 +1031,7 @@ subroutine calc_chemistry(iBlock)
             ChemicalHeatingSubI = &
               ChemicalHeatingSubI + Reaction*1.655
 
-          end if
+          endif
 
           IonSources(iO_4SP_) = IonSources(iO_4SP_) + Reaction
           IonLosses(iO_2DP_) = IonLosses(iO_2DP_) + Reaction
@@ -1156,7 +1156,7 @@ subroutine calc_chemistry(iBlock)
             rr = 0.275e-16*ti3m045
           else
             rr = 0.475e-16
-          end if
+          endif
 
           Reaction = &
             rr* &
@@ -1187,7 +1187,7 @@ subroutine calc_chemistry(iBlock)
             rr = 1.2e-18*ti3m045
           else
             rr = 7.0e-19*ti10m212
-          end if
+          endif
 
           Reaction = &
             rr* &
@@ -1617,7 +1617,7 @@ subroutine calc_chemistry(iBlock)
             rr = 0.495e-16*ti3m045
           else
             rr = 0.855e-16
-          end if
+          endif
 
           Reaction = &
             rr* &
@@ -1667,7 +1667,7 @@ subroutine calc_chemistry(iBlock)
             rr = 1.98e-16*ti3m045
           else
             rr = 3.42e-16
-          end if
+          endif
 
           Reaction = &
             rr* &
@@ -1678,7 +1678,7 @@ subroutine calc_chemistry(iBlock)
             NeutralSources(iO_1D_) = NeutralSources(iO_1D_) + Reaction
           else
             NeutralSources(iO_3P_) = NeutralSources(iO_3P_) + Reaction
-          end if
+          endif
 
           IonSources(iNOP_) = IonSources(iNOP_) + Reaction
           IonLosses(iNP_) = IonLosses(iNP_) + Reaction
@@ -1848,7 +1848,7 @@ subroutine calc_chemistry(iBlock)
               ChemicalHeatingSub + &
               Reaction*2.38
 
-          end if
+          endif
 
           NeutralSources(iN_4S_) = NeutralSources(iN_4S_) + Reaction
           NeutralLosses(iN_2D_) = NeutralLosses(iN_2D_) + Reaction
@@ -1982,7 +1982,7 @@ subroutine calc_chemistry(iBlock)
               ChemicalHeatingSub + &
               Reaction*3.76
 
-          end if
+          endif
           NeutralSources(iNO_) = NeutralSources(iNO_) + Reaction
           NeutralLosses(iN_2D_) = NeutralLosses(iN_2D_) + Reaction
           NeutralLosses(iO2_) = NeutralLosses(iO2_) + Reaction
@@ -2229,7 +2229,7 @@ subroutine calc_chemistry(iBlock)
               ChemicalHeatingS(io1d_o) + &
               Reaction*1.96
 
-          end if
+          endif
 
           ! ----------------------------------------------------------
           ! NO
@@ -2259,9 +2259,9 @@ subroutine calc_chemistry(iBlock)
               if (.not. UseIonConstituent(iIon)) then
                 IonSources(iIon) = 0.0
                 IonLosses(iIon) = 0.0
-              end if
-            end do
-          end if
+              endif
+            enddo
+          endif
 
           if (.not. UseNeutralChemistry) then
             NeutralSources = 0.0
@@ -2271,9 +2271,9 @@ subroutine calc_chemistry(iBlock)
               if (.not. UseNeutralConstituent(iNeutral)) then
                 NeutralSources(iNeutral) = 0.0
                 NeutralLosses(iNeutral) = 0.0
-              end if
-            end do
-          end if
+              endif
+            enddo
+          endif
 
           ! Take Implicit time step
           Ions(ie_) = 0.0
@@ -2284,7 +2284,7 @@ subroutine calc_chemistry(iBlock)
                          (1 + DtSub*ionlo)
             ! sum for e-
             Ions(ie_) = Ions(ie_) + Ions(iIon)
-          end do
+          enddo
 
           do iNeutral = 1, nSpeciesTotal
 
@@ -2306,7 +2306,7 @@ subroutine calc_chemistry(iBlock)
               NeutralLossesTotal(ialt, iNeutral) + &
               NeutralLosses(iNeutral)*DtSub
 
-          end do
+          enddo
 
           ChemicalHeatingRate(iLon, iLat, iAlt) = &
             ChemicalHeatingRate(iLon, iLat, iAlt) + &
@@ -2339,19 +2339,19 @@ subroutine calc_chemistry(iBlock)
             do iIon = 1, nIons
               write(*, *) "Ion Source/Loss : ", &
                 iIon, IonSources(iIon), IonLosses(iIon)
-            end do
+            enddo
             do iNeutral = 1, nSpeciesTotal
               write(*, *) "Neutral Source/Loss : ", iAlt, &
                 iNeutral, NeutralSources(iNeutral), &
                 NeutralLosses(iNeutral), Neutrals(iNeutral)
-            end do
+            enddo
 
             call stop_gitm("Chemistry is too fast!!")
-          end if
+          endif
 
           nIters = nIters + 1
 
-        end do
+        enddo
 
         IDensityS(iLon, iLat, iAlt, :, iBlock) = Ions
         NDensityS(iLon, iLat, iAlt, :, iBlock) = Neutrals
@@ -2364,9 +2364,9 @@ subroutine calc_chemistry(iBlock)
             if (ieee_is_nan(Neutrals(iNeutral))) then
               write(*, *) "chemistry : Neutral is nan", iLon, iLat, iAlt, iNeutral
               call stop_gitm("Must stop now.")
-            end if
-          end do
-        end if
+            endif
+          enddo
+        endif
 
         ChemicalHeating2d(iLon, iLat) = &
           ChemicalHeating2d(iLon, iLat) + &
@@ -2374,9 +2374,9 @@ subroutine calc_chemistry(iBlock)
           Element_Charge* &
           dAlt_GB(iLon, iLat, iAlt, iBlock)
 
-      end do ! Alt
-    end do ! Lat
-  end do ! Lon
+      enddo ! Alt
+    enddo ! Lat
+  enddo ! Lon
 
   ChemicalHeatingRate(:, :, :) = &
     ChemicalHeatingRate(:, :, :)*Element_Charge/ &
@@ -2392,8 +2392,8 @@ subroutine calc_chemistry(iBlock)
     do iIon = 1, nIons
       write(*, *) "====> calc_chemistry: Max Ion Density: ", iIon, &
         maxval(IDensityS(1:nLons, 1:nLats, (nAlts*4)/5, iIon, iBlock))
-    end do
-  end if
+    enddo
+  endif
 
   if (iDebugLevel > 2) &
     write(*, *) "===> calc_chemistry: Average Dt for this timestep : ", &

--- a/src/calc_chemistry.Jupiter.f90
+++ b/src/calc_chemistry.Jupiter.f90
@@ -223,13 +223,13 @@ subroutine calc_chemistry(iBlock)
                 else
                   IonSources(iIon) = 0.0
                   IonLosses(iIon) = 0.0
-                end if
-              end if
+                endif
+              endif
             else
               IonSources(iIon) = 0.0
               IonLosses(iIon) = 0.0
-            end if
-          end do
+            endif
+          enddo
 
           do iNeutral = 1, nSpeciesTotal
 
@@ -249,13 +249,13 @@ subroutine calc_chemistry(iBlock)
                 else
                   NeutralSources(iNeutral) = 0.0
                   NeutralLosses(iNeutral) = 0.0
-                end if
-              end if
+                endif
+              endif
             else
               NeutralSources(iNeutral) = 0.0
               NeutralLosses(iNeutral) = 0.0
-            end if
-          end do
+            endif
+          enddo
 
           Ions(nIons) = 0.0
           do iIon = 1, nIons - 1
@@ -271,15 +271,15 @@ subroutine calc_chemistry(iBlock)
                 iIon, iLon, iLat, iAlt, &
                 Ions(iIon), &
                 IonSources(iIon), IonLosses(iIon)
-            end if
-          end do
+            endif
+          enddo
 
           do iNeutral = 1, nSpeciesTotal
             Neutrals(iNeutral) = &
               Neutrals(iNeutral) + &
               (NeutralSources(iNeutral) - NeutralLosses(iNeutral))* &
               DtSub
-          end do
+          enddo
 
           ChemicalHeatingRate(iLon, iLat, iAlt) = &
             ChemicalHeatingRate(iLon, iLat, iAlt) + &
@@ -304,14 +304,14 @@ subroutine calc_chemistry(iBlock)
                 iDtReducer, iLon, iLat, iAlt, &
                 Ions(iDtReducer), &
                 IonSources(iDtReducer), IonLosses(iDtReducer)
-            end if
+            endif
 
             call stop_gitm("Ion Chemistry is too fast!!")
-          end if
+          endif
 
           nIters = nIters + 1
 
-        end do
+        enddo
 
         IDensityS(iLon, iLat, iAlt, :, iBlock) = Ions
         NDensityS(iLon, iLat, iAlt, :, iBlock) = Neutrals
@@ -319,16 +319,16 @@ subroutine calc_chemistry(iBlock)
         Emissions(iLon, iLat, iAlt, :, iBlock) = &
           Emissions(iLon, iLat, iAlt, :, iBlock) + EmissionTotal
 
-      end do
-    end do
-  end do
+      enddo
+    enddo
+  enddo
 
   if (iDebugLevel > 3) then
     do iIon = 1, nIons
       write(*, *) "====> Max Ion Density: ", iIon, &
         maxval(IDensityS(1:nLons, 1:nLats, (nAlts*4)/5, iIon, iBlock))
-    end do
-  end if
+    enddo
+  endif
 
   if (iDebugLevel > 2) &
     write(*, *) "===> Average Dt for this timestep : ", &

--- a/src/calc_chemistry.LV-426.f90
+++ b/src/calc_chemistry.LV-426.f90
@@ -103,9 +103,9 @@ subroutine calc_chemistry(iBlock)
               if (.not. UseIonConstituent(iIon)) then
                 IonSources(iIon) = 0.0
                 IonLosses(iIon) = 0.0
-              end if
-            end do
-          end if
+              endif
+            enddo
+          endif
 
           tli = DtSub*IonLosses
           tsi = DtSub*IonSources + Ions
@@ -117,11 +117,11 @@ subroutine calc_chemistry(iBlock)
                   (IonSources(iIon) + Ions(iIon)/DtSub)*0.9
               else
                 DtSub = DtSub/2.0
-              end if
+              endif
               tli(iIon) = DtSub*IonLosses(iIon)
               tsi(iIon) = DtSub*IonSources(iIon) + Ions(iIon)
-            end do
-          end do
+            enddo
+          enddo
 
           !---- Neutrals
 
@@ -133,9 +133,9 @@ subroutine calc_chemistry(iBlock)
               if (.not. UseNeutralConstituent(iNeutral)) then
                 NeutralSources(iNeutral) = 0.0
                 NeutralLosses(iNeutral) = 0.0
-              end if
-            end do
-          end if
+              endif
+            enddo
+          endif
 
           tln = DtSub*NeutralLosses
           tsn = DtSub*NeutralSources + 0.1*Neutrals
@@ -143,7 +143,7 @@ subroutine calc_chemistry(iBlock)
             DtSub = DtSub/2.0
             tln = DtSub*NeutralLosses
             tsn = DtSub*NeutralSources + 0.1*Neutrals
-          end do
+          enddo
 
           Ions(nIons) = 0.0
 
@@ -156,7 +156,7 @@ subroutine calc_chemistry(iBlock)
             else
               Ions(iIon) = Ions(iIon) + &
                            (IonSources(iIon) - IonLosses(iIon))*DtSub
-            end if
+            endif
 
 !                 Ions(iIon) = max(0.01,Ions(iIon))
 
@@ -168,8 +168,8 @@ subroutine calc_chemistry(iBlock)
                 iIon, iLon, iLat, iAlt, &
                 Ions(iIon), &
                 IonSources(iIon), IonLosses(iIon)
-            end if
-          end do
+            endif
+          enddo
 
           do iNeutral = 1, nSpeciesTotal
             Neutrals(iNeutral) = &
@@ -190,9 +190,9 @@ subroutine calc_chemistry(iBlock)
                 iNeutral, iLon, iLat, iAlt, DtSub, &
                 Neutrals(iNeutral), &
                 NeutralSources(iNeutral), NeutralLosses(iNeutral)
-            end if
+            endif
 
-          end do
+          enddo
 
           ChemicalHeatingRate(iLon, iLat, iAlt) = &
             ChemicalHeatingRate(iLon, iLat, iAlt) + &
@@ -215,19 +215,19 @@ subroutine calc_chemistry(iBlock)
             do iIon = 1, nIons
               write(*, *) "Ion Source/Loss : ", &
                 iIon, IonSources(iIon), IonLosses(iIon)
-            end do
+            enddo
             do iNeutral = 1, nSpeciesTotal
               write(*, *) "Neutral Source/Loss : ", iAlt, &
                 iNeutral, NeutralSources(iNeutral), &
                 NeutralLosses(iNeutral), Neutrals(iNeutral)
-            end do
+            enddo
 
             call stop_gitm("Chemistry is too fast!!")
-          end if
+          endif
 
           nIters = nIters + 1
 
-        end do
+        enddo
 
         IDensityS(iLon, iLat, iAlt, :, iBlock) = Ions
         NDensityS(iLon, iLat, iAlt, :, iBlock) = Neutrals
@@ -235,9 +235,9 @@ subroutine calc_chemistry(iBlock)
         Emissions(iLon, iLat, iAlt, :, iBlock) = &
           Emissions(iLon, iLat, iAlt, :, iBlock) + EmissionTotal
 
-      end do
-    end do
-  end do
+      enddo
+    enddo
+  enddo
 
   ChemicalHeatingRate(:, :, :) = &
     ChemicalHeatingRate(:, :, :)*Element_Charge/ &

--- a/src/calc_chemistry.Mars.f90
+++ b/src/calc_chemistry.Mars.f90
@@ -44,8 +44,8 @@ subroutine calc_chemistry(iBlock)
     do iIon = 1, nIons
       write(*, *) "====> start calc_chemistry: Max Ion Density: ", iIon, &
         maxval(IDensityS(1:nLons, 1:nLats, (nAlts*4)/5, iIon, iBlock))
-    end do
-  end if
+    enddo
+  endif
 
   ChemicalHeatingRate = 0.0
   ChemicalHeatingRateIon = 0.0
@@ -86,7 +86,7 @@ subroutine calc_chemistry(iBlock)
           doImplicit = .true.
         else
           doImplicit = .false.
-        end if
+        endif
 
         if (doImplicit) then
           !write(*,*)ialt," implicit"
@@ -102,11 +102,11 @@ subroutine calc_chemistry(iBlock)
 
           do iVar = 0, nSpeciesTotal
             if (.not. UseNeutralConstituent(ivar)) nSources(ivar) = 0
-          end do
+          enddo
 
           do iVar = 0, nIons
             if (.not. UseIonConstituent(ivar)) iSources(ivar) = 0
-          end do
+          enddo
 
           NDensityS(iLon, iLat, iAlt, :, iBlock) = NDensityS(iLon, iLat, iAlt, :, iBlock) + nSources
           IDensityS(iLon, iLat, iAlt, :, iBlock) = IDensityS(iLon, iLat, iAlt, :, iBlock) + iSources
@@ -115,7 +115,7 @@ subroutine calc_chemistry(iBlock)
           do iIon = 1, nIons - 1
             IDensityS(iLon, iLat, iAlt, nIons, iBlock) = IDensityS(iLon, iLat, iAlt, nIons, iBlock) + &
                                                          IDensityS(iLon, iLat, iAlt, iIon, iBlock)
-          end do
+          enddo
 
           ! end if implicit --------------------------
         else
@@ -128,8 +128,8 @@ subroutine calc_chemistry(iBlock)
               F = ions(iion)/IonSources(iion)*10.0
               IonLosses(iion) = f*IonLosses(iion)
               IonSources(iion) = f*IonSources(iion)
-            end if
-          end do
+            endif
+          enddo
 
           Ions(nIons) = 0.0
           do iIon = 1, nIons - 1
@@ -144,8 +144,8 @@ subroutine calc_chemistry(iBlock)
                 iIon, iLon, iLat, iAlt, &
                 Ions(iIon), &
                 IonSources(iIon), IonLosses(iIon)
-            end if
-          end do
+            endif
+          enddo
 
           userdata1d(1, 1, ialt, 25) = 0
           userdata1d(1, 1, ialt, 25) = (NeutralSources(1) - NeutralLosses(1))*DtSub
@@ -168,8 +168,8 @@ subroutine calc_chemistry(iBlock)
                 iNeutral, iLon, iLat, iAlt, DtSub, &
                 Neutrals(iNeutral), &
                 NeutralSources(iNeutral), NeutralLosses(iNeutral)
-            end if
-          end do
+            endif
+          enddo
 
           ChemicalHeatingRate(iLon, iLat, iAlt) = &
             ChemicalHeatingRate(iLon, iLat, iAlt) + &
@@ -201,9 +201,9 @@ subroutine calc_chemistry(iBlock)
                 if (.not. UseIonConstituent(iIon)) then
                   IonSources(iIon) = 0.0
                   IonLosses(iIon) = 0.0
-                end if
-              end do
-            end if
+                endif
+              enddo
+            endif
 
             if (.not. UseNeutralChemistry) then
               NeutralSources = 0.0
@@ -213,17 +213,17 @@ subroutine calc_chemistry(iBlock)
                 if (.not. UseNeutralConstituent(iNeutral)) then
                   NeutralSources(iNeutral) = 0.0
                   NeutralLosses(iNeutral) = 0.0
-                end if
-              end do
-            end if
+                endif
+              enddo
+            endif
 
             do iIon = 1, nIons - 1
               if (IonSources(iion) > 100.0*ions(iion) .and. IonLosses(iion) > 100.0*ions(iion)) then
                 F = ions(iion)/IonSources(iion)*10.0
                 IonLosses(iion) = f*IonLosses(iion)
                 IonSources(iion) = f*IonSources(iion)
-              end if
-            end do
+              endif
+            enddo
 
             call calc_dtsub(IonSources, IonLosses, NeutralSources, NeutralLosses, dtSub)
 
@@ -237,7 +237,7 @@ subroutine calc_chemistry(iBlock)
               else
                 Ions(iIon) = Ions(iIon) + &
                              (IonSources(iIon) - IonLosses(iIon))*DtSub
-              end if
+              endif
 
               ! sum for e-
               Ions(nIons) = Ions(nIons) + Ions(iIon)
@@ -247,8 +247,8 @@ subroutine calc_chemistry(iBlock)
                   iIon, iLon, iLat, iAlt, &
                   Ions(iIon), &
                   IonSources(iIon), IonLosses(iIon)
-              end if
-            end do
+              endif
+            enddo
 
             do iNeutral = 1, nSpeciesTotal
               Neutrals(iNeutral) = &
@@ -269,8 +269,8 @@ subroutine calc_chemistry(iBlock)
                   iNeutral, iLon, iLat, iAlt, DtSub, &
                   Neutrals(iNeutral), &
                   NeutralSources(iNeutral), NeutralLosses(iNeutral)
-              end if
-            end do
+              endif
+            enddo
 
             ChemicalHeatingRate(iLon, iLat, iAlt) = &
               ChemicalHeatingRate(iLon, iLat, iAlt) + &
@@ -294,19 +294,19 @@ subroutine calc_chemistry(iBlock)
               do iIon = 1, nIons
                 write(*, *) "Ion Source/Loss : ", &
                   iIon, IonSources(iIon), IonLosses(iIon)
-              end do
+              enddo
               do iNeutral = 1, nSpeciesTotal
                 write(*, *) "Neutral Source/Loss : ", &
                   iNeutral, NeutralSources(iNeutral), &
                   NeutralLosses(iNeutral)
-              end do
+              enddo
 
               call stop_gitm("Chemistry is too fast!!")
-            end if
+            endif
 
             nIters = nIters + 1
 
-          end do
+          enddo
           !              write(*,*)"actual: ", niters
 
           !               if (ialt .eq. 42 .and. istep .eq. 10000) then
@@ -330,10 +330,10 @@ subroutine calc_chemistry(iBlock)
           Emissions(iLon, iLat, iAlt, :, iBlock) = &
             Emissions(iLon, iLat, iAlt, :, iBlock) + EmissionTotals
 
-        end if
-      end do
-    end do
-  end do
+        endif
+      enddo
+    enddo
+  enddo
   !stop
   if (iDebugLevel > 2) &
     write(*, *) "===> calc_chemistry: Average Dt for this timestep : ", &
@@ -353,8 +353,8 @@ subroutine calc_chemistry(iBlock)
     do iIon = 1, nIons
       write(*, *) "====> calc_chemistry: Max Ion Density: ", iIon, &
         maxval(IDensityS(1:nLons, 1:nLats, (nAlts*4)/5, iIon, iBlock))
-    end do
-  end if
+    enddo
+  endif
   call end_timing("calc_chemistry")
 
 end subroutine calc_chemistry
@@ -381,7 +381,7 @@ subroutine calc_dtsub(IonSources, IonLosses, NeutralSources, NeutralLosses, dtSu
     DtSub = DtSub/2.0
     tli = DtSub*IonLosses
     tsi = DtSub*IonSources + 0.25*Ions
-  end do
+  enddo
 
 !  tli = DtSub * IonLosses
 !  tsi = DtSub * IonSources + Ions
@@ -406,7 +406,7 @@ subroutine calc_dtsub(IonSources, IonLosses, NeutralSources, NeutralLosses, dtSu
     DtSub = DtSub/2.0
     tln = DtSub*NeutralLosses
     tsn = DtSub*NeutralSources + 0.1*Neutrals
-  end do
+  enddo
 
 end subroutine calc_dtsub
 

--- a/src/calc_chemistry.Titan.f90
+++ b/src/calc_chemistry.Titan.f90
@@ -64,8 +64,8 @@ subroutine calc_chemistry(iBlock)
     do iIon = 1, nIons
       write(*, *) "====> start calc_chemistry: Max Ion Density: ", iIon, &
         maxval(IDensityS(1:nLons, 1:nLats, (nAlts*4)/5, iIon, iBlock))
-    end do
-  end if
+    enddo
+  endif
 
   UseNeutralConstituent = .true.
   UseIonConstituent = .true.
@@ -123,7 +123,7 @@ subroutine calc_chemistry(iBlock)
     mb = mb + &
          (mass(iNeutral)*Collisions(1:nLons, 1:nLats, 1:nAlts, iVIN_))/ &
          (mass(iNeutral) + MassI(iO_4SP_))
-  end do
+  enddo
 
   mb = mb/mbb
 
@@ -424,7 +424,7 @@ subroutine calc_chemistry(iBlock)
             rr = 5.1e-17*ti3m116
           else
             rr = 1.26e-17*ti10m067
-          end if
+          endif
 
           Reaction = &
             rr* &
@@ -454,7 +454,7 @@ subroutine calc_chemistry(iBlock)
             rr = 1.33e-16*ti3m044
           else
             rr = 6.55e-17*ti15m023
-          end if
+          endif
 
           Reaction = &
             rr* &
@@ -604,7 +604,7 @@ subroutine calc_chemistry(iBlock)
             rr = 1.6e-17*ti3m052
           else
             rr = 9e-18*ti9m092
-          end if
+          endif
 
           Reaction = &
             rr* &
@@ -708,7 +708,7 @@ subroutine calc_chemistry(iBlock)
             rr = 1.925e-16*ti3m045
           else
             rr = 3.325e-16
-          end if
+          endif
 
           Reaction = &
             rr* &
@@ -740,7 +740,7 @@ subroutine calc_chemistry(iBlock)
             rr = 0.825e-16*ti3m045
           else
             rr = 1.425e-16
-          end if
+          endif
 
           Reaction = &
             rr* &
@@ -775,7 +775,7 @@ subroutine calc_chemistry(iBlock)
             rr = 1.95e-13*te3m07
           else
             rr = 7.39e-14*te12m056
-          end if
+          endif
 
           Reaction = &
             rr* &
@@ -816,7 +816,7 @@ subroutine calc_chemistry(iBlock)
               ChemicalHeatingS(io2p_e) + &
               Reaction*5.0
 
-          end if
+          endif
 
           IonLosses(iO2P_) = IonLosses(iO2P_) + Reaction
 
@@ -1026,7 +1026,7 @@ subroutine calc_chemistry(iBlock)
             ChemicalHeatingSubI = &
               ChemicalHeatingSubI + Reaction*1.655
 
-          end if
+          endif
 
           IonSources(iO_4SP_) = IonSources(iO_4SP_) + Reaction
           IonLosses(iO_2DP_) = IonLosses(iO_2DP_) + Reaction
@@ -1151,7 +1151,7 @@ subroutine calc_chemistry(iBlock)
             rr = 0.275e-16*ti3m045
           else
             rr = 0.475e-16
-          end if
+          endif
 
           Reaction = &
             rr* &
@@ -1182,7 +1182,7 @@ subroutine calc_chemistry(iBlock)
             rr = 1.2e-18*ti3m045
           else
             rr = 7.0e-19*ti10m212
-          end if
+          endif
 
           Reaction = &
             rr* &
@@ -1518,7 +1518,7 @@ subroutine calc_chemistry(iBlock)
             rr = 0.495e-16*ti3m045
           else
             rr = 0.855e-16
-          end if
+          endif
 
           Reaction = &
             rr* &
@@ -1568,7 +1568,7 @@ subroutine calc_chemistry(iBlock)
             rr = 1.98e-16*ti3m045
           else
             rr = 3.42e-16
-          end if
+          endif
 
           Reaction = &
             rr* &
@@ -1579,7 +1579,7 @@ subroutine calc_chemistry(iBlock)
             NeutralSources(iO_1D_) = NeutralSources(iO_1D_) + Reaction
           else
             NeutralSources(iO_3P_) = NeutralSources(iO_3P_) + Reaction
-          end if
+          endif
 
           IonSources(iNOP_) = IonSources(iNOP_) + Reaction
           IonLosses(iNP_) = IonLosses(iNP_) + Reaction
@@ -1749,7 +1749,7 @@ subroutine calc_chemistry(iBlock)
               ChemicalHeatingSub + &
               Reaction*2.38
 
-          end if
+          endif
 
           NeutralSources(iN_4S_) = NeutralSources(iN_4S_) + Reaction
           NeutralLosses(iN_2D_) = NeutralLosses(iN_2D_) + Reaction
@@ -1883,7 +1883,7 @@ subroutine calc_chemistry(iBlock)
               ChemicalHeatingSub + &
               Reaction*3.76
 
-          end if
+          endif
           NeutralSources(iNO_) = NeutralSources(iNO_) + Reaction
           NeutralLosses(iN_2D_) = NeutralLosses(iN_2D_) + Reaction
           NeutralLosses(iO2_) = NeutralLosses(iO2_) + Reaction
@@ -2130,7 +2130,7 @@ subroutine calc_chemistry(iBlock)
               ChemicalHeatingS(io1d_o) + &
               Reaction*1.96
 
-          end if
+          endif
 
           ! ----------------------------------------------------------
           ! NO
@@ -2160,9 +2160,9 @@ subroutine calc_chemistry(iBlock)
               if (.not. UseIonConstituent(iIon)) then
                 IonSources(iIon) = 0.0
                 IonLosses(iIon) = 0.0
-              end if
-            end do
-          end if
+              endif
+            enddo
+          endif
 
           if (.not. UseNeutralChemistry) then
             NeutralSources = 0.0
@@ -2172,9 +2172,9 @@ subroutine calc_chemistry(iBlock)
               if (.not. UseNeutralConstituent(iNeutral)) then
                 NeutralSources(iNeutral) = 0.0
                 NeutralLosses(iNeutral) = 0.0
-              end if
-            end do
-          end if
+              endif
+            enddo
+          endif
 
           ! Take Implicit time step
           Ions(ie_) = 0.0
@@ -2185,7 +2185,7 @@ subroutine calc_chemistry(iBlock)
                          (1 + DtSub*ionlo)
             ! sum for e-
             Ions(ie_) = Ions(ie_) + Ions(iIon)
-          end do
+          enddo
 
           do iNeutral = 1, nSpeciesTotal
 
@@ -2203,7 +2203,7 @@ subroutine calc_chemistry(iBlock)
               NeutralLossesTotal(ialt, iNeutral) + &
               NeutralLosses(iNeutral)*DtSub
 
-          end do
+          enddo
 
           ChemicalHeatingRate(iLon, iLat, iAlt) = &
             ChemicalHeatingRate(iLon, iLat, iAlt) + &
@@ -2234,19 +2234,19 @@ subroutine calc_chemistry(iBlock)
             do iIon = 1, nIons
               write(*, *) "Ion Source/Loss : ", &
                 iIon, IonSources(iIon), IonLosses(iIon)
-            end do
+            enddo
             do iNeutral = 1, nSpeciesTotal
               write(*, *) "Neutral Source/Loss : ", iAlt, &
                 iNeutral, NeutralSources(iNeutral), &
                 NeutralLosses(iNeutral), Neutrals(iNeutral)
-            end do
+            enddo
 
             call stop_gitm("Chemistry is too fast!!")
-          end if
+          endif
 
           nIters = nIters + 1
 
-        end do
+        enddo
 
         IDensityS(iLon, iLat, iAlt, :, iBlock) = Ions
         NDensityS(iLon, iLat, iAlt, :, iBlock) = Neutrals
@@ -2254,9 +2254,9 @@ subroutine calc_chemistry(iBlock)
         Emissions(iLon, iLat, iAlt, :, iBlock) = &
           Emissions(iLon, iLat, iAlt, :, iBlock) + EmissionTotal
 
-      end do
-    end do
-  end do
+      enddo
+    enddo
+  enddo
 
   ChemicalHeatingRate(:, :, :) = &
     ChemicalHeatingRate(:, :, :)*Element_Charge/ &
@@ -2272,8 +2272,8 @@ subroutine calc_chemistry(iBlock)
     do iIon = 1, nIons
       write(*, *) "====> calc_chemistry: Max Ion Density: ", iIon, &
         maxval(IDensityS(1:nLons, 1:nLats, (nAlts*4)/5, iIon, iBlock))
-    end do
-  end if
+    enddo
+  endif
 
   if (iDebugLevel > 2) &
     write(*, *) "===> calc_chemistry: Average Dt for this timestep : ", &

--- a/src/calc_chemistry.Venus.f90
+++ b/src/calc_chemistry.Venus.f90
@@ -46,8 +46,8 @@ subroutine calc_chemistry(iBlock)
     do iIon = 1, nIons
       write(*, *) "====> start calc_chemistry: Max Ion Density: ", iIon, &
         maxval(IDensityS(1:nLons, 1:nLats, (nAlts*4)/5, iIon, iBlock))
-    end do
-  end if
+    enddo
+  endif
 
   ChemicalHeatingRate = 0.0
   ChemicalHeatingRateIon = 0.0
@@ -88,9 +88,9 @@ subroutine calc_chemistry(iBlock)
             if (.not. UseIonConstituent(iIon)) then
               IonSources(iIon) = 0.0
               IonLosses(iIon) = 0.0
-            end if
-          end do
-        end if
+            endif
+          enddo
+        endif
 
         if (.not. UseNeutralChemistry) then
           NeutralSources = 0.0
@@ -100,9 +100,9 @@ subroutine calc_chemistry(iBlock)
             if (.not. UseNeutralConstituent(iNeutral)) then
               NeutralSources(iNeutral) = 0.0
               NeutralLosses(iNeutral) = 0.0
-            end if
-          end do
-        end if
+            endif
+          enddo
+        endif
 
         ! Take Implicit time step
         Ions(ie_) = 0.0
@@ -113,7 +113,7 @@ subroutine calc_chemistry(iBlock)
                        (1 + DtSub*ionlo)
           ! sum for e-
           Ions(ie_) = Ions(ie_) + Ions(iIon)
-        end do
+        enddo
 
         do iNeutral = 1, nSpeciesTotal
 
@@ -123,7 +123,7 @@ subroutine calc_chemistry(iBlock)
           Neutrals(iNeutral) = (Neutrals(iNeutral) + neuso*DtSub)/ &
                                (1 + DtSub*neulo)
 
-        end do
+        enddo
 
         NDensityS(iLon, iLat, iAlt, :, iBlock) = Neutrals
         IDensityS(iLon, iLat, iAlt, :, iBlock) = Ions
@@ -141,9 +141,9 @@ subroutine calc_chemistry(iBlock)
 
         EmissionTotals = EmissionTotals + Emission*DtSub
 
-      end do
-    end do
-  end do
+      enddo
+    enddo
+  enddo
 
   ChemicalHeatingRate(:, :, :) = &
     ChemicalHeatingRate(:, :, :)*Element_Charge/ &
@@ -159,8 +159,8 @@ subroutine calc_chemistry(iBlock)
     do iIon = 1, nIons
       write(*, *) "====> calc_chemistry: Max Ion Density: ", iIon, &
         maxval(IDensityS(1:nLons, 1:nLats, (nAlts*4)/5, iIon, iBlock))
-    end do
-  end if
+    enddo
+  endif
   call end_timing("calc_chemistry")
 
 end subroutine calc_chemistry

--- a/src/calc_conduction.f90
+++ b/src/calc_conduction.f90
@@ -65,7 +65,7 @@ subroutine calc_thermal_conduction(iBlock)
       Cp(1:nLons, 1:nLats, 0:nAlts + 1, iBlock)
   else
     Prandtl = 0.0
-  end if
+  endif
 
   DtCSLocal = Dt/2.0
   TmpTemp = Temperature(1:nLons, 1:nLats, -1:nAlts + 2, iBlock)* &
@@ -216,26 +216,26 @@ subroutine calc_conduction_1d(iBlock, DtIn, NeuBCS, Quantity, Diff, MulFac, dTdt
         b(nAlts + 1) = -1.0
         c(nAlts + 1) = 0.0
         d(nAlts + 1) = -tempold(nAlts + 1)
-      end if
+      endif
 
       cp(0) = c(0)/b(0)
       do iAlt = 1, nAlts + 1
         cp(iAlt) = c(iAlt)/(b(iAlt) - cp(iAlt - 1)*a(iAlt))
-      end do
+      enddo
       dp(0) = d(0)/b(0)
       do iAlt = 1, nAlts + 1
         dp(iAlt) = (d(iAlt) - dp(iAlt - 1)*a(iAlt))/(b(iAlt) - cp(iAlt - 1)*a(iAlt))
-      end do
+      enddo
       temp(nAlts + 1) = dp(nAlts + 1)
       do iAlt = nAlts, 0, -1
         temp(iAlt) = dp(iAlt) - cp(iAlt)*temp(iAlt + 1)
-      end do
+      enddo
 
       dTdt_cond(iLon, iLat, 0:nAlts + 1) = &
         temp(0:nAlts + 1) - Quantity(iLon, iLat, 0:nAlts + 1)
 
-    end do
-  end do
+    enddo
+  enddo
 
   call end_timing("conduction_1d")
 

--- a/src/calc_efield.f90
+++ b/src/calc_efield.f90
@@ -80,9 +80,9 @@ subroutine calc_efield(iBlock)
         efield(j, i, k, iNorth_) = efield(j, i, k, iNorth_) - edotb*bdir(iNorth_)
         efield(j, i, k, iUp_) = efield(j, i, k, iUp_) - edotb*bdir(iUp_)
 
-      end do
-    end do
-  end do
+      enddo
+    enddo
+  enddo
 
   ExB(:, :, :, iEast_) = EField(:, :, :, iNorth_)*B0(:, :, :, iUp_, iBlock) - &
                          EField(:, :, :, iUp_)*B0(:, :, :, iNorth_, iBlock)
@@ -116,13 +116,13 @@ subroutine calc_efield(iBlock)
               dLonDist_GB(j, i, k, iBlock), &
               ExB(j, i, k, iNorth_), B0(j, i, k, iMag_, iBlock)
             maxi = abs(ExB(j, i, k, iNorth_))
-          end if
+          endif
 
-        end do
-      end do
-    end do
+        enddo
+      enddo
+    enddo
 
-  end if
+  endif
 
   if (iDebugLevel > 3) then
 
@@ -131,7 +131,7 @@ subroutine calc_efield(iBlock)
     write(*, *) "====> Max ExB : ", maxval(ExB(:, :, :, iEast_)), &
       maxval(ExB(:, :, :, iNorth_)), maxval(ExB(:, :, :, iUp_))
 
-  end if
+  endif
 
   call end_timing("calc_efield")
 

--- a/src/calc_electrodynamics.f90
+++ b/src/calc_electrodynamics.f90
@@ -195,7 +195,7 @@ subroutine UA_calc_electrodynamics(UAi_nMLTs, UAi_nLats)
 
     if (iError /= 0) then
       call stop_gitm("Error allocating array DivJuAltMC")
-    end if
+    endif
 
     date = iStartTime(1) + float(iJulianDay)/float(jday(iStartTime(1), 12, 31))
 
@@ -230,7 +230,7 @@ subroutine UA_calc_electrodynamics(UAi_nMLTs, UAi_nLats)
             sLon = GeoLonMC(i, j - 1)
           else
             sLat = -100.0
-          end if
+          endif
 
           ReferenceAlt = Altitude_GB(1, 1, 0, 1)/1000.0
           AltMinIono = ReferenceAlt
@@ -253,10 +253,10 @@ subroutine UA_calc_electrodynamics(UAi_nMLTs, UAi_nLats)
           GeoLatMC(i, j) = gLat*pi/180.0
           GeoLonMC(i, j) = gLon*pi/180.0
 
-        end if
+        endif
 
-      end do
-    end do
+      enddo
+    enddo
 
     if (iDebugLevel > 3) &
       write(*, *) "====> Starting Messagepass for apex_to_geo"
@@ -279,18 +279,18 @@ subroutine UA_calc_electrodynamics(UAi_nMLTs, UAi_nLats)
     do i = 1, nMagLons + 1
       do j = 2, nMagLats - 1
         deltalmc(i, j) = MagLatMC(i, j + 1) - MagLatMC(i, j - 1)
-      end do
+      enddo
       deltalmc(i, 1) = 2*(MagLatMC(i, 2) - MagLatMC(i, 1))
       deltalmc(i, nMagLats) = 2*(MagLatMC(i, nMagLats) - MagLatMC(i, nMagLats - 1))
-    end do
+    enddo
 
     do j = 1, nMagLats
       do i = 2, nMagLons
         deltapmc(i, j) = MagLonMC(i + 1, j) - MagLonMC(i - 1, j)
-      end do
+      enddo
       deltapmc(1, j) = 2*(MagLonMC(2, j) - MagLonMC(1, j))
       deltapmc(nMagLons + 1, j) = deltapmc(1, j)
-    end do
+    enddo
 
     deltapmc = deltapmc*Pi/180.0/2.0
     deltalmc = deltalmc*Pi/180.0/2.0
@@ -298,9 +298,9 @@ subroutine UA_calc_electrodynamics(UAi_nMLTs, UAi_nLats)
     if (UseNewTrace) then
       LengthFieldLine = 0.0
       call MMT_Init
-    end if
+    endif
 
-  end if
+  endif
 
   if ((UseApex .and. IsEarth) .or. IsFramework) then
 
@@ -314,9 +314,9 @@ subroutine UA_calc_electrodynamics(UAi_nMLTs, UAi_nLats)
 
         MagLocTimeMC(i, j) = mod(mltMC + 24.0, 24.0)
 
-      end do
-    end do
-  end if
+      enddo
+    enddo
+  endif
 
   if (.not. UseDynamo) return
 
@@ -383,7 +383,7 @@ subroutine UA_calc_electrodynamics(UAi_nMLTs, UAi_nLats)
                                           Sigma_Pedersen(:, :, k)*dAlt_GB(:, :, k, iBlock)
       HallConductance(:, :, iBlock) = HallConductance(:, :, iBlock) + &
                                       Sigma_Hall(:, :, k)*dAlt_GB(:, :, k, iBlock)
-    end do
+    enddo
 
     call report("Starting Conductances", 2)
     if (UseBarriers) call MPI_BARRIER(iCommGITM, iError)
@@ -462,9 +462,9 @@ subroutine UA_calc_electrodynamics(UAi_nMLTs, UAi_nLats)
           SigmaR(i, j, k, iUp_, iUp_) = &
             Sigma_Pedersen(i, j, k)*cos(DipAngle(i, j, k, iBlock))**2 + &
             Sigma_0(i, j, k)*sin(DipAngle(i, j, k, iBlock))**2
-        end do
-      end do
-    end do
+        enddo
+      enddo
+    enddo
 
     call report("Ending Conductances", 2)
     if (UseBarriers) call MPI_BARRIER(iCommGITM, iError)
@@ -510,9 +510,9 @@ subroutine UA_calc_electrodynamics(UAi_nMLTs, UAi_nLats)
                                      Ju(iLon, iLat, iAlt, :)* &
                                      B0(iLon, iLat, iAlt, 1:3, iBlock)/B0(iLon, iLat, iAlt, iMag_, iBlock))
 
-        end do
-      end do
-    end do
+        enddo
+      enddo
+    enddo
 
     DivJu = 0.0
 
@@ -525,12 +525,12 @@ subroutine UA_calc_electrodynamics(UAi_nMLTs, UAi_nLats)
       DivJu(:, :, :) = DivJu(:, :, :) - Gradient_GC(:, :, 1:nAlts, iDir)* &
                        B0(:, :, 1:nAlts, iDir, iBlock)/B0(:, :, 1:nAlts, iMag_, iBlock)
 
-    end do
+    enddo
 
     DivJuAlt = 0.0
     do k = 1, nAlts
       DivJuAlt(:, :) = DivJuAlt(:, :) + DivJu(:, :, k)*dAlt_GB(:, :, k, iBlock)
-    end do
+    enddo
 
     call report("Field-line integrals", 2)
     if (UseBarriers) call MPI_BARRIER(iCommGITM, iError)
@@ -620,12 +620,12 @@ subroutine UA_calc_electrodynamics(UAi_nMLTs, UAi_nLats)
           if (GeoLat > pi/2.) then
             GeoLat = pi - GeoLat
             GeoLon = mod(GeoLon + pi, twopi)
-          end if
+          endif
 
           if (GeoLat < -pi/2.) then
             GeoLat = -pi - GeoLat
             GeoLon = mod(GeoLon + pi, twopi)
-          end if
+          endif
           GeoLon = mod(GeoLon, twopi)
           if (GeoLon < 0.) GeoLon = GeoLon + twopi
 
@@ -738,27 +738,27 @@ subroutine UA_calc_electrodynamics(UAi_nMLTs, UAi_nLats)
                 if (GeoLat > pi/2.) then
                   GeoLat = pi - GeoLat
                   GeoLon = mod(GeoLon + pi, twopi)
-                end if
+                endif
 
                 if (GeoLat < -pi/2.) then
                   GeoLat = -pi - GeoLat
                   GeoLon = mod(GeoLon + pi, twopi)
-                end if
+                endif
                 GeoLon = mod(GeoLon, twopi)
                 if (GeoLon < 0.) GeoLon = GeoLon + twopi
 
-              end if
-            end if
+              endif
+            endif
 
-          end do
+          enddo
 
           if (iDebugLevel > 9) write(*, *) "=========> EndWhile "
           if (UseBarriers) call MPI_BARRIER(iCommGITM, iError)
 
-        end do
-      end do
+        enddo
+      enddo
 
-    end if
+    endif
 
     call report("Calc MLT", 2)
     if (UseBarriers) call MPI_BARRIER(iCommGITM, iError)
@@ -815,7 +815,7 @@ subroutine UA_calc_electrodynamics(UAi_nMLTs, UAi_nLats)
           else
             SigmaPLMC(i, j) = -(shh - scc)
             SigmaLPMC(i, j) = +(shh + scc)
-          end if
+          endif
 
           KDlmMC(i, j) = -sign(1.0, mLatMC)*kdlm_s*be3
           KDpmMC(i, j) = kdpm_s*be3*abs(sinim)
@@ -823,15 +823,15 @@ subroutine UA_calc_electrodynamics(UAi_nMLTs, UAi_nLats)
           KlmMC(i, j) = -sign(1.0, mLatMC)*klm_s
           KpmMC(i, j) = kpm_s*abs(sinim)
 
-        end if
+        endif
 
-      end do
-    end do
+      enddo
+    enddo
 
     call report("Done with find_mag_points", 5)
     if (UseBarriers) call MPI_BARRIER(iCommGITM, iError)
 
-  end do
+  enddo
 
   if (iDebugLevel > 2) write(*, *) "===> Beginning Sum of Electrodynamics"
   if (UseBarriers) call MPI_BARRIER(iCommGITM, iError)
@@ -882,9 +882,9 @@ subroutine UA_calc_electrodynamics(UAi_nMLTs, UAi_nLats)
       do k = -iAve, iAve
         ii = mod(i + k + nMagLons, nMagLons) + 1
         AverageMC(i + 1, j) = AverageMC(i + 1, j) + SigmaPPMC(ii, j)
-      end do
-    end do
-  end do
+      enddo
+    enddo
+  enddo
   SigmaPPMC = AverageMC/(iAve*2 + 1)
   SigmaPPMC(nMagLons + 1, :) = SigmaPPMC(1, :)
 
@@ -898,9 +898,9 @@ subroutine UA_calc_electrodynamics(UAi_nMLTs, UAi_nLats)
       do k = -iAve, iAve
         ii = mod(i + k + nMagLons, nMagLons) + 1
         AverageMC(i + 1, j) = AverageMC(i + 1, j) + SigmaLLMC(ii, j)
-      end do
-    end do
-  end do
+      enddo
+    enddo
+  enddo
   SigmaLLMC = AverageMC/(iAve*2 + 1)
   SigmaLLMC(nMagLons + 1, :) = SigmaLLMC(1, :)
 
@@ -914,9 +914,9 @@ subroutine UA_calc_electrodynamics(UAi_nMLTs, UAi_nLats)
       do k = -iAve, iAve
         ii = mod(i + k + nMagLons, nMagLons) + 1
         AverageMC(i + 1, j) = AverageMC(i + 1, j) + SigmaHHMC(ii, j)
-      end do
-    end do
-  end do
+      enddo
+    enddo
+  enddo
   SigmaHHMC = AverageMC/(iAve*2 + 1)
   SigmaHHMC(nMagLons + 1, :) = SigmaHHMC(1, :)
 
@@ -930,9 +930,9 @@ subroutine UA_calc_electrodynamics(UAi_nMLTs, UAi_nLats)
       do k = -iAve, iAve
         ii = mod(i + k + nMagLons, nMagLons) + 1
         AverageMC(i + 1, j) = AverageMC(i + 1, j) + SigmaCCMC(ii, j)
-      end do
-    end do
-  end do
+      enddo
+    enddo
+  enddo
   SigmaCCMC = AverageMC/(iAve*2 + 1)
   SigmaCCMC(nMagLons + 1, :) = SigmaCCMC(1, :)
 
@@ -946,9 +946,9 @@ subroutine UA_calc_electrodynamics(UAi_nMLTs, UAi_nLats)
       do k = -iAve, iAve
         ii = mod(i + k + nMagLons, nMagLons) + 1
         AverageMC(i + 1, j) = AverageMC(i + 1, j) + SigmaLPMC(ii, j)
-      end do
-    end do
-  end do
+      enddo
+    enddo
+  enddo
   SigmaLPMC = AverageMC/(iAve*2 + 1)
   SigmaLPMC(nMagLons + 1, :) = SigmaLPMC(1, :)
 
@@ -962,9 +962,9 @@ subroutine UA_calc_electrodynamics(UAi_nMLTs, UAi_nLats)
       do k = -iAve, iAve
         ii = mod(i + k + nMagLons, nMagLons) + 1
         AverageMC(i + 1, j) = AverageMC(i + 1, j) + SigmaPLMC(ii, j)
-      end do
-    end do
-  end do
+      enddo
+    enddo
+  enddo
   SigmaPLMC = AverageMC/(iAve*2 + 1)
   SigmaPLMC(nMagLons + 1, :) = SigmaPLMC(1, :)
 
@@ -978,9 +978,9 @@ subroutine UA_calc_electrodynamics(UAi_nMLTs, UAi_nLats)
       do k = -iAve, iAve
         ii = mod(i + k + nMagLons, nMagLons) + 1
         AverageMC(i + 1, j) = AverageMC(i + 1, j) + KDlmMC(ii, j)
-      end do
-    end do
-  end do
+      enddo
+    enddo
+  enddo
   KDlmMC = AverageMC/(iAve*2 + 1)
   KDlmMC(nMagLons + 1, :) = KDlmMC(1, :)
 
@@ -994,9 +994,9 @@ subroutine UA_calc_electrodynamics(UAi_nMLTs, UAi_nLats)
       do k = -iAve, iAve
         ii = mod(i + k + nMagLons, nMagLons) + 1
         AverageMC(i + 1, j) = AverageMC(i + 1, j) + KDpmMC(ii, j)
-      end do
-    end do
-  end do
+      enddo
+    enddo
+  enddo
   KDpmMC = AverageMC/(iAve*2 + 1)
   KDpmMC(nMagLons + 1, :) = KDpmMC(1, :)
 
@@ -1010,9 +1010,9 @@ subroutine UA_calc_electrodynamics(UAi_nMLTs, UAi_nLats)
       do k = -iAve, iAve
         ii = mod(i + k + nMagLons, nMagLons) + 1
         AverageMC(i + 1, j) = AverageMC(i + 1, j) + KlmMC(ii, j)
-      end do
-    end do
-  end do
+      enddo
+    enddo
+  enddo
   KlmMC = AverageMC/(iAve*2 + 1)
   KlmMC(nMagLons + 1, :) = KlmMC(1, :)
 
@@ -1026,9 +1026,9 @@ subroutine UA_calc_electrodynamics(UAi_nMLTs, UAi_nLats)
       do k = -iAve, iAve
         ii = mod(i + k + nMagLons, nMagLons) + 1
         AverageMC(i + 1, j) = AverageMC(i + 1, j) + KpmMC(ii, j)
-      end do
-    end do
-  end do
+      enddo
+    enddo
+  enddo
   KpmMC = AverageMC/(iAve*2 + 1)
   KpmMC(nMagLons + 1, :) = KpmMC(1, :)
 
@@ -1038,7 +1038,7 @@ subroutine UA_calc_electrodynamics(UAi_nMLTs, UAi_nLats)
   do iLon = 1, nMagLons
     if (MagLocTimeMC(iLon, iEquator) <= 12.0 .and. &
         MagLocTimeMC(iLon + 1, iEquator) >= 12.0) iLonNoon = iLon
-  end do
+  enddo
 
   ! Now we want to find out how far away we have to go away from the equator,
   ! before we need to start filling in values.
@@ -1063,12 +1063,12 @@ subroutine UA_calc_electrodynamics(UAi_nMLTs, UAi_nLats)
   do i = 1, nMagLons + 1
     do j = iStart + 1, iEquator - 1
       SigmaHHMC(i, j) = 0.83*SigmaHHMC(i, j - 1)
-    end do
+    enddo
     do j = iEnd - 1, iEquator + 1, -1
       SigmaHHMC(i, j) = 0.83*SigmaHHMC(i, j + 1)
-    end do
+    enddo
     SigmaHHMC(i, iEquator) = 0.83*(SigmaHHMC(i, iEquator - 1) + SigmaHHMC(i, iEquator + 1))/2.0
-  end do
+  enddo
 
   ! LL Conductance
 
@@ -1090,12 +1090,12 @@ subroutine UA_calc_electrodynamics(UAi_nMLTs, UAi_nLats)
   do i = 1, nMagLons + 1
     do j = iStart + 1, iEquator - 1
       SigmaLLMC(i, j) = 0.85*SigmaLLMC(i, j - 1)
-    end do
+    enddo
     do j = iEnd - 1, iEquator + 1, -1
       SigmaLLMC(i, j) = 0.85*SigmaLLMC(i, j + 1)
-    end do
+    enddo
     SigmaLLMC(i, iEquator) = 0.85*(SigmaLLMC(i, iEquator - 1) + SigmaLLMC(i, iEquator + 1))/2.0
-  end do
+  enddo
 
   ! PP Conductance
 
@@ -1115,13 +1115,13 @@ subroutine UA_calc_electrodynamics(UAi_nMLTs, UAi_nLats)
       SigmaCCMC(i, j) = 0.9*SigmaCCMC(i, j - 1)
       SigmaPLMC(i, j) = -(sigmahhmc(i, j) - sigmaccmc(i, j))
       SigmaLPMC(i, j) = +(sigmahhmc(i, j) + sigmaccmc(i, j))
-    end do
+    enddo
     do j = iEnd - 1, iEquator + 1, -1
       SigmaPPMC(i, j) = 0.9*SigmaPPMC(i, j + 1)
       SigmaCCMC(i, j) = 0.9*SigmaCCMC(i, j + 1)
       SigmaPLMC(i, j) = +(sigmahhmc(i, j) - sigmaccmc(i, j))
       SigmaLPMC(i, j) = -(sigmahhmc(i, j) + sigmaccmc(i, j))
-    end do
+    enddo
     j = iEquator
     SigmaPPMC(i, j) = 0.9*(SigmaPPMC(i, j - 1) + SigmaPPMC(i, j + 1))/2.0
     SigmaCCMC(i, j) = 0.9*(SigmaCCMC(i, j - 1) + SigmaCCMC(i, j - 1))/2.0
@@ -1135,7 +1135,7 @@ subroutine UA_calc_electrodynamics(UAi_nMLTs, UAi_nLats)
 !        if (isnan(SigmaLPMC(i,j))) write(*,*) 'sigmalp is nan : ',i,j
 !     enddo
 
-  end do
+  enddo
 
   do i = 1, nMagLons + 1
     do j = 1, iEquator - 1    ! Southern hemisphere
@@ -1159,9 +1159,9 @@ subroutine UA_calc_electrodynamics(UAi_nMLTs, UAi_nLats)
 
       if (SigmaLLMC(i, j) > 10000.0) &
         write(*, *) 'SigmaLLMC:', iproc, MagLonMC(i, j), MagLatMC(i, j), MagLatMC(i, k), SigmaLLMC(i, j)
-    end do
+    enddo
 
-  end do
+  enddo
 
   where (SigmaPLMC < 0.001) SigmaPLMC = 0.001
   where (SigmaLPMC > -0.001) SigmaLPMC = -0.001
@@ -1186,13 +1186,13 @@ subroutine UA_calc_electrodynamics(UAi_nMLTs, UAi_nLats)
 
     do j = iStart + 1, iEquator - 1
       KDlmMC(i, j) = 0.92*KDlmMC(i, j - 1)
-    end do
+    enddo
     do j = iEnd - 1, iEquator + 1, -1
       KDlmMC(i, j) = 0.92*KDlmMC(i, j + 1)
-    end do
+    enddo
     KDlmMC(i, iEquator) = 0.92*(KDlmMC(i, iEquator - 1) + KDlmMC(i, iEquator + 1))/2
 
-  end do
+  enddo
 
   ! KDpmMC
 
@@ -1214,12 +1214,12 @@ subroutine UA_calc_electrodynamics(UAi_nMLTs, UAi_nLats)
   do i = 1, nMagLons + 1
     do j = iStart + 1, iEquator - 1
       KDpmMC(i, j) = 0.92*KDpmMC(i, j - 1)
-    end do
+    enddo
     do j = iEnd - 1, iEquator + 1, -1
       KDpmMC(i, j) = 0.92*KDpmMC(i, j + 1)
-    end do
+    enddo
     KDpmMC(i, iEquator) = 0.92*(KDpmMC(i, iEquator - 1) + KDpmMC(i, iEquator + 1))/2
-  end do
+  enddo
 
   !============
 
@@ -1235,7 +1235,7 @@ subroutine UA_calc_electrodynamics(UAi_nMLTs, UAi_nLats)
       dklmdlMC(i, j) = cos(MagLatMC(i, j)*pi/180)* &
                        0.5*(KlmMC(i, j + 1) - KlmMC(i, j - 1))/deltalmc(i, j)
       dklmdlMC(i, j) = dklmdlMC(i, j) - sin(MagLatMC(i, j)*pi/180)*KlmMC(i, j)
-    end do
+    enddo
     dSigmaLLdlMC(i, 1) = (SigmaLLMC(i, 2) - SigmaLLMC(i, 1))/deltalmc(i, 1)
     dSigmaLLdlMC(i, nMagLats) = &
       (SigmaLLMC(i, nMagLats) - SigmaLLMC(i, nMagLats - 1))/deltalmc(i, nMagLats)
@@ -1262,7 +1262,7 @@ subroutine UA_calc_electrodynamics(UAi_nMLTs, UAi_nLats)
     j = nMagLats
     dklmdlMC(i, j) = dklmdlMC(i, j) - sin(MagLatMC(i, j)*pi/180)*KlmMC(i, j)
 
-  end do
+  enddo
 
   do j = 1, nMagLats
     do i = 2, nMagLons
@@ -1270,7 +1270,7 @@ subroutine UA_calc_electrodynamics(UAi_nMLTs, UAi_nLats)
       dSigmaPPdpMC(i, j) = 0.5*(SigmaPPMC(i + 1, j) - SigmaPPMC(i - 1, j))/deltapmc(i, j)
       dKDpmdpMC(i, j) = 0.5*(KDpmMC(i + 1, j) - KDpmMC(i - 1, j))/deltapmc(i, j)
       dKpmdpMC(i, j) = 0.5*(KpmMC(i + 1, j) - KpmMC(i - 1, j))/deltapmc(i, j)
-    end do
+    enddo
     dSigmaPLdpMC(1, j) = (SigmaPLMC(2, j) - SigmaPLMC(1, j))/deltapmc(1, j)
     dSigmaPLdpMC(nMagLons + 1, j) = dSigmaPLdpMC(1, j)
     dSigmaPPdpMC(1, j) = (SigmaPPMC(2, j) - SigmaPPMC(1, j))/deltapmc(1, j)
@@ -1279,7 +1279,7 @@ subroutine UA_calc_electrodynamics(UAi_nMLTs, UAi_nLats)
     dKDpmdpMC(nMagLons + 1, j) = dKDpmdpMC(1, j)
     dKpmdpMC(1, j) = (KpmMC(2, j) - KpmMC(1, j))/deltapmc(1, j)
     dKpmdpMC(nMagLons + 1, j) = dKpmdpMC(1, j)
-  end do
+  enddo
 
   solver_a_mc = 4*deltalmc**2*sigmappmc/cos(MagLatMC*pi/180)
   solver_b_mc = 4*deltapmc**2*cos(MagLatMC*pi/180)*sigmallmc
@@ -1337,22 +1337,22 @@ subroutine UA_calc_electrodynamics(UAi_nMLTs, UAi_nLats)
       do j = iStart, iEnd
         sll = SigmaLLMC(i, j)
         SigmaCowlingMC(i, j) = SigmaPPMC(i, j) - (SigmaPLMC(i, j)*SigmaLPMC(i, j)/sll)
-      end do
-    end do
+      enddo
+    enddo
     do j = iStart + 1, iEnd - 1
       do i = 2, nMagLons
         dSigmaCowlingdpMC(i, j) = 0.5*(SigmaCowlingMC(i + 1, j) - SigmaCowlingMC(i - 1, j))/deltapmc(i, j)
         dSigmaLLdpMC(i, j) = 0.5*(SigmaLLMC(i + 1, j) - SigmaLLMC(i - 1, j))/deltapmc(i, j)
         dKDlmdpMC(i, j) = 0.5*(KDlmMC(i + 1, j) - KDlmMC(i - 1, j))/deltapmc(i, j)
 
-      end do
+      enddo
       dSigmaCowlingdpMC(1, j) = (SigmaCowlingMC(2, j) - SigmaCowlingMC(1, j))/deltapmc(1, j)
       dSigmaCowlingdpMC(nMagLons + 1, j) = dSigmaCowlingdpMC(1, j)
       dSigmaLLdpMC(1, j) = (SigmaLLMC(2, j) - SigmaLLMC(1, j))/deltapmc(1, j)
       dSigmaLLdpMC(nMagLons + 1, j) = dSigmaLLdpMC(1, j)
       dKDlmdpMC(1, j) = (KDlmMC(2, j) - KDlmMC(1, j))/deltapmc(1, j)
       dKDlmdpMC(nMagLons + 1, j) = dKDlmdpMC(1, j)
-    end do
+    enddo
 
     do i = 1, nMagLons + 1
       do j = iStart, iEnd
@@ -1385,10 +1385,10 @@ subroutine UA_calc_electrodynamics(UAi_nMLTs, UAi_nLats)
            (sll*dSigmaPLdpMC(i, j) &
             - SigmaPLMC(i, j)*dSigmaLLdpMC(i, j)))
 
-      end do
-    end do
+      enddo
+    enddo
 
-  end if
+  endif
 
   ! Add this to make sure solver_a never goes below 0
   where (solver_a_mc < 0.001) solver_a_mc = 0.001
@@ -1416,7 +1416,7 @@ subroutine UA_calc_electrodynamics(UAi_nMLTs, UAi_nLats)
     write(*, *) "Error in routine calc_electrodynamics (UA_SetGrid):"
     write(*, *) iError
     call stop_gitm("Stopping in calc_electrodynamics")
-  end if
+  endif
 
   iError = 0
   call UA_GetPotential(SmallPotentialMC, iError)
@@ -1426,7 +1426,7 @@ subroutine UA_calc_electrodynamics(UAi_nMLTs, UAi_nLats)
     write(*, *) iError
 !     call stop_gitm("Stopping in calc_electrodynamics")
     SmallPotentialMC = 0.0
-  end if
+  endif
 
   do iLat = 2, nMagLats - 1
     do iLon = 1, nMagLons
@@ -1458,15 +1458,15 @@ subroutine UA_calc_electrodynamics(UAi_nMLTs, UAi_nLats)
         b(iI) = b(iI) - (solver_b_mc(iLon, iLat) - solver_d_mc(iLon, iLat))* &
                 SmallPotentialMC(iLon, 1)
         e1_I(iI) = 0.0
-      end if
+      endif
       if (iLat == nMagLats - 1) then
         b(iI) = b(iI) - (solver_b_mc(iLon, iLat) + solver_d_mc(iLon, iLat))* &
                 SmallPotentialMC(iLon, 2)
         f1_I(iI) = 0.0
-      end if
+      endif
 
-    end do
-  end do
+    enddo
+  enddo
 
   call start_timing("dynamo_solver")
 
@@ -1496,7 +1496,7 @@ subroutine UA_calc_electrodynamics(UAi_nMLTs, UAi_nLats)
     DoTestMe = .true.
   else
     DoTestMe = .false.
-  end if
+  endif
 
   Residual = 1.0    !! Residual = 1.0 iterations required ~ 103
              !! with Residual=0.01,only 20 more iterations are required (~ 122)
@@ -1513,8 +1513,8 @@ subroutine UA_calc_electrodynamics(UAi_nMLTs, UAi_nLats)
     do iLon = 1, nMagLons
       iI = iI + 1
       DynamoPotentialMC(iLon, iLat) = x(iI)
-    end do
-  end do
+    enddo
+  enddo
 
   DynamoPotentialMC(:, 1) = 0.0
   DynamoPotentialMC(:, nMagLats) = 0.0
@@ -1528,8 +1528,8 @@ subroutine UA_calc_electrodynamics(UAi_nMLTs, UAi_nLats)
     do iLon = 1, nMagLons
       iI = nMagLats - iLat + 1
       DynamoPotentialMC(iLon, iLat) = OldPotMC(iLon, iI)
-    end do
-  end do
+    enddo
+  enddo
   ! --------------------------------------------------------------------------
 
   DynamoPotentialMC(nMagLons + 1, :) = DynamoPotentialMC(1, :)
@@ -1541,11 +1541,11 @@ subroutine UA_calc_electrodynamics(UAi_nMLTs, UAi_nLats)
     do i = 2, nMagLons
       Ed1new(i, j) = -(1/(RBody*cos(MagLatMC(i, j)*pi/180)))* &
                      0.5*(DynamoPotentialMC(i + 1, j) - DynamoPotentialMC(i - 1, j))/deltapmc(i, j)
-    end do
+    enddo
     Ed1new(1, j) = -(1/(RBody*cos(MagLatMC(i, j)*pi/180)))* &
                    (DynamoPotentialMC(2, j) - DynamoPotentialMC(1, j))/deltapmc(1, j)
     Ed1new(nMagLons + 1, j) = Ed1new(1, j)
-  end do
+  enddo
 
   do i = 1, nMagLons + 1
     do j = 2, nMagLats - 1
@@ -1553,7 +1553,7 @@ subroutine UA_calc_electrodynamics(UAi_nMLTs, UAi_nLats)
                   sqrt(4.0 - 3.0*cos(MagLatMC(i, j)*pi/180))) + 1e-6
       Ed2new(i, j) = (1/(RBody*sinIm))* &
                      0.5*(DynamoPotentialMC(i, j + 1) - DynamoPotentialMC(i, j - 1))/deltalmc(i, j)
-    end do
+    enddo
     sinim = abs(2.0*sin(MagLatMC(i, 1)*pi/180)/ &
                 sqrt(4.0 - 3.0*cos(MagLatMC(i, 1)*pi/180))) + 1e-6
     Ed2new(i, 1) = (1/(RBody*sinIm))* &
@@ -1564,7 +1564,7 @@ subroutine UA_calc_electrodynamics(UAi_nMLTs, UAi_nLats)
     Ed2new(i, nMagLats) = (1/(RBody*sinIm))* &
                           (DynamoPotentialMC(i, nMagLats) - DynamoPotentialMC(i, nMagLats - 1))/deltalmc(i, nMagLats)
 
-  end do
+  enddo
 ! End Electric field
 
 !  write(*,*) "=========> Done! ", iProc, i, j
@@ -1595,11 +1595,11 @@ contains
             if (iLon == nLons) then
               magloctime_local(iLon + 1, iLat) = &
                 magloctime_local(iLon + 1, iLat) + 24.0
-            end if
-          end if
-        end if
-      end do
-    end do
+            endif
+          endif
+        endif
+      enddo
+    enddo
 
   end subroutine calc_mltlocal
 
@@ -1653,7 +1653,7 @@ contains
       jj = jj + 1
       if (gLatMC >= Latitude(jj, iBlock) .and. &
           gLatMC < Latitude(jj + 1, iBlock)) IsFound = .true.
-    end do
+    enddo
 
     IsFound = .false.
     ii = -1
@@ -1661,7 +1661,7 @@ contains
       ii = ii + 1
       if (gLonMC >= Longitude(ii, iBlock) .and. &
           gLonMC < Longitude(ii + 1, iBlock)) IsFound = .true.
-    end do
+    enddo
 
     mfac = (gLonMC - Longitude(ii, iBlock))/ &
            (Longitude(ii + 1, iBlock) - Longitude(ii, iBlock))
@@ -1744,7 +1744,7 @@ contains
           gmlt = gmlt - 24.0
         else
           if (gmlt2 < gmlt .and. mltMC > gmlt) gmlt2 = gmlt2 + 24.0
-        end if
+        endif
 
         IsFound = .false.
 
@@ -1774,8 +1774,8 @@ contains
                 mlatMC == MLatitude(ii, jj + 1, k, iBlock)) &
               IsFound = .true.
 
-          end if
-        end if
+          endif
+        endif
 
 !          if (ii == 0 .or. jj == 0) IsFound = .false.
 
@@ -1807,12 +1807,12 @@ contains
           ii = nLons
           jj = nLats
 
-        end if
+        endif
 
         jj = jj + 1
-      end do
+      enddo
       ii = ii + 1
-    end do
+    enddo
 
   end subroutine find_mag_point_old
 
@@ -1855,8 +1855,8 @@ subroutine matvec_gitm(x_I, y_I, n)
     do iLon = 1, nMagLons
       i = i + 1
       x_G(iLon, iLat) = x_I(i)
-    end do
-  end do
+    enddo
+  enddo
 
   x_G(:, 1) = 0.0
   x_G(:, nMagLats) = 0.0
@@ -1894,8 +1894,8 @@ subroutine matvec_gitm(x_I, y_I, n)
         x_G(iLm, iLat + 1) + &
         (solver_c_mc(iLon, iLat))* &
         x_G(iLm, iLat - 1)
-    end do
-  end do
+    enddo
+  enddo
 
 !!!  ! Preconditioning: y'= U^{-1}.L^{-1}.y
   call Lhepta(n, 1, nMagLons, n, y_I, d_I, e_I, e1_I)
@@ -1961,9 +1961,9 @@ subroutine UA_calc_electrodynamics_1d
                                           Sigma_Pedersen(:, :, k)*dAlt_GB(:, :, k, iBlock)
       HallConductance(:, :, iBlock) = HallConductance(:, :, iBlock) + &
                                       Sigma_Hall(:, :, k)*dAlt_GB(:, :, k, iBlock)
-    end do
+    enddo
 
-  end do
+  enddo
 
   call end_timing("calc_electrodyn_1d")
 

--- a/src/calc_electron_temperature.Earth.f90
+++ b/src/calc_electron_temperature.Earth.f90
@@ -114,7 +114,7 @@ subroutine calc_electron_ion_temperature(iBlock)
 
       if (MLT(iLon, iLat, nAlts) < 0.0) then
         MLT(iLon, iLat, nAlts) = MLT(iLon, iLat, nAlts) + 24.0
-      end if
+      endif
 
       if (abs(MLT(iLon, iLat, nAlts) - x1) < 12) then
         temp = 1 - (MLT(iLon, iLat, nAlts) - x1)**2/aa**2 - &
@@ -122,20 +122,20 @@ subroutine calc_electron_ion_temperature(iBlock)
       else
         temp = 1 - (24 - abs(MLT(iLon, iLat, nAlts) - x1))**2/aa**2 - &
                (abs(MLatitude(iLon, iLat, nAlts, iBlock)) - y1)**2/bb**2
-      end if
+      endif
 
       if (temp > 0.0) then
         eflux(iLon, iLat) = z1 + cc*sqrt(temp)
       else
         eflux(iLon, iLat) = z1
-      end if
+      endif
 
       eflux(iLon, iLat) = exp(log(10.)*eflux(iLon, iLat))
 
       eflux(iLon, iLat) = eflux(iLon, iLat)*1.602e-19*1e4*0.2
 
-    end do
-  end do
+    enddo
+  enddo
 
   sinI2 = (B0(0:nLons + 1, 0:nLats + 1, 0:nAlts + 1, iUp_, iBlock)/ &
            B0(0:nLons + 1, 0:nLats + 1, 0:nAlts + 1, iMag_, iBlock))**2
@@ -193,25 +193,25 @@ subroutine calc_electron_ion_temperature(iBlock)
           if (ieee_is_nan(a(iAlt))) then
             write(*, *) "a : ", iLon, iLat, iAlt
             NanFound = .true.
-          end if
+          endif
 
           if (ieee_is_nan(b(iAlt))) then
             write(*, *) "b : ", iLon, iLat, iAlt
             NanFound = .true.
-          end if
+          endif
 
           if (ieee_is_nan(c(iAlt))) then
             write(*, *) "c : ", iLon, iLat, iAlt
             NanFound = .true.
-          end if
+          endif
 
           if (ieee_is_nan(d(iAlt))) then
             write(*, *) "d : ", iLon, iLat, iAlt
             write(*, *) xcoef, tte, eHeatingm(iLon, iLat, iAlt)
             NanFound = .true.
-          end if
+          endif
 
-        end if
+        endif
 
         eConduction(iLon, iLat, iAlt) = c(iAlt)*te(iLon, iLat, iAlt + 1) + &
                                         a(iAlt)*te(iLon, iLat, iAlt + 1) + &
@@ -221,8 +221,8 @@ subroutine calc_electron_ion_temperature(iBlock)
           if (ieee_is_nan(eConduction(iLon, iLat, iAlt))) then
             write(*, *) "eCondu : ", iLon, iLat, iAlt
             NanFound = .true.
-          end if
-        end if
+          endif
+        endif
 
         if (abs(MLatitude(iLon, iLat, nAlts, iBlock)) .GE. 45.) then
 
@@ -244,8 +244,8 @@ subroutine calc_electron_ion_temperature(iBlock)
             if (ieee_is_nan(JParaAlt(iLon, iLat))) then
               write(*, *) "jpar : ", iLon, iLat, iAlt
               NanFound = .true.
-            end if
-          end if
+            endif
+          endif
 
           ! use thermoelectric heating
 
@@ -282,9 +282,9 @@ subroutine calc_electron_ion_temperature(iBlock)
           !     uiup(iLon,iLat,iAlt) &
           !     *zl**2/hcoef
 
-        end if
+        endif
 
-      end do
+      enddo
 
       ! Bottom Bounday Te = Tn
       a(1) = 0
@@ -306,8 +306,8 @@ subroutine calc_electron_ion_temperature(iBlock)
 
       if (NanFound) call stop_gitm('must stop')
 
-    end do
-  end do
+    enddo
+  enddo
 
   lam_i = lami*sinI2
   ! Use tri-diagnal solver to solve the equation
@@ -339,12 +339,12 @@ subroutine calc_electron_ion_temperature(iBlock)
           b(iAlt) = -xcoef - iHeatingp(iLon, iLat, iAlt)
           c(iAlt) = 0.
           d(iAlt) = -xcoef*tti - iHeatingm(iLon, iLat, iAlt)
-        end if
+        endif
 
         iConduction(iLon, iLat, iAlt) = c(iAlt)*ti(iLon, iLat, iAlt + 1) + &
                                         a(iAlt)*ti(iLon, iLat, iAlt + 1) + &
                                         (-2*ilam/hcoef*(zu + zl) + fcoef*(zu**2 - zl**2))*tti
-      end do
+      enddo
 
       ! Bottom Bounday Ti = Tn
       a(1) = 0
@@ -357,8 +357,8 @@ subroutine calc_electron_ion_temperature(iBlock)
       itemp(iLon, iLat, 1:nAlts) = u(1:nAlts)
       itemp(iLon, iLat, nAlts + 1) = itemp(iLon, iLat, nAlts)
       itemp(iLon, iLat, 0) = itemp(iLon, iLat, 1)
-    end do
-  end do
+    enddo
+  enddo
 
   ! Check if reasonable temperatures
   where (etemp .LT. tn) etemp = tn
@@ -397,14 +397,14 @@ contains
       m = b(iAlt) - cpp(iAlt - 1)*a(iAlt)
       cpp(iAlt) = c(iAlt)/m
       dpp(iAlt) = (d(iAlt) - dpp(iAlt - 1)*a(iAlt))/m
-    end do
+    enddo
 
     ! initialize u
     u(nAlts) = dpp(nAlts)
     ! solve for u from the vectors c-prime and d-prime
     do iAlt = nAlts - 1, 1, -1
       u(iAlt) = dpp(iAlt) - cpp(iAlt)*u(iAlt + 1)
-    end do
+    enddo
 
   end subroutine tridag
 
@@ -430,7 +430,7 @@ contains
                                (iVelo(:, :, :, iDir) - eVelo(:, :, :, iDir))
 
       OverB0(:, :, :, iDir) = B0(:, :, :, iDir, iBlock)/B0(:, :, :, iMag_, iBlock)**2
-    end do
+    enddo
 
     do iAlt = -1, nAlts + 2
       do iLat = -1, nLats + 2
@@ -438,9 +438,9 @@ contains
           JuTotalDotB(iLon, iLat, iAlt) = sum( &
                                           JuTotal(iLon, iLat, iAlt, 1:3)* &
                                           B0(iLon, iLat, iAlt, 1:3, iBlock))
-        end do
-      end do
-    end do
+        enddo
+      enddo
+    enddo
 
     DivJPerp = 0.0
     do iDir = 1, 3
@@ -454,14 +454,14 @@ contains
       call UAM_Gradient_GC(OverB0(:, :, :, iDir), Gradient_GC, iBlock)
       DivJPerp(:, :, :) = DivJPerp(:, :, :) - Gradient_GC(:, :, :, iDir) &
                           *JuTotalDotB(:, :, :)
-    end do
+    enddo
 
     PartialJPara = -DivJPerp
 
     JParaAlt = 0.0
     do iAlt = 1, nAlts
       JParaAlt(:, :) = JParaAlt(:, :) - DivJPerp(:, :, iAlt)*dAlt_GB(:, :, iAlt, iBlock)
-    end do
+    enddo
 
   end Subroutine calc_thermoelectric_current
 
@@ -636,11 +636,11 @@ subroutine calc_electron_ion_sources(iBlock) !,eHeatingp,iHeatingp,eHeatingm,iHe
             write(*, *) 'ep : ', epsilon(iLon, iLat, iAlt)
             write(*, *) 'qphe : ', qphe(iLon, iLat, iAlt)
             call stop_gitm('epsilon')
-          end if
-        end do
-      end do
-    end do
-  end if
+          endif
+        enddo
+      enddo
+    enddo
+  endif
 
 ! Auroral heating
   Qaurora = 0.0
@@ -711,7 +711,7 @@ subroutine calc_electron_ion_sources(iBlock) !,eHeatingp,iHeatingp,eHeatingm,iHe
   do iDir = 1, 3
     dv2_en = dv2_en + (Velocity(0:nLons + 1, 0:nLats + 1, 0:nAlts + 1, iDir, iBlock) &
                        - ExB(0:nLons + 1, 0:nLats + 1, 0:nAlts + 1, iDir))**2
-  end do
+  enddo
 
   Qenc_v = ne*Mass_Electron*dv2_en* &
            (2.33e-11*nn2*1.e-6*(1 - 1.21e-4*te)*te*Mass(iN2_)/(Mass_Electron + Mass(iN2_)) &
@@ -725,7 +725,7 @@ subroutine calc_electron_ion_sources(iBlock) !,eHeatingp,iHeatingp,eHeatingm,iHe
   do iDir = 1, 3
     dv2_ei = dv2_ei + (IVelocity(0:nLons + 1, 0:nLats + 1, 0:nAlts + 1, iDir, iBlock) &
                        - ExB(0:nLons + 1, 0:nLats + 1, 0:nAlts + 1, iDir))**2
-  end do
+  enddo
 
   Qeic_v = ne*Mass_Electron*dv2_ei*5.45*1.e-5/(te**1.5)*(nop + no2p + nn2p + nnop + nnp)
 !        (nop/(Mass_Electron+MassI(iO_4SP_))  &
@@ -856,19 +856,19 @@ subroutine calc_electron_ion_sources(iBlock) !,eHeatingp,iHeatingp,eHeatingm,iHe
             Qvib_n2(iLon, iLat, iAlt) = Qvib_n2(iLon, iLat, iAlt) + &
                                         (1.-exp(-3353./ttn))*10**logQv0(iLon, iLat, iAlt, iLevel) &
                                         *(1.-exp(iLevel*3353.*(1./tte - 1./ttn)))
-          end do
+          enddo
 
           do iLevel = 2, 9
             Qvib_n2(iLon, iLat, iAlt) = Qvib_n2(iLon, iLat, iAlt) + &
                                         (1.-exp(-3353./ttn))*exp(-3353./ttn) &
                                         *10**logQv1(iLon, iLat, iAlt, iLevel)* &
                                         (1.-exp((iLevel - 1)*3353.*(1./tte - 1./ttn)))
-          end do
+          enddo
 
-        end if
-      end do
-    end do
-  end do
+        endif
+      enddo
+    enddo
+  enddo
 
   Qvib_n2 = -ne*nn2*1.e-12*Qvib_n2*1.6e-13
 
@@ -919,7 +919,7 @@ subroutine calc_electron_ion_sources(iBlock) !,eHeatingp,iHeatingp,eHeatingm,iHe
   do iDir = 1, 3
     dv2 = dv2 + (IVelocity(0:nLons + 1, 0:nLats + 1, 0:nAlts + 1, iDir, iBlock) &
                  - Velocity(0:nLons + 1, 0:nLats + 1, 0:nAlts + 1, iDir, iBlock))**2
-  end do
+  enddo
 
   ! Changed this to use the ion-neutral collision frequencies defined in
   ! calc_rates.  These should be used for consistency throughout the code
@@ -965,8 +965,8 @@ subroutine calc_electron_ion_sources(iBlock) !,eHeatingp,iHeatingp,eHeatingm,iHe
                dv2/ &
                (MassI(iIon) + Mass(iSpecies))
 
-    end do
-  end do
+    enddo
+  enddo
 
 !  Qinc_t = &
 !       nop  * MassI(iO_4SP_) * nu_oop   * (3.*Boltzmanns_Constant*(tn-ti))/(MassI(iO_4SP_) + Mass(iO_3P_)) + &
@@ -1095,7 +1095,7 @@ subroutine calc_electron_ion_sources(iBlock) !,eHeatingp,iHeatingp,eHeatingm,iHe
   do iLat = 1, nLats
     sintheta(:, iLat) = sin(PI/2.-Latitude(iLat, iBlock))
     costheta(:, iLat) = cos(PI/2.-Latitude(iLat, iBlock))
-  end do
+  enddo
   where (sintheta .LT. 0.1 .AND. sintheta .GE. 0.0) sintheta = 0.1
   where (sintheta .GT. -0.1 .AND. sintheta .LE. 0.0) sintheta = -0.1
   sin2theta = sintheta**2
@@ -1199,7 +1199,7 @@ subroutine calc_electron_ion_sources(iBlock) !,eHeatingp,iHeatingp,eHeatingm,iHe
     !      + sin2dec(1:nLons,1:nLats,iAlt) / sin2theta  &
     !      * (ti_con(2:nLons+1,1:nLats,iAlt) + ti_con(0:nLons-1,1:nLats,iAlt) &
 ! - 2*ti_con(1:nLons,1:nLats,iAlt)) / dLon**2 )
-  end do
+  enddo
 
   JouleHeating2d = 0.0
   HeatTransfer2d = 0.0
@@ -1222,13 +1222,13 @@ subroutine calc_electron_ion_sources(iBlock) !,eHeatingp,iHeatingp,eHeatingm,iHe
       HeatTransfer2d(1:nLons, 1:nLats) = &
         HeatTransfer2d(1:nLons, 1:nLats) + &
         Qnic_t(1:nLons, 1:nLats, iAlt)*dAlt_GB(1:nLons, 1:nLats, iAlt, iBlock)
-    end do
+    enddo
 
   else
 
     JouleHeating = 0.0
 
-  end if
+  endif
 
   ElectronHeating = -Qenc(1:nLons, 1:nLats, 1:nAlts)/ &
                     TempUnit(1:nLons, 1:nLats, 1:nAlts)/ &
@@ -1267,9 +1267,9 @@ subroutine calc_electron_ion_sources(iBlock) !,eHeatingp,iHeatingp,eHeatingm,iHe
           if (ieee_is_nan(Qenc_v(iLon, iLat, iAlt))) call stop_gitm('Qenc_v')
           if (ieee_is_nan(Qeic_v(iLon, iLat, iAlt))) call stop_gitm('Qeic_v')
           if (ieee_is_nan(Qeconhm(iLon, iLat, iAlt))) call stop_gitm('Qeconhm')
-        end do
-      end do
-    end do
-  end if
+        enddo
+      enddo
+    enddo
+  endif
 
 end subroutine calc_electron_ion_sources

--- a/src/calc_electron_temperature.Mars.f90
+++ b/src/calc_electron_temperature.Mars.f90
@@ -59,19 +59,19 @@ subroutine calc_electron_temperature(iBlock)
           eTemperature(iLon, iLat, iAlt, iBlock) = &
             Temperature(iLon, iLat, iAlt, iBlock)*TempUnit(iLon, iLat, iAlt)
           k130 = ialt
-        end if
+        endif
 
         if (Alt >= 130.0 .and. Alt <= 180.0) Then
           TN130 = Temperature(iLon, iLat, k130, iBlock)*TempUnit(iLon, iLat, k130)
           eTemperature(iLon, iLat, iAlt, iBlock) = TN130 + (TE180 - TN130)*(Alt - 130.)/50.
-        end if
+        endif
 
         if (Alt > 180.0) eTemperature(iLon, iLat, iAlt, iBlock) = &
           0.5*(TH + TL) + 0.5*(TH - TL)*tanh((Alt - Z0)/H0)
 
-      end do
-    end do
-  end do
+      enddo
+    enddo
+  enddo
 
   !Ion Temperature
   !FOX[93] FORMULATION FOR DY TI FROM ROHRBAUGH ET. AL. [79]
@@ -91,9 +91,9 @@ subroutine calc_electron_temperature(iBlock)
         if (Alt >= 180.0 .and. Alt <= 300.0) iTemperature(iLon, iLat, iAlt, iBlock) = &
           10.0**(2.243 + (Alt - 180.0)/95.0)
 
-      end do
-    end do
-  end do
+      enddo
+    enddo
+  enddo
 
 end subroutine calc_electron_temperature
 

--- a/src/calc_electron_temperature.Titan.f90
+++ b/src/calc_electron_temperature.Titan.f90
@@ -80,9 +80,9 @@ subroutine calc_electron_temperature(iBlock, eHeatingp, iHeatingp, eHeatingm, iH
                Temperature(iLon, iLat, iAlt, iBlock)*TempUnit(iLon, iLat, iAlt))* &
           (1.0 + tanh((Altitude_GB(iLon, iLat, iAlt, iBlock) - 1900.0e+03)/200.0e+03)) + &
           Temperature(iLon, iLat, iAlt, iBlock)*TempUnit(iLon, iLat, iAlt)
-      end do !iAlt = -1, nAlts+2
-    end do !iLat = -1, nLats+2
-  end do !iLon = -1, nLons+2
+      enddo !iAlt = -1, nAlts+2
+    enddo !iLat = -1, nLats+2
+  enddo !iLon = -1, nLons+2
 
 !!!! Upper Boundary Conditions!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
 !!!!!![Reference: 1. J.T. Hastings and R.G. Roble, Planet. Space Sci., Vol.25, pp.209, 1977.  Equation(31)
@@ -382,14 +382,14 @@ contains
       m = b(iAlt) - cpp(iAlt - 1)*a(iAlt)
       cpp(iAlt) = c(iAlt)/m
       dpp(iAlt) = (d(iAlt) - dpp(iAlt - 1)*a(iAlt))/m
-    end do
+    enddo
 
     ! initialize u
     u(nAlts) = dpp(nAlts)
     ! solve for u from the vectors c-prime and d-prime
     do iAlt = nAlts - 1, 1, -1
       u(iAlt) = dpp(iAlt) - cpp(iAlt)*u(iAlt + 1)
-    end do
+    enddo
 
   end subroutine tridag
 
@@ -415,7 +415,7 @@ contains
                                (iVelo(:, :, :, iDir) - eVelo(:, :, :, iDir))
 
       OverB0(:, :, :, iDir) = B0(:, :, :, iDir, iBlock)/B0(:, :, :, iMag_, iBlock)**2
-    end do
+    enddo
 
     do iAlt = -1, nAlts + 2
       do iLat = -1, nLats + 2
@@ -423,9 +423,9 @@ contains
           JuTotalDotB(iLon, iLat, iAlt) = sum( &
                                           JuTotal(iLon, iLat, iAlt, 1:3)* &
                                           B0(iLon, iLat, iAlt, 1:3, iBlock))
-        end do
-      end do
-    end do
+        enddo
+      enddo
+    enddo
 
     DivJPerp = 0.0
     do iDir = 1, 3
@@ -439,14 +439,14 @@ contains
       call UAM_Gradient_GC(OverB0(:, :, :, iDir), Gradient_GC, iBlock)
       DivJPerp(:, :, :) = DivJPerp(:, :, :) - Gradient_GC(:, :, :, iDir) &
                           *JuTotalDotB(:, :, :)
-    end do
+    enddo
 
     PartialJPara = -DivJPerp
 
     JParaAlt = 0.0
     do iAlt = 1, nAlts
       JParaAlt(:, :) = JParaAlt(:, :) - DivJPerp(:, :, iAlt)*dAlt_GB(:, :, iAlt, iBlock)
-    end do
+    enddo
 
   end Subroutine calc_thermoelectric_current
 
@@ -879,19 +879,19 @@ subroutine calc_electron_ion_sources(iBlock, eHeatingp, iHeatingp, eHeatingm, iH
               Qvib_n2(iLon, iLat, iAlt) + &
               (1.-exp(-3353./ttn))*10**logQv0(iLon, iLat, iAlt, iLevel) &
               *(1.-exp(iLevel*3353.*(1./tte - 1./ttn)))
-          end do
+          enddo
 
           do iLevel = 2, 9
             Qvib_n2(iLon, iLat, iAlt) = Qvib_n2(iLon, iLat, iAlt) + &
                                         (1.-exp(-3353./ttn))*exp(-3353./ttn) &
                                         *10**logQv1(iLon, iLat, iAlt, iLevel)* &
                                         (1.-exp((iLevel - 1)*3353.*(1./tte - 1./ttn)))
-          end do
+          enddo
 
-        end if
-      end do
-    end do
-  end do
+        endif
+      enddo
+    enddo
+  enddo
   ! No N2-vibration below 300 K
 
   Qvib_n2 = -ne*nn2*1.e-12*Qvib_n2*1.6e-13
@@ -983,7 +983,7 @@ subroutine calc_electron_ion_sources(iBlock, eHeatingp, iHeatingp, eHeatingm, iH
   do iDir = 1, 3
     dv2 = dv2 + (IVelocity(0:nLons + 1, 0:nLats + 1, 0:nAlts + 1, iDir, iBlock) &
                  - Velocity(0:nLons + 1, 0:nLats + 1, 0:nAlts + 1, iDir, iBlock))**2
-  end do
+  enddo
 
   ! Next sum over the ion-neutral pairs
   ! Heating due to the Tn - Ti
@@ -1126,7 +1126,7 @@ subroutine calc_electron_ion_sources(iBlock, eHeatingp, iHeatingp, eHeatingm, iH
   do iLat = 1, nLats
     sintheta(:, iLat) = sin(PI/2.-Latitude(iLat, iBlock))
     costheta(:, iLat) = cos(PI/2.-Latitude(iLat, iBlock))
-  end do
+  enddo
 
   where (sintheta .LT. 0.1 .AND. sintheta .GE. 0.0) sintheta = 0.1
   where (sintheta .GT. -0.1 .AND. sintheta .LE. 0.0) sintheta = -0.1
@@ -1218,7 +1218,7 @@ subroutine calc_electron_ion_sources(iBlock, eHeatingp, iHeatingp, eHeatingm, iH
     !      + sin2dec(1:nLons,1:nLats,iAlt) / sin2theta  &
     !      * (ti_con(2:nLons+1,1:nLats,iAlt) + ti_con(0:nLons-1,1:nLats,iAlt) &
 ! - 2*ti_con(1:nLons,1:nLats,iAlt)) / dLon**2 )
-  end do
+  enddo
 
   if (UseJouleHeating .and. UseIonDrag) then
 
@@ -1234,7 +1234,7 @@ subroutine calc_electron_ion_sources(iBlock, eHeatingp, iHeatingp, eHeatingm, iH
 
     JouleHeating = 0.0
 
-  end if
+  endif
 
   ElectronHeating = -Qenc(1:nLons, 1:nLats, 1:nAlts)/ &
                     TempUnit(1:nLons, 1:nLats, 1:nAlts)/ &

--- a/src/calc_electron_temperature.Venus.f90
+++ b/src/calc_electron_temperature.Venus.f90
@@ -60,21 +60,21 @@ subroutine calc_electron_temperature(iBlock)
           eTemperature(iLon, iLat, iAlt, iBlock) = &
             Temperature(iLon, iLat, iAlt, iBlock)*TempUnit(iLon, iLat, iAlt)
           k130 = ialt
-        end if
+        endif
 
         if (Alt >= 130.0 .and. Alt <= 180.0) Then
           TN130 = Temperature(iLon, iLat, k130, iBlock)*TempUnit(iLon, iLat, k130)
           eTemperature(iLon, iLat, iAlt, iBlock) = TN130 + (TE180 - TN130)*(Alt - 130.)/50.
-        end if
+        endif
 
         !        if (Alt > 180.0) eTemperature(iLon,iLat,iAlt,iBlock) = &
         !           0.5*(TH+TL) + 0.5*(TH-TL)*tanh((Alt-Z0)/H0)
         if (Alt > 180.0) eTemperature(iLon, iLat, iAlt, iBlock) = &
           0.5*(TH + TL2) + 0.5*(TH - TL2)*tanh((Alt - Z0)/H0)
 
-      end do
-    end do
-  end do
+      enddo
+    enddo
+  enddo
 
   !Ion Temperature
   !FOX[93] FORMULATION FOR DY TI FROM ROHRBAUGH ET. AL. [79]
@@ -94,9 +94,9 @@ subroutine calc_electron_temperature(iBlock)
         if (Alt >= 180.0 .and. Alt <= 300.0) iTemperature(iLon, iLat, iAlt, iBlock) = &
           10.0**(2.243 + (Alt - 180.0)/95.0)
 
-      end do
-    end do
-  end do
+      enddo
+    enddo
+  enddo
 
 end subroutine calc_electron_temperature
 

--- a/src/calc_etemp_sources.f90
+++ b/src/calc_etemp_sources.f90
@@ -241,9 +241,9 @@ subroutine calc_etemp_sources(Heating, Cooling, iBlock)
 
         if (altitude(k)/1000. < 250.) then
           cooling(i, j, k) = 0.99*Heating(i, j, k)
-        end if
+        endif
 
-      end do
+      enddo
 
       do k = 1, nAlts
 
@@ -252,10 +252,10 @@ subroutine calc_etemp_sources(Heating, Cooling, iBlock)
         if (cooling(i, j, k) < 0.6*Heating(i, j, k)) &
           cooling(i, j, k) = 0.6*Heating(i, j, k)
 
-      end do
+      enddo
 
-    end do
-  end do
+    enddo
+  enddo
 
 end subroutine calc_etemp_sources
 

--- a/src/calc_euv.f90
+++ b/src/calc_euv.f90
@@ -39,7 +39,7 @@ subroutine euv_ionization_heat(iBlock)
   else
     if (floor((tSimulation - dT)/dTAurora) == &
         floor(tSimulation/dTAurora)) return
-  end if
+  endif
 
   call report("euv_ionization_heat", 2)
   call start_timing("euv_ionization_heat")
@@ -66,7 +66,7 @@ subroutine euv_ionization_heat(iBlock)
       do iSpecies = 1, nSpecies
         Tau = Tau + &
               photoabs(iWave, iSpecies)*ChapmanLittle(:, :, iSpecies)
-      end do
+      enddo
 
       Intensity = Flux_of_EUV(iWave)*exp(-1.0*Tau)
 
@@ -82,8 +82,8 @@ subroutine euv_ionization_heat(iBlock)
             (1.0 + PhotoElecIon(iWave, iIon))
         else
           EuvIonRateS(:, :, iAlt, iIon, iBlock) = 0.0
-        end if
-      end do
+        endif
+      enddo
 
       do iSpecies = 1, nSpecies
         EuvDissRateS(:, :, iAlt, iSpecies, iBlock) = &
@@ -91,15 +91,15 @@ subroutine euv_ionization_heat(iBlock)
           Intensity*PhotoDis(iWave, iSpecies)* &
           NeutralDensity(:, :, iSpecies)* &
           (1.0 + PhotoElecDiss(iWave, iSpecies))
-      end do
+      enddo
 
       do iSpecies = 1, nSpecies
         EHeat = EHeat + &
                 Intensity*PhotonEnergy(iWave)* &
                 photoabs(iWave, iSpecies)*NeutralDensity(:, :, iSpecies)
-      end do
+      enddo
 
-    end do
+    enddo
 
     EuvHeating(:, :, iAlt, iBlock) = EHeat*HeatingEfficiency_CB(:, :, iAlt, iBlock)
     eEuvHeating(:, :, iAlt, iBlock) = EHeat*eHeatingEfficiency_CB(:, :, iAlt, iBlock)
@@ -114,7 +114,7 @@ subroutine euv_ionization_heat(iBlock)
     !   enddo
     !enddo
 
-  end do
+  enddo
 
   if (IncludeEclipse) call calc_eclipse_effects
   if (IsEarth) call night_euv_ionization
@@ -147,11 +147,11 @@ subroutine euv_ionization_heat(iBlock)
                                      TempUnit(1:nLons, 1:nLats, iAlt)/ &
                                      HeatingEfficiency_CB(:, :, iAlt, iBlock)
 
-    end do
+    enddo
 
   else
     EuvHeating = 0.0
-  end if
+  endif
 
   call end_timing("euv_ionization_heat")
 
@@ -227,7 +227,7 @@ contains
                 EuvIonRateS(iLon, iLat, iAlt, iIon, iBlock) = &
                   EuvIonRateS(iLon, iLat, iAlt, iIon, iBlock)* &
                   Factor(iLon, iLat, iAlt)
-              end do
+              enddo
               EuvHeating(iLon, iLat, iAlt, iBlock) = &
                 EuvHeating(iLon, iLat, iAlt, iBlock)* &
                 Factor(iLon, iLat, iAlt)
@@ -241,13 +241,13 @@ contains
               CH4PERateS(iLon, iLat, iAlt, :, iBlock) = &
                 CH4PERateS(iLon, iLat, iAlt, :, iBlock)*Factor(iLon, iLat, iAlt)
 
-            end if
+            endif
 
-          end do
-        end do
-      end do
+          enddo
+        enddo
+      enddo
 
-    end if
+    endif
 
   end subroutine calc_eclipse_effects
 
@@ -330,7 +330,7 @@ contains
       nighteuvflux(iWave, :, :, iBlock) = tempflux
       nPhotonEnergy(iWave) = tempPhotonEnergy
 
-    end do
+    enddo
 
     !! Calculate Tau
     do iAlt = nAlts, 1, -1
@@ -349,10 +349,10 @@ contains
             /(-Gravity_GB(1:nLons, 1:nLats, iAlt, iBlock)*Mass(iSpecies))
           night_col(:, :, iAlt, iSpecies) = nNeutralDensity(:, :, iSpecies) &
                                             *ScaleHeightS
-        end if
+        endif
 
-      end do
-    end do
+      enddo
+    enddo
 
     do iAlt = 1, nAlts
       nEHeat = 0.0
@@ -364,7 +364,7 @@ contains
         do iSpecies = 1, nSpecies
           nTau = nTau + &
                  night_photoabs(iWave, iSpecies)*night_col(:, :, iAlt, iSpecies)
-        end do
+        enddo
 
         nIntensity = nighteuvflux(iWave, :, :, iBlock)*exp(-1.0*nTau)
 
@@ -377,8 +377,8 @@ contains
               nEuvIonRateS(:, :, iAlt, iIon, iBlock) + &
               nIntensity*night_photoion(iWave, iIon)* &
               nNeutralDensity(:, :, iNeutral)
-          end if
-        end do
+          endif
+        enddo
 
         do iSpecies = 1, nSpecies
           nEHeat = nEHeat + &
@@ -387,9 +387,9 @@ contains
                    night_photoabs(iWave, iSpecies)* &
                    nNeutralDensity(:, :, iSpecies)
 
-        end do
+        enddo
 
-      end do
+      enddo
 
       nEuvHeating(:, :, iAlt) = nEHeat*HeatingEfficiency_CB(:, :, iAlt, iBlock)
       neEuvHeating(:, :, iAlt) = nEHeat*eHeatingEfficiency_CB(:, :, iAlt, iBlock)
@@ -398,11 +398,11 @@ contains
           if (Altitude_GB(iLon, iLat, iAlt, iBlock) .lt. 80000.0) then
             nEUVHeating(iLon, iLat, iAlt) = 0.0
             neEUVHeating(iLon, iLat, iAlt) = 0.0
-          end if
-        end do
-      end do
+          endif
+        enddo
+      enddo
 
-    end do
+    enddo
 
   end subroutine night_euv_ionization
 
@@ -450,7 +450,7 @@ subroutine calc_euv
     IF (FLXFAC .LT. 0.8) FLXFAC = 0.8
     EUV_Flux(i) = F74113(II)*FLXFAC*1.0E9*10000.
 
-  end do
+  enddo
 
 end subroutine calc_euv
 
@@ -505,14 +505,14 @@ subroutine calc_scaled_euv
     write(*, *) "Error in getting F107 value.  Is this set?"
     write(*, *) "Code : ", iError
     call stop_gitm("Stopping in euv_ionization_heat")
-  end if
+  endif
 
   call get_f107a(CurrentTime, f107a, iError)
   if (iError /= 0) then
     write(*, *) "Error in getting F107a value.  Is this set?"
     write(*, *) "Code : ", iError
     call stop_gitm("Stopping in euv_ionization_heat")
-  end if
+  endif
 
   if (UseEUVData) then
 
@@ -520,18 +520,18 @@ subroutine calc_scaled_euv
 
     if (iError /= 0) then
       call stop_gitm("Stopping in euv_ionization_heat. Error in EUV data. Check times!")
-    end if
+    endif
 
     do N = 1, Num_WaveLengths_High
       wvavg(N) = (WAVEL(N) + WAVES(N))/2.
-    end do
+    enddo
 
     call start_timing("new_euv")
     SeeTime(:) = 0
 
     do N = 1, nSeeTimes
       SeeTime(N) = TimeSee(N)
-    end do
+    enddo
 
     tDiff = CurrentTime - SeeTime
 
@@ -571,17 +571,17 @@ subroutine calc_scaled_euv
               Timed_Flux = k*exp(-1*m*x)
             else
               DuringFlare = .False.
-            end if
-          end if
-        end if
-      end if
-    end if
+            endif
+          endif
+        endif
+      endif
+    endif
 
      !!need to convert from W/m^2 to photons/m^2/s
     do N = 1, Num_WaveLengths_High
       Flux_of_EUV(N) = Timed_Flux(N)*wvavg(N)*1.0e-10/(6.626e-34*2.998e8) &
                        /(SunPlanetDistance**2)
-    end do
+    enddo
     call end_timing("new_euv")
 
   else
@@ -597,7 +597,7 @@ subroutine calc_scaled_euv
         wvavg(N) = (WAVEL(N) + WAVES(N))/2.
         Flux_of_EUV(N) = Solar_Flux(N)*wvavg(N)*1.0e-10/(6.626e-34*2.998e8) &
                          /(SunPlanetDistance**2)
-      end do
+      enddo
 
     else
 
@@ -618,7 +618,7 @@ subroutine calc_scaled_euv
       f107_ratio = (f107 - 68.0)/(243.0 - 68.0)
       do N = 1, Num_WaveLengths_High
         Solar_Flux(N) = RFLUX(N) + (XFLUX(N) - RFLUX(N))*f107_Ratio
-      end do
+      enddo
 
       ! This is a total hack, just comparing FISM to these fluxes:
       Solar_flux(Num_WaveLengths_High - 4) = Solar_flux(Num_WaveLengths_High - 4)*3.0
@@ -640,15 +640,15 @@ subroutine calc_scaled_euv
           hlymod = heiew*3.77847e9 + 8.40317e10
         else
           hlymod = 8.70e8*F107 + 1.90e11
-        end if
+        endif
 
-      end if
+      endif
 
       if (heiew > 0.001) then
         heimod = heiew*3.77847e9 + 8.40317e10
       else
         heimod = hlymod
-      end if
+      endif
 
       ! hlymod is SME Lyman-alpha
       ! heimod is He I 10,830A, scaled to Lyman-alpha
@@ -659,7 +659,7 @@ subroutine calc_scaled_euv
                         TCOR0(N) + &
                         TCOR1(N)*f107 + &
                         TCOR2(N)*f107A
-      end do
+      enddo
 
       !
       ! Substitute in H Lyman-alpha and XUVFAC if provided:
@@ -670,7 +670,7 @@ subroutine calc_scaled_euv
         xuvf = xuvfac
       else
         xuvf = 1.0
-      end if
+      endif
 
       !
       ! Convert from gigaphotons to photons, cm^-2 to m^-2, etc.:
@@ -683,7 +683,7 @@ subroutine calc_scaled_euv
         ! I don't know why we scale this...
         IF ((WAVEL(N) < 251.0) .AND. (WAVES(N) > 15.0)) then
           Solar_Flux(N) = Solar_Flux(N)*xuvf
-        end if
+        endif
 
         !
         ! Convert to photons/m^2/s
@@ -698,12 +698,12 @@ subroutine calc_scaled_euv
         wavelength_ave = (WAVEL(N) + WAVES(N))/2.0
         PhotonEnergy(N) = 6.626e-34*2.998e8/(wavelength_ave*1.0e-10)
 
-      end do
+      enddo
       ! Solar_Flux has the Tobiska and Hinteregger fluxes in there already:
 
       do N = 1, Num_WaveLengths_High
         Flux_of_EUV(N) = Solar_Flux(N)
-      end do
+      enddo
 
       if (UseEUVAC) then
         do N = 1, Num_WaveLengths_Low
@@ -712,22 +712,22 @@ subroutine calc_scaled_euv
             Flux_of_EUV(NN) = 0.5*(EUV_Flux(N) + Solar_Flux(NN))
           else
             Flux_of_EUV(NN) = EUV_Flux(N)
-          end if
-        end do
-      end if
+          endif
+        enddo
+      endif
 
       ! Take into account the sun distance to the planet:
       Flux_of_EUV = Flux_of_EUV/(SunPlanetDistance**2)
 
-    end if
+    endif
 
-  end if
+  endif
 
   do N = 1, Num_WaveLengths_High
     ! Calculate the energy in the bin:
     wavelength_ave = (WAVEL(N) + WAVES(N))/2.0
     PhotonEnergy(N) = 6.626e-34*2.998e8/(wavelength_ave*1.0e-10)
-  end do
+  enddo
 
 end subroutine calc_scaled_euv
 
@@ -753,7 +753,7 @@ subroutine init_euv
 
     RLMSRC(N) = RLMEUV(N)
 
-  end do
+  enddo
 
   DO N = 1, Num_WaveLengths_Low
 
@@ -763,7 +763,7 @@ subroutine init_euv
     IF (N .GT. 14) then
       BranchingRatio_OPlus2P(N) = &
         1.-BranchingRatio_OPlus2D(N) - BranchingRatio_OPlus4S(N)
-    end if
+    endif
 
     PhotoAbs_O2(NN) = Photoabsorption_O2(N)
     PhotoAbs_O(NN) = Photoabsorption_O(N)
@@ -783,7 +783,7 @@ subroutine init_euv
     BranchingRatio_N2(NN) = BranchingRatio_N2_to_NPlus(N)
     BranchingRatio_O2(NN) = BranchingRatio_O2_to_OPlus(N)
 
-  end do
+  enddo
 
   ! Convert everything from /cm2 to /m2
 
@@ -839,7 +839,7 @@ subroutine Set_Euv(iError, StartTime, EndTime)
     ! If we still have a lot of data in memory, then don't bother
     ! reading more.
     if (StartTime + BufferTime < TimeSee(nSeeTimes)) return
-  end if
+  endif
 
   ! Assume that we can read the entire file
   ReReadEUVFile = .false.
@@ -856,7 +856,7 @@ subroutine Set_Euv(iError, StartTime, EndTime)
     write(*, *) "Error in opening EUV file  Is this set?"
     write(*, *) "Code : ", iError, cEUVFile
     call stop_gitm("Stopping in calc_euv")
-  end if
+  endif
 
   iline = 1
 
@@ -877,17 +877,17 @@ subroutine Set_Euv(iError, StartTime, EndTime)
           read(iInputUnit_, *) TimeOfFlare(1:6)
           TimeOfFlare(7) = 0
           call time_int_to_real(TimeOfFlare, FlareTimes(i))
-        end do
+        enddo
 
       case ('#START')
         NotDone = .false.
 
       end select
-    end if
+    endif
 
     iline = iline + 1
 
-  end do
+  enddo
 
   TimeSee(:) = 0
   iline = 1
@@ -910,9 +910,9 @@ subroutine Set_Euv(iError, StartTime, EndTime)
     if (iline > nSeeLinesMax - 1) then
       iErrortemp = 1
       ReReadEUVFile = .true.
-    end if
+    endif
 
-  end do
+  enddo
 
   close(iInputUnit_)
   nSeeTimes = iline - 1
@@ -944,13 +944,13 @@ subroutine read_euv_waves(iError)
     write(*, *) "Error in opening RidleyEUVFile  Is this set?"
     write(*, *) "Code : ", iError, cRidleyEUVFile
     call stop_gitm("Stopping in read_euv_waves")
-  end if
+  endif
 
   read(iInputUnit_, *, iostat=iError) nFiles
 
   do i = 1, nFiles
     read(iInputUnit_, *, iostat=iError) cline
-  end do
+  enddo
 
   read(iInputUnit_, *, iostat=iError) nWaves
 
@@ -958,7 +958,7 @@ subroutine read_euv_waves(iError)
     write(*, *) "Error in RidleyEUVFile - nWaves /= Num_wavelengths_high"
     write(*, *) "Values : ", nWaves, Num_WaveLengths_High
     call stop_gitm("Stopping in read_euv_waves")
-  end if
+  endif
 
   read(iInputUnit_, *, iostat=iError) cline
 
@@ -972,7 +972,7 @@ subroutine read_euv_waves(iError)
     RidleyPowers(1, i) = tmp(5)
     RidleyPowers(2, i) = tmp(6)
 
-  end do
+  enddo
 
   close(iInputUnit_)
 

--- a/src/calc_ion_drag.f90
+++ b/src/calc_ion_drag.f90
@@ -65,7 +65,7 @@ subroutine calc_ion_drag(iBlock)
     IonDrag(:, :, :, iDir) = tmp* &
                              (IVelocity(1:nLons, 1:nLats, 1:nAlts, iDir, iBlock) - &
                               Velocity(1:nLons, 1:nLats, 1:nAlts, iDir, iBlock))
-  end do
+  enddo
 
   ! F_iondrag = rho_i/rho * Vis * (Ui-Un)
   ! where Vis = Vin *(Ns/N)
@@ -83,7 +83,7 @@ subroutine calc_ion_drag(iBlock)
                                          (IVelocity(1:nLons, 1:nLats, 1:nAlts, iUp_, iBlock) - &
                                           VerticalVelocity(1:nLons, 1:nLats, 1:nAlts, iSpecies, iBlock))
 
-  end do
+  enddo
 
 end subroutine calc_ion_drag
 

--- a/src/calc_ion_v.f90
+++ b/src/calc_ion_v.f90
@@ -50,7 +50,7 @@ subroutine calc_ion_v(iBlock)
   if (Is1D) then
     LocalPressureGradient(:, :, :, iEast_) = 0.0
     LocalPressureGradient(:, :, :, iNorth_) = 0.0
-  end if
+  endif
 
   ! If the user doesn't want to use the pressure gradient, set it to zero:
   if (.not. useIonPressureGradient) LocalPressureGradient = 0.0
@@ -60,14 +60,14 @@ subroutine calc_ion_v(iBlock)
     LocalGravity = Gravity_GB(:, :, :, iBlock)
   else
     LocalGravity = 0.0
-  end if
+  endif
 
   ! Store the neutral winds, if we don't use, set to zero:
   if (UseNeutralDrag) then
     LocalNeutralWinds = Velocity(:, :, :, :, iBlock)
   else
     LocalNeutralWinds = 0.0
-  end if
+  endif
 
   Force = 0.0
 
@@ -78,7 +78,7 @@ subroutine calc_ion_v(iBlock)
   do iAlt = -1, nAlts + 2
     Force(:, :, iAlt, iUp_) = Force(:, :, iAlt, iUp_) + &
                               IRho(:, :, iAlt)*LocalGravity(:, :, iAlt)
-  end do
+  enddo
 
   ! calculate charge density:
   Nie = IDensityS(:, :, :, ie_, iBlock)*Element_Charge
@@ -91,8 +91,8 @@ subroutine calc_ion_v(iBlock)
     do iDir = 1, 3
       Force(:, :, :, iDir) = Force(:, :, :, iDir) + &
                              Nie*EField(:, :, :, iDir)
-    end do
-  end if
+    enddo
+  endif
 
   ! Calculate the mass density weighted collision
   ! between ions and neutrals (nu_in):
@@ -102,8 +102,8 @@ subroutine calc_ion_v(iBlock)
       RhoNu = RhoNu + &
               IDensityS(:, :, :, iIon, iBlock)*MassI(iIon)* &
               IonCollisions(:, :, :, iIon, iSpecies)
-    end do
-  end do
+    enddo
+  enddo
   nu_in = RhoNu/iRho
 
   ! Add neutral wind force:
@@ -111,8 +111,8 @@ subroutine calc_ion_v(iBlock)
     do iDir = 1, 3
       Force(:, :, :, iDir) = Force(:, :, :, iDir) + &
                              RhoNu*LocalNeutralWinds(:, :, :, iDir)
-    end do
-  end if
+    enddo
+  endif
 
   ! Break neutral wind force into parallel and
   ! perpendicular components:
@@ -121,7 +121,7 @@ subroutine calc_ion_v(iBlock)
     ForcePerp(:, :, :, iDir) = Force(:, :, :, iDir) - &
                                ForceDotB(:, :, :)*B0(:, :, :, iDir, iBlock)/ &
                                B0(:, :, :, iMag_, iBlock)**2
-  end do
+  enddo
 
   ! The implicit scheme needs to know about the old, ion velocity
   ! along the magnetic field line, so put the (stored) parallel ion
@@ -131,7 +131,7 @@ subroutine calc_ion_v(iBlock)
     VIParallel = VIParallel + &
                  IVelocityPar(:, :, :, iDir, iBlock)*B0(:, :, :, iDir, iBlock)/ &
                  B0(:, :, :, iMag_, iBlock)
-  end do
+  enddo
 
   ! If there is no magnetic field, then solve for the ion
   ! velocity in one way:
@@ -167,8 +167,8 @@ subroutine calc_ion_v(iBlock)
         gDotB(iLon, iLat, :) = LocalGravity(iLon, iLat, :) &
                                *BLocal(iLon, iLat, :, iUp_) &
                                /B0(iLon, iLat, :, iMag_, iBlock)
-      end do
-    end do
+      enddo
+    enddo
 
     ! Update parallel ion velocity, with either implicit
     ! or steady-state equations:
@@ -180,7 +180,7 @@ subroutine calc_ion_v(iBlock)
                    + VIParallel/dt)
     else
       VIParallel = UDotB + (gDotB*iRho - gpDotB)/RhoNu
-    end if
+    endif
 
     ! Limit the Parallel Flow to something reasonable...
     VIParallel = min(UDotB + MaxVParallel, VIParallel)
@@ -225,9 +225,9 @@ subroutine calc_ion_v(iBlock)
         IVelocityPar(:, :, :, iDir, iBlock) + &
         IVelocityPerp(:, :, :, iDir, iBlock)
 
-    end do
+    enddo
 
-  end if
+  endif
 
   ! Limit the ion velocity to something "reasonable":
   IVelocity(:, :, :, :, iBlock) = min(3000.0, IVelocity(:, :, :, :, iBlock))

--- a/src/calc_ir_heating.f90
+++ b/src/calc_ir_heating.f90
@@ -56,15 +56,15 @@ subroutine calc_ir_heating(iBlock)
             if (sza(iLon, iLat, iBlock) .le. sza_table(iSza + 1) .and. &
                 sza(iLon, iLat, iBlock) .ge. sza_table(iSza)) then
               exit
-            end if
-          end do
+            endif
+          enddo
 
           do jAlt = 1, 40
             if (Altitude_GB(iLon, iLat, iAlt, iBlock) .le. altitude_table(jAlt + 1) .and. &
                 Altitude_GB(iLon, iLat, iAlt, iBlock) .ge. altitude_table(jAlt)) then
               exit
-            end if
-          end do
+            endif
+          enddo
 
           !Debugging stuff
           !if (iProc == 0) then
@@ -94,13 +94,13 @@ subroutine calc_ir_heating(iBlock)
             write(*, *) "r is too big...", iLon, iLat, iAlt
             write(*, *) "GITM SZA:", sza(iLon, iLat, iBlock)
             write(*, *) "Table SZA:", sza_table(iSza), sza_table(iSza + 1)
-          end if
+          endif
 
           if (x03 < 0.0 .or. x12 < 0.0) then
             write(*, *) "First interpolated value is negative...this is wrong."
             write(*, *) "x03", x03
             write(*, *) "x12", x12
-          end if
+          endif
 
           QnirTOT(iLon, iLat, iAlt, iBlock) = &
             x03*(1 - r_sza) + x12*r_sza
@@ -112,7 +112,7 @@ subroutine calc_ir_heating(iBlock)
                                               /TempUnit(iLon, iLat, iAlt)! &
           ! / Rho(iLon,iLat,iAlt, iBlock) &
           ! / cp(iLon,iLat,iAlt,iBlock)
-        end if
+        endif
 
         !LTE IR Heating Section
         if (Altitude_GB(iLon, iLat, iAlt, iBlock)/1000.0 < 100.0) then
@@ -127,16 +127,16 @@ subroutine calc_ir_heating(iBlock)
             if (ABS(Latitude(iLat, iBlock)*180.0/pi) .ge. 5*(iLatTable - 1) .and. &
                 ABS(Latitude(iLat, iBlock)*180.0/pi) .le. 5*(iLatTable)) then
               exit
-            end if
-          end do
+            endif
+          enddo
 
           do iAltTable = 1, 16
             if (Altitude_GB(iLon, iLat, iAlt, iBlock)/1000.0 .ge. 70 + 2*(iAltTable - 1) &
                 .and. &
                 Altitude_GB(iLon, iLat, iAlt, iBlock)/1000.0 .le. 70 + 2*(iAltTable)) then
               exit
-            end if
-          end do
+            endif
+          enddo
 
           QnirTOT(iLon, iLat, iAlt, iBlock) = diurnalHeating(iLatTable, iAltTable)* &
                                               cos(2*pi/24*(LST - 12)) + &
@@ -145,7 +145,7 @@ subroutine calc_ir_heating(iBlock)
 
           if (QnirTOT(iLon, iLat, iAlt, iBlock) < 0.0) then
             QnirTOT(iLon, iLat, iAlt, iBlock) = 0.0
-          end if
+          endif
 
           !Given in K/s. No need for rho or cp because that
           !converts J/s -> K/s. Need TempUnit to normalize it to
@@ -154,10 +154,10 @@ subroutine calc_ir_heating(iBlock)
                                               /TempUnit(iLon, iLat, iAlt)! &
           ! / Rho(iLon,iLat,iAlt, iBlock) &
           ! / cp(iLon,iLat,iAlt,iBlock)
-        end if
-      end do
-    end do
-  end do
+        endif
+      enddo
+    enddo
+  enddo
 
   call end_timing("IR Heating")
 

--- a/src/calc_neutral_friction.f90
+++ b/src/calc_neutral_friction.f90
@@ -68,7 +68,7 @@ subroutine calc_neutral_friction(DtIn, oVel, EddyCoef_1d, NDensity_1d, NDensityS
           if (ieee_is_nan(Temp(iAlt))) write(*, *) "Friction : Temp is nan", iAlt
           if (ieee_is_nan(NDensity_1d(iAlt))) write(*, *) "Friction : NDen is nan", iAlt
           if (ieee_is_nan(NDensityS_1d(iAlt, jSpecies))) write(*, *) "Friction : NDenS is nan", iAlt, jSpecies
-        end if
+        endif
 
         ! TempDij are the Dij binary coefficients
         ! Based upon the formulation by Banks and Kokarts.
@@ -87,23 +87,23 @@ subroutine calc_neutral_friction(DtIn, oVel, EddyCoef_1d, NDensity_1d, NDensityS
                            denscale*NDensityS_1d(iAlt, jSpecies)/ &
                            (TempDij)
 
-      end do  ! End DO over jSpecies
+      enddo  ! End DO over jSpecies
 
       EddyContribution(iSpecies) = &
         -1.0*EddyCoef_1d(iAlt)*GradLogCon(iAlt, iSpecies)
 
-    end do  !End DO Over iSpecies
+    enddo  !End DO Over iSpecies
 
     Matrix = -DtIn*CoefMatrix
     do iSpecies = 1, nSpecies
       Matrix(iSpecies, iSpecies) = &
         1.0 + DtIn*(sum(CoefMatrix(iSpecies, :)))
-    end do
+    enddo
     call ludcmp(Matrix, nSpecies, nSpecies, iPivot, Parity)
     call lubksb(Matrix, nSpecies, nSpecies, iPivot, Vel)
 
     oVel(iAlt, 1:nSpecies) = Vel(1:nSpecies) + &
                              EddyContribution(1:nSpecies)
-  end do
+  enddo
 
 end subroutine calc_neutral_friction

--- a/src/calc_neutral_friction_new.f90
+++ b/src/calc_neutral_friction_new.f90
@@ -106,7 +106,7 @@ subroutine calc_neutral_friction(oVel, EddyCoef_1d, NDensity_1d, NDensityS_1d, &
                                denscale*NDensityS_1d(iAlt, jSpecies)/ &
                                (TempDij)
 
-          end if   !! UseBoqueho And Blelly
+          endif   !! UseBoqueho And Blelly
 
         else   !! Not Earth
 
@@ -129,7 +129,7 @@ subroutine calc_neutral_friction(oVel, EddyCoef_1d, NDensity_1d, NDensityS_1d, &
             InvDij(iSpecies) = InvDij(iSpecies) + &
                                denscale*NDensityS_1d(iAlt, jSpecies)/ &
                                (TempDij)
-          end if
+          endif
 
           if (UseBoquehoAndBlelly) then
             EddyDiffCorrection(iSpecies) = &
@@ -141,11 +141,11 @@ subroutine calc_neutral_friction(oVel, EddyCoef_1d, NDensity_1d, NDensityS_1d, &
               EddyDiffCorrection(iSpecies) + &
               Dt*CoefMatrix(iSpecies, jSpecies)* &
               EddyCoef_1d(iAlt)*GradLogCon(iAlt, jSpecies)
-          end if
+          endif
 
-        end if   ! Check if IsEarth
+        endif   ! Check if IsEarth
 
-      end do  ! End DO over jSpecies
+      enddo  ! End DO over jSpecies
 
       if (UseBoquehoAndBlelly) then
 
@@ -155,7 +155,7 @@ subroutine calc_neutral_friction(oVel, EddyCoef_1d, NDensity_1d, NDensityS_1d, &
         if (UseEddyCorrection) then
           EddyCoefRatio_1d(iAlt, iSpecies) = &
             EddyCoefRatio_1d(iAlt, iSpecies) - EddyDiffCorrection(iSpecies)
-        end if
+        endif
 
       else
 
@@ -166,11 +166,11 @@ subroutine calc_neutral_friction(oVel, EddyCoef_1d, NDensity_1d, NDensityS_1d, &
         if (UseEddyCorrection) then
           EddyCoefRatio_1d(iAlt, iSpecies) = &
             EddyCoefRatio_1d(iAlt, iSpecies) + EddyDiffCorrection(iSpecies)
-        end if
+        endif
 
-      end if
+      endif
 
-    end do  !End DO Over iSpecies
+    enddo  !End DO Over iSpecies
 
     Vel(1:nSpecies) = Vel(1:nSpecies) + EddyCoefRatio_1d(iAlt, 1:nSpecies)
 
@@ -182,7 +182,7 @@ subroutine calc_neutral_friction(oVel, EddyCoef_1d, NDensity_1d, NDensityS_1d, &
     do iSpecies = 1, nSpecies
       Matrix(iSpecies, iSpecies) = &
         1.0 + dt*(sum(CoefMatrix(iSpecies, :)))
-    end do
+    enddo
 
     BulkWind = 0.0
     MassDensity = 0.0
@@ -190,20 +190,20 @@ subroutine calc_neutral_friction(oVel, EddyCoef_1d, NDensity_1d, NDensityS_1d, &
       BulkWind = BulkWind + &
                  vel(iSpecies)*mass(iSpecies)*NDensityS_1d(iAlt, iSpecies)
       MassDensity = MassDensity + mass(iSpecies)*NDensityS_1d(iAlt, iSpecies)
-    end do
+    enddo
     BulkWind = BulkWind/MassDensity
 
     do iSpecies = 1, nSpecies
       r = Matrix(iSpecies, iSpecies)/sum(Matrix(iSpecies, :)) - 1.0
 !        write(*,*) iAlt, iSpecies, vel(iSpecies), r, BulkWind
       if (r > 1.0) vel(iSpecies) = BulkWind
-    end do
+    enddo
 
     call ludcmp(Matrix, nSpecies, nSpecies, iPivot, Parity)
     call lubksb(Matrix, nSpecies, nSpecies, iPivot, Vel)
 
     oVel(iAlt, 1:nSpecies) = Vel(1:nSpecies) !+ EddyCoefRatio_1d(iAlt,1:nSpecies)
 
-  end do
+  enddo
 
 end subroutine calc_neutral_friction

--- a/src/calc_physics.f90
+++ b/src/calc_physics.f90
@@ -75,7 +75,7 @@ subroutine calc_physics(iBlock)
     DEccAnomaly = dM/(1 - eccentricity*cos(pi/180*eccAnomaly))
     eccAnomaly = eccAnomaly + dEccAnomaly
     i = i + 1
-  end do
+  enddo
 
   !Get heliocentric coordinates, TrueAnomaly and sunplanetdistance
   heliocentricX = semimajoraxis*(cos(EccAnomaly*pi/180.) - eccentricity)
@@ -139,13 +139,13 @@ subroutine calc_physics(iBlock)
             MLT(iLon, iLat, iAlt))
           if (mlt(iLon, iLat, iAlt) < 0) &
             mlt(iLon, iLat, iAlt) = mlt(iLon, iLat, iAlt) + 24.0
-        end do
-      end do
+        enddo
+      enddo
     else
 
       do iLat = -1, nLats + 2
         MLT(:, iLat, iAlt) = LocalTime
-      end do
+      enddo
 
       ! Since we go over the pole,
       !we have to move the points to the proper location:
@@ -153,16 +153,16 @@ subroutine calc_physics(iBlock)
       if (Latitude(0, iBlock) < -pi/2.0) then
         MLT(:, -1, iAlt) = MLT(:, 2, iAlt) + 12.0
         MLT(:, 0, iAlt) = MLT(:, 1, iAlt) + 12.0
-      end if
+      endif
 
       if (Latitude(0, iBlock) > pi/2.0) then
         MLT(:, nLats + 1, iAlt) = MLT(:, nLats, iAlt) + 12.0
         MLT(:, nLats + 2, iAlt) = MLT(:, nLats - 1, iAlt) + 12.0
-      end if
+      endif
 
-    end if
+    endif
 
-  end do
+  enddo
 
 !  write(*,*) mlt(1,1,1)
 
@@ -179,10 +179,10 @@ subroutine calc_physics(iBlock)
 
       if (DtLTERadiation < RotationPeriodInput) then
         call calc_avesza(iLon, iLat, iBlock, SinDec, CosDec)
-      end if
+      endif
 
-    end do
-  end do
+    enddo
+  enddo
 
   call calc_scaled_euv
 
@@ -191,7 +191,7 @@ subroutine calc_physics(iBlock)
                          *cos(SZA(:, :, iBlock))
     ySolar(:, :, iAlt) = RadialDistance_GB(1:nLons, 1:nLats, iAlt, iBlock) &
                          *sin(SZA(:, :, iBlock))
-  end do
+  enddo
 
 end subroutine calc_physics
 

--- a/src/calc_pressure.f90
+++ b/src/calc_pressure.f90
@@ -18,7 +18,7 @@ subroutine calc_pressure
   do iSpecies = 1, nSpecies
     NDensity(:, :, :, 1:nBlocks) = &
       NDensity(:, :, :, 1:nBlocks) + NDensityS(:, :, :, iSpecies, 1:nBlocks)
-  end do
+  enddo
 
   Pressure = Temperature*Rho
 
@@ -27,7 +27,7 @@ subroutine calc_pressure
     IPressure(:, :, :, 1:nBlocks) = IPressure(:, :, :, 1:nBlocks) + &
                                     IDensityS(:, :, :, iSpecies, 1:nBlocks)* &
                                     Boltzmanns_Constant*ITemperature(:, :, :, 1:nBlocks)
-  end do
+  enddo
 
   ePressure(:, :, :, 1:nBlocks) = &
     IDensityS(:, :, :, ie_, 1:nBlocks)*Boltzmanns_Constant* &
@@ -72,7 +72,7 @@ subroutine calc_pressure
           NDensityS(1:nLons, 1:nLats, iAlt, iSpecies, iBlock)/ &
           (Vibration(iSpecies) - 2)
 
-      end do
+      enddo
 
       cp(:, :, iAlt, iBlock) = cp(:, :, iAlt, iBlock)/ &
                                (2.0*NDensity(1:nLons, 1:nLats, iAlt, iBlock))
@@ -81,8 +81,8 @@ subroutine calc_pressure
         gamma(1:nLons, 1:nLats, iAlt, iBlock)*2.0/ &
         NDensity(1:nLons, 1:nLats, iAlt, iBlock) + 1
 
-    end do
+    enddo
 
-  end do
+  enddo
 
 end subroutine calc_pressure

--- a/src/calc_rates.Earth.f90
+++ b/src/calc_rates.Earth.f90
@@ -36,7 +36,7 @@ subroutine calc_rates(iBlock)
     MeanMajorMass = MeanMajorMass + &
                     Mass(iSpecies)* &
                     NDensityS(:, :, :, iSpecies, iBlock)/(NDensity(:, :, :, iBlock) + 1.0)
-  end do
+  enddo
 
   ! Once again, in the corners, the meanmajormass is 0.
   where (MeanMajorMass == 0) MeanMajorMass = Mass(1)
@@ -45,7 +45,7 @@ subroutine calc_rates(iBlock)
     MeanIonMass = MeanIonMass + &
                   MassI(iIon)*IDensityS(:, :, :, iIon, iBlock)/ &
                   IDensityS(:, :, :, ie_, iBlock)
-  end do
+  enddo
 
   TempUnit = MeanMajorMass/Boltzmanns_Constant
 
@@ -76,7 +76,7 @@ subroutine calc_rates(iBlock)
       (Temperature(1:nLons, 1:nLats, iAlt, iBlock)* &
        TempUnit(1:nLons, 1:nLats, iAlt))**0.648
 
-  end do
+  enddo
 
   ! Thermal Diffusion is zero for all but the lightest species
   ! Banks and Kockarts suggest Alpha_T = -0.38 for He
@@ -134,7 +134,7 @@ subroutine calc_collisions(iBlock)
   NeMajor = 0.0
   do iSpecies = 1, nIonsAdvect
     NeMajor = NeMajor + IDensityS(:, :, :, iSpecies, iBlock)
-  end do
+  enddo
 
   !\
   ! -----------------------------------------------------------
@@ -324,7 +324,7 @@ subroutine calc_viscosity_coef(iBlock)
     ViscCoefS(1:nLons, 1:nLats, 0:nAlts + 1, iSpecies) = &
       ViscCoef(1:nLons, 1:nLats, 0:nAlts + 1)* &
       sqrt(Mass(iSpecies)/MeanMajorMass(1:nLons, 1:nLats, 0:nAlts + 1))
-  end do
+  enddo
 
 end subroutine calc_viscosity_coef
 

--- a/src/calc_rates.Jupiter.f90
+++ b/src/calc_rates.Jupiter.f90
@@ -81,7 +81,7 @@ subroutine calc_rates(iBlock)
           write(*, *) 'Temperature(', iLon, iLat, iAlt, iBlock, ') = ', &
             Temperature(iLon, iLat, iAlt, iBlock)
           trouble = .true.
-        end if
+        endif
 
         do iSpecies = 1, nSpeciesTotal
           if (.not. (NDensityS(iLon, iLat, iAlt, iSpecies, iBlock) < 0.0) .and. &
@@ -101,8 +101,8 @@ subroutine calc_rates(iBlock)
             write(*, *) 'NDensityS(', iLon, iLat, iAlt, iSpecies, iBlock, ') = ', &
               NDensityS(iLon, iLat, iAlt, iSpecies, iBlock)
             trouble = .true.
-          end if
-        end do !iSpecies = 1,nSpeciesTotal
+          endif
+        enddo !iSpecies = 1,nSpeciesTotal
 
         if (.not. (NDensity(iLon, iLat, iAlt, iBlock) < 0.0) .and. &
             .not. (NDensity(iLon, iLat, iAlt, iBlock) > 0.0)) then
@@ -121,11 +121,11 @@ subroutine calc_rates(iBlock)
           write(*, *) 'NDensity(', iLon, iLat, iAlt, iBlock, ') = ', &
             NDensity(iLon, iLat, iAlt, iBlock)
           trouble = .true.
-        end if
+        endif
 
-      end do
-    end do
-  end do
+      enddo
+    enddo
+  enddo
 
   ! -------------------------------------------------------------------------------
 
@@ -133,7 +133,7 @@ subroutine calc_rates(iBlock)
     write(*, *) 'trouble found!!'
     write(*, *) 'Stop GITM'
     stop
-  end if
+  endif
 
   ! -------------------------------------------------------------------------------
 
@@ -169,7 +169,7 @@ subroutine calc_rates(iBlock)
     MeanMajorMass = MeanMajorMass + &
                     Mass(iSpecies)* &
                     NDensityS(:, :, :, iSpecies, iBlock)/mnd
-  end do
+  enddo
 
   !  MMM_3D(1:nLons,1:nLats,1:nAlts,iBlock) = &
   !       MeanMajorMass(1:nLons,1:nLats,1:nAlts)/AMU
@@ -184,7 +184,7 @@ subroutine calc_rates(iBlock)
   do iIon = 1, nIons - 1
     MeanIonMass = MeanIonMass + &
                   MassI(iIon)*IDensityS(:, :, :, iIon, iBlock)/Ne
-  end do
+  enddo
 
   ! -------------------------------------------------------------------------------
 
@@ -210,7 +210,7 @@ subroutine calc_rates(iBlock)
                        TempUnit(:, :, iAlt)
     tt(:, :, iAlt) = ttot(:, :, iAlt)**0.69
 
-  end do
+  enddo
 
   ! -------------------------------------------------------------------------------
 
@@ -273,9 +273,9 @@ subroutine calc_rates(iBlock)
                                    pco2(iLon, iLat, iAlt)*co2kt(iLon, iLat, iAlt))* &
                                   1.0E-05
 
-      end do
-    end do
-  end do
+      enddo
+    enddo
+  enddo
   ! -------------------------------------------------------------------------------
 
   if (iDebugLevel > 4) write(*, *) "=====> Before cp and kappatemp", iblock
@@ -308,8 +308,8 @@ subroutine calc_rates(iBlock)
           KappaTemp(iLon, iLat, iAlt, iBlock) + &
           EddyDiffusionCoef*cp(iLon, iLat, iAlt, iBlock)* &
           Rho(iLon, iLat, iAlt, iBlock)/10.
-      end do
-    end do
+      enddo
+    enddo
     ! ---------------------------------------------------------------------------
 
     !   Earth GITM formulation for Molecular Viscosity (mks)
@@ -323,7 +323,7 @@ subroutine calc_rates(iBlock)
 !     Visc_3D(:,:,iAlt,iBlock) =  kmmix(1:nLons,1:nLats,iAlt)
 
     ! ---------------------------------------------------------------------------
-  end do
+  enddo
 
   call end_timing("calc_rates")
 

--- a/src/calc_rates.LV-426.f90
+++ b/src/calc_rates.LV-426.f90
@@ -30,7 +30,7 @@ subroutine calc_rates(iBlock)
     MeanMajorMass = MeanMajorMass + &
                     Mass(iSpecies)* &
                     NDensityS(:, :, :, iSpecies, iBlock)/(NDensity(:, :, :, iBlock) + 1.0)
-  end do
+  enddo
 
   ! Once again, in the corners, the meanmajormass is 0.
   where (MeanMajorMass == 0) MeanMajorMass = Mass(1)
@@ -39,7 +39,7 @@ subroutine calc_rates(iBlock)
     MeanIonMass = MeanIonMass + &
                   MassI(iIon)*IDensityS(:, :, :, iIon, iBlock)/ &
                   IDensityS(:, :, :, ie_, iBlock)
-  end do
+  enddo
 
   TempUnit = MeanMajorMass/Boltzmanns_Constant
 
@@ -60,7 +60,7 @@ subroutine calc_rates(iBlock)
                                        (Temperature(1:nLons, 1:nLats, iAlt, iBlock)* &
                                         TempUnit(1:nLons, 1:nLats, iAlt)/1000.)**(-0.71)
 
-  end do
+  enddo
 
   call end_timing("calc_rates")
 

--- a/src/calc_rates.Mars.f90
+++ b/src/calc_rates.Mars.f90
@@ -137,7 +137,7 @@ subroutine calc_rates(iBlock)
     write(*, *) 'trouble found!!'
     write(*, *) 'Stop GITM'
     stop
-  end if
+  endif
 
 ! -------------------------------------------------------------------------------
 
@@ -173,7 +173,7 @@ subroutine calc_rates(iBlock)
     MeanMajorMass = MeanMajorMass + &
                     Mass(iSpecies)* &
                     NDensityS(:, :, :, iSpecies, iBlock)
-  end do
+  enddo
   MeanMajorMass = MeanMajorMass*invmnd
 !  MMM_3D(1:nLons,1:nLats,1:nAlts,iBlock) = MeanMajorMass(1:nLons,1:nLats,1:nAlts)/AMU
 
@@ -187,7 +187,7 @@ subroutine calc_rates(iBlock)
   do iIon = 1, nIons - 1
     MeanIonMass = MeanIonMass + &
                   MassI(iIon)*IDensityS(:, :, :, iIon, iBlock)
-  end do
+  enddo
   MeanIonMass = MeanIonMass*invNe
 
 ! -------------------------------------------------------------------------------
@@ -291,9 +291,9 @@ subroutine calc_rates(iBlock)
                                    pco2(iLon, iLat, iAlt)*co2kt(iLon, iLat, iAlt))* &
                                   1.0E-05
 
-      end do
-    end do
-  end do
+      enddo
+    enddo
+  enddo
 ! -------------------------------------------------------------------------------
 
   if (iDebugLevel > 4) write(*, *) "=====> Before cp and kappatemp", iblock
@@ -327,8 +327,8 @@ subroutine calc_rates(iBlock)
           KappaTemp(iLon, iLat, iAlt, iBlock) + &
           KappaEddyDiffusion(iLon, iLat, iAlt, iBlock)*cp(iLon, iLat, iAlt, iBlock)* &
           Rho(iLon, iLat, iAlt, iBlock)/10.
-      end do
-    end do
+      enddo
+    enddo
 ! -------------------------------------------------------------------------------
 
 !   Earth GITM formulation for Molecular Viscosity (mks)
@@ -352,7 +352,7 @@ subroutine calc_rates(iBlock)
 !     Visc_3D(:,:,iAlt,iBlock) =  kmmix(1:nLons,1:nLats,iAlt)
 
 ! -------------------------------------------------------------------------------
-  end do
+  enddo
 
   call end_timing("calc_rates")
 

--- a/src/calc_rates.Titan.f90
+++ b/src/calc_rates.Titan.f90
@@ -58,7 +58,7 @@ subroutine calc_rates(iBlock)
     MeanMajorMass = MeanMajorMass + &
                     Mass(iSpecies)* &
                     NDensityS(:, :, :, iSpecies, iBlock)/(NDensity(:, :, :, iBlock) + 1.0)
-  end do
+  enddo
 
   ! Once again, in the corners, the meanmajormass is 0.
   where (MeanMajorMass == 0) MeanMajorMass = Mass(1)
@@ -67,7 +67,7 @@ subroutine calc_rates(iBlock)
     MeanIonMass = MeanIonMass + &
                   MassI(iIon)*IDensityS(:, :, :, iIon, iBlock)/ &
                   IDensityS(:, :, :, ie_, iBlock)
-  end do
+  enddo
 
   !TempUnit = MeanMajorMass / Boltzmanns_Constant
   TempUnit = Mass(iN2_)/Boltzmanns_Constant
@@ -331,7 +331,7 @@ subroutine calc_viscosity_coef(iBlock)
   do iSpecies = 1, nSpecies
     ViscCoefS(1:nLons, 1:nLats, 0:nAlts + 1, iSpecies) = &
       ViscCoef(1:nLons, 1:nLats, 0:nAlts + 1)
-  end do
+  enddo
 
   ViscCoefS(1:nLons, 1:nLats, 0:nAlts + 1, iN2_) = &
     ViscN2(1:nLons, 1:nLats, 0:nAlts + 1)

--- a/src/calc_rates.Venus.f90
+++ b/src/calc_rates.Venus.f90
@@ -139,7 +139,7 @@ subroutine calc_rates(iBlock)
     write(*, *) 'trouble found!!'
     write(*, *) 'Stop GITM'
     stop
-  end if
+  endif
 
 ! -------------------------------------------------------------------------------
 
@@ -175,7 +175,7 @@ subroutine calc_rates(iBlock)
     MeanMajorMass = MeanMajorMass + &
                     Mass(iSpecies)* &
                     NDensityS(:, :, :, iSpecies, iBlock)
-  end do
+  enddo
   MeanMajorMass = MeanMajorMass*invmnd
 !  MMM_3D(1:nLons,1:nLats,1:nAlts,iBlock) = MeanMajorMass(1:nLons,1:nLats,1:nAlts)/AMU
 
@@ -189,7 +189,7 @@ subroutine calc_rates(iBlock)
   do iIon = 1, nIons - 1
     MeanIonMass = MeanIonMass + &
                   MassI(iIon)*IDensityS(:, :, :, iIon, iBlock)
-  end do
+  enddo
   MeanIonMass = MeanIonMass*invNe
 
 ! -------------------------------------------------------------------------------
@@ -293,9 +293,9 @@ subroutine calc_rates(iBlock)
                                    pco2(iLon, iLat, iAlt)*co2kt(iLon, iLat, iAlt))* &
                                   1.0E-05
 
-      end do
-    end do
-  end do
+      enddo
+    enddo
+  enddo
 ! -------------------------------------------------------------------------------
 
   if (iDebugLevel > 4) write(*, *) "=====> Before cp and kappatemp", iblock
@@ -329,8 +329,8 @@ subroutine calc_rates(iBlock)
           KappaTemp(iLon, iLat, iAlt, iBlock) + &
           KappaEddyDiffusion(iLon, iLat, iAlt, iBlock)*cp(iLon, iLat, iAlt, iBlock)* &
           Rho(iLon, iLat, iAlt, iBlock)/10.
-      end do
-    end do
+      enddo
+    enddo
 ! -------------------------------------------------------------------------------
 
 !   Earth GITM formulation for Molecular Viscosity (mks)
@@ -357,7 +357,7 @@ subroutine calc_rates(iBlock)
 !     Visc_3D(:,:,iAlt,iBlock) =  kmmix(1:nLons,1:nLats,iAlt)
 
 ! -------------------------------------------------------------------------------
-  end do
+  enddo
 
   call end_timing("calc_rates")
 

--- a/src/calc_sources.f90
+++ b/src/calc_sources.f90
@@ -48,7 +48,7 @@ subroutine calc_GITM_sources(iBlock)
     call calc_physics(iBlock)
     call euv_ionization_heat(iBlock)
 
-  end if
+  endif
 
   if (.not. UseSolarHeating) EuvHeating = 0.0
 
@@ -67,7 +67,7 @@ subroutine calc_GITM_sources(iBlock)
     call calc_thermal_conduction(iBlock)
   else
     Conduction = 0.0
-  end if
+  endif
 
   !\
   ! IR Heating (Venus Only) ---------------------------------------
@@ -76,7 +76,7 @@ subroutine calc_GITM_sources(iBlock)
   QnirTOT(:, :, :, :) = 0.0
   if (UseIRHeating .and. isVenus) then
     call calc_ir_heating(iBlock)
-  end if
+  endif
 
   !\
   ! ---------------------------------------------------------------
@@ -93,7 +93,7 @@ subroutine calc_GITM_sources(iBlock)
   else
     IonDrag = 0.0
     VerticalIonDrag = 0.0
-  end if
+  endif
 
   !\
   ! Viscosity ----------------------------------------------------
@@ -103,7 +103,7 @@ subroutine calc_GITM_sources(iBlock)
     call calc_viscosity(iBlock)
   else
     Viscosity = 0.0
-  end if
+  endif
 
   !\
   ! ---------------------------------------------------------------

--- a/src/calc_tec.f90
+++ b/src/calc_tec.f90
@@ -63,7 +63,7 @@ subroutine calc_single_vtec(iLon, iLat, iBlock, single_vtec)
 
     ! Sum successive incrimentations of height * density
     single_vtec = single_vtec + height*density
-  end do
+  enddo
 
   ! Convert from SI units to TEC units
 
@@ -93,8 +93,8 @@ subroutine calc_vtec(iBlock)
   do iLon = -1, nLons + 2
     do iLat = -1, nLats + 2
       call calc_single_vtec(iLon, iLat, iBlock, VTEC(iLon, iLat, iBlock))
-    end do
-  end do
+    enddo
+  enddo
 
   return
 end subroutine calc_vtec
@@ -124,7 +124,7 @@ subroutine calc_single_vtec_interp(LonFind, LatFind, single_vtec)
 
   if (iiLon .lt. 0 .or. iiLat .lt. 0 .or. iiLon .gt. nLons .or. iiLat .gt. nLats) then
     return
-  end if
+  endif
 
   ! Interpolate electron density
 
@@ -140,7 +140,7 @@ subroutine calc_single_vtec_interp(LonFind, LatFind, single_vtec)
     height = Altitude_GB(iiLon, iiLat, i + 1, iiBlock) &
              - Altitude_GB(iiLon, iiLat, i, iiBlock)
     single_vtec = single_vtec + height*(column(i) + column(i + 1))/2.0
-  end do
+  enddo
 
   !  VTEC is in TECU while electron density is in m^-3
 

--- a/src/calc_timestep.f90
+++ b/src/calc_timestep.f90
@@ -60,12 +60,12 @@ subroutine calc_timestep_horizontal
                            cSound_H(iLon, iLat))/ &
                           dLatDist_GB(iLon, iLat, iAlt, iBlock))/2.0)
 
-        end do
-      end do
+        enddo
+      enddo
 
-    end do
+    enddo
 
-  end do
+  enddo
 
   DtEnd = EndTime - CurrentTime
   DtLocal = min(DtLocal, DtEnd)
@@ -115,7 +115,7 @@ subroutine calc_timestep_vertical
           cMax_GDB(iLon, iLat, iAlt, iUp_, iBlock) = &
             maxval(abs(VerticalVelocity(iLon, iLat, iAlt, :, iBlock))) + &
             sqrt(Gamma(iLon, iLat, iAlt, iBlock)*Temperature(iLon, iLat, iAlt, iBlock))
-        end do
+        enddo
 
         DtLocal = min(DtLocal, &
                       Cfl/ &
@@ -131,12 +131,12 @@ subroutine calc_timestep_vertical
                         Cfl/ &
                         maxval(cm/dAlt_GB(iLon, iLat, 1:nAlts, iBlock)))
 
-        end if
+        endif
 
-      end do
-    end do
+      enddo
+    enddo
 
-  end do
+  enddo
 
   DtEnd = EndTime - CurrentTime
   dTLocal = min(DtLocal, DtEnd)
@@ -152,7 +152,7 @@ subroutine calc_timestep_vertical
   if (dt < cfl/100.0 .and. dt < 0.99*DtEnd) then
     write(*, *) "Dt too slow!!!", dt
     call stop_gitm("Stopping in calc_timestep_vertical")
-  end if
+  endif
 
 end subroutine calc_timestep_vertical
 

--- a/src/calc_viscosity.f90
+++ b/src/calc_viscosity.f90
@@ -115,7 +115,7 @@ subroutine calc_viscosity(iBlock)
        VelocityF(1:nLons, 1:nLats, 0:nAlts + 1, iDir)) - &
       Velocity(1:nLons, 1:nLats, 0:nAlts + 1, iDir, iBlock)
 
-  end do !iDir = iEast_, iNorth_
+  enddo !iDir = iEast_, iNorth_
 
   if (iDebugLevel > 4) write(*, *) "=====> Vertical Viscosity", iproc
   if (UseBarriers) call MPI_BARRIER(iCommGITM, iErr)
@@ -184,6 +184,6 @@ subroutine calc_viscosity(iBlock)
        VerticalVelocityF(1:nLons, 1:nLats, 0:nAlts + 1, iSpecies)) - &
       VerticalVelocity(1:nLons, 1:nLats, 0:nAlts + 1, iSpecies, iBlock)
 
-  end do ! iSpecies
+  enddo ! iSpecies
 
 end subroutine calc_viscosity

--- a/src/cet.f90
+++ b/src/cet.f90
@@ -111,7 +111,7 @@ subroutine calc_electron_temperature(iBlock, eHeatingp, iHeatingp, eHeatingm, iH
 
       if (MLT(iLon, iLat, nAlts) < 0.0) then
         MLT(iLon, iLat, nAlts) = MLT(iLon, iLat, nAlts) + 24.0
-      end if
+      endif
 
       if (abs(MLT(iLon, iLat, nAlts) - x1) < 12) then
         temp = 1 - (MLT(iLon, iLat, nAlts) - x1)**2/aa**2 - &
@@ -119,20 +119,20 @@ subroutine calc_electron_temperature(iBlock, eHeatingp, iHeatingp, eHeatingm, iH
       else
         temp = 1 - (24 - abs(MLT(iLon, iLat, nAlts) - x1))**2/aa**2 - &
                (abs(MLatitude(iLon, iLat, nAlts, iBlock)) - y1)**2/bb**2
-      end if
+      endif
 
       if (temp > 0.0) then
         eflux(iLon, iLat) = z1 + cc*sqrt(temp)
       else
         eflux(iLon, iLat) = z1
-      end if
+      endif
 
       eflux(iLon, iLat) = exp(log(10.)*eflux(iLon, iLat))
 
       eflux(iLon, iLat) = eflux(iLon, iLat)*1.602e-19*1e4*0.2
 
-    end do
-  end do
+    enddo
+  enddo
 
   ! eflux = 1.e-9
   ! mlats = MLatitude(1:nLons,1:nLats,nAlts,iBlock)
@@ -250,9 +250,9 @@ subroutine calc_electron_temperature(iBlock, eHeatingp, iHeatingp, eHeatingm, iH
           !     uiup(iLon,iLat,iAlt) &
           !     *zl**2/hcoef
 
-        end if
+        endif
 
-      end do
+      enddo
 
       ! Bottom Bounday Te = Tn
       a(1) = 0
@@ -272,8 +272,8 @@ subroutine calc_electron_temperature(iBlock, eHeatingp, iHeatingp, eHeatingm, iH
       etemp(iLon, iLat, nAlts + 1) = etemp(iLon, iLat, nAlts)
       etemp(iLon, iLat, 0) = etemp(iLon, iLat, 1)
 
-    end do
-  end do
+    enddo
+  enddo
 
 ! Ion Conductivity
   lam_op = 3.1e4*ti**2.5/Ao**0.5 &
@@ -349,13 +349,13 @@ subroutine calc_electron_temperature(iBlock, eHeatingp, iHeatingp, eHeatingm, iH
           b(iAlt) = -xcoef - iHeatingp(iLon, iLat, iAlt)
           c(iAlt) = 0.
           d(iAlt) = -xcoef*tti - iHeatingm(iLon, iLat, iAlt)
-        end if
+        endif
 
         iConduction(iLon, iLat, iAlt) = c(iAlt)*ti(iLon, iLat, iAlt + 1) + &
                                         a(iAlt)*ti(iLon, iLat, iAlt + 1) + &
                                         (-2*ilam/hcoef*(zu + zl) + fcoef*(zu**2 - zl**2))*tti
 
-      end do
+      enddo
 
       ! Bottom Bounday Ti = Tn
       a(1) = 0
@@ -368,8 +368,8 @@ subroutine calc_electron_temperature(iBlock, eHeatingp, iHeatingp, eHeatingm, iH
       itemp(iLon, iLat, 1:nAlts) = u(1:nAlts)
       itemp(iLon, iLat, nAlts + 1) = itemp(iLon, iLat, nAlts)
       itemp(iLon, iLat, 0) = itemp(iLon, iLat, 1)
-    end do
-  end do
+    enddo
+  enddo
 
 !!!! Check if reasonable temperatures
   where (etemp .LT. tn) etemp = tn
@@ -405,14 +405,14 @@ contains
       m = b(iAlt) - cpp(iAlt - 1)*a(iAlt)
       cpp(iAlt) = c(iAlt)/m
       dpp(iAlt) = (d(iAlt) - dpp(iAlt - 1)*a(iAlt))/m
-    end do
+    enddo
 
     ! initialize u
     u(nAlts) = dpp(nAlts)
     ! solve for u from the vectors c-prime and d-prime
     do iAlt = nAlts - 1, 1, -1
       u(iAlt) = dpp(iAlt) - cpp(iAlt)*u(iAlt + 1)
-    end do
+    enddo
 
   end subroutine tridag
 
@@ -438,7 +438,7 @@ contains
                                (iVelo(:, :, :, iDir) - eVelo(:, :, :, iDir))
 
       OverB0(:, :, :, iDir) = B0(:, :, :, iDir, iBlock)/B0(:, :, :, iMag_, iBlock)**2
-    end do
+    enddo
 
     do iAlt = -1, nAlts + 2
       do iLat = -1, nLats + 2
@@ -446,9 +446,9 @@ contains
           JuTotalDotB(iLon, iLat, iAlt) = sum( &
                                           JuTotal(iLon, iLat, iAlt, 1:3)* &
                                           B0(iLon, iLat, iAlt, 1:3, iBlock))
-        end do
-      end do
-    end do
+        enddo
+      enddo
+    enddo
 
     DivJPerp = 0.0
     do iDir = 1, 3
@@ -462,14 +462,14 @@ contains
       call UAM_Gradient_GC(OverB0(:, :, :, iDir), Gradient_GC, iBlock)
       DivJPerp(:, :, :) = DivJPerp(:, :, :) - Gradient_GC(:, :, :, iDir) &
                           *JuTotalDotB(:, :, :)
-    end do
+    enddo
 
     PartialJPara = -DivJPerp
 
     JParaAlt = 0.0
     do iAlt = 1, nAlts
       JParaAlt(:, :) = JParaAlt(:, :) - DivJPerp(:, :, iAlt)*dAlt_GB(:, :, iAlt, iBlock)
-    end do
+    enddo
 
   end Subroutine calc_thermoelectric_current
 
@@ -668,7 +668,7 @@ subroutine calc_electron_ion_sources(iBlock, eHeatingp, iHeatingp, eHeatingm, iH
   do iDir = 1, 3
     dv2_en = dv2_en + (Velocity(1:nLons, 1:nLats, 1:nAlts, iDir, iBlock) &
                        - ExB(1:nLons, 1:nLats, 1:nAlts, iDir))**2
-  end do
+  enddo
 
   Qenc_v = ne*Mass_Electron*dv2_en* &
            (2.33e-11*nn2*1.e-6*(1 - 1.21e-4*te)*te*Mass(iN2_)/(Mass_Electron + Mass(iN2_)) &
@@ -682,7 +682,7 @@ subroutine calc_electron_ion_sources(iBlock, eHeatingp, iHeatingp, eHeatingm, iH
   do iDir = 1, 3
     dv2_ei = dv2_ei + (IVelocity(1:nLons, 1:nLats, 1:nAlts, iDir, iBlock) &
                        - ExB(1:nLons, 1:nLats, 1:nAlts, iDir))**2
-  end do
+  enddo
 
   Qeic_v = ne*Mass_Electron*dv2_ei*5.45*1.e-5/(te**1.5)*(nop + no2p + nn2p + nnop + nnp)
 !        (nop/(Mass_Electron+MassI(iO_4SP_))  &
@@ -808,18 +808,18 @@ subroutine calc_electron_ion_sources(iBlock, eHeatingp, iHeatingp, eHeatingm, iH
               Qvib_n2(iLon, iLat, iAlt) &
               + (1.-exp(-3353./ttn))*10**logQv0(iLon, iLat, iAlt, iLevel) &
               *(1.-exp(iLevel*3353.*(1./tte - 1./ttn)))
-          end do
+          enddo
 
           do iLevel = 2, 9
             Qvib_n2(iLon, iLat, iAlt) = Qvib_n2(iLon, iLat, iAlt) + &
                                         (1.-exp(-3353./ttn))*exp(-3353./ttn)*10**logQv1(iLon, iLat, iAlt, iLevel)* &
                                         (1.-exp((iLevel - 1)*3353.*(1./tte - 1./ttn)))
-          end do
+          enddo
 
-        end if
-      end do
-    end do
-  end do
+        endif
+      enddo
+    enddo
+  enddo
 
   Qvib_n2 = -ne*nn2*1.e-12*Qvib_n2*1.6e-13
 
@@ -849,7 +849,7 @@ subroutine calc_electron_ion_sources(iBlock, eHeatingp, iHeatingp, eHeatingm, iH
   do iDir = 1, 3
     dv2 = dv2 + (IVelocity(1:nLons, 1:nLats, 1:nAlts, iDir, iBlock) &
                  - Velocity(1:nLons, 1:nLats, 1:nAlts, iDir, iBlock))**2
-  end do
+  enddo
 
   Qinc_t = nop*MassI(iO_4SP_)*nu_oop*(3.*Boltzmanns_Constant*(tn - ti))/(MassI(iO_4SP_) + Mass(iO_3P_)) &
            + nnp*MassI(iNP_)*nu_nnp*(3.*Boltzmanns_Constant*(tn - ti))/(MassI(iNP_) + Mass(iN_2P_)) &
@@ -907,7 +907,7 @@ subroutine calc_electron_ion_sources(iBlock, eHeatingp, iHeatingp, eHeatingm, iH
 
     JouleHeating = 0.0
 
-  end if
+  endif
 
   ElectronHeating = -Qenc(:, :, 1:nAlts)/ &
                     TempUnit(1:nLons, 1:nLats, 1:nAlts)/ &

--- a/src/chapman_new.f90
+++ b/src/chapman_new.f90
@@ -68,7 +68,7 @@ subroutine chapman_integrals(iBlock)
 
             Integrals(iLon, iLat, iAlt, iSpecies) = &
               NDensityS(iLon, iLat, iAlt, iSpecies, iBlock)*ScaleHeightS
-          end if
+          endif
           ScaleHeightS = &
             Temperature(iLon, iLat, iAlt, iBlock) &
             *TempUnit(iLon, iLat, iAlt)*Boltzmanns_Constant &
@@ -87,10 +87,10 @@ subroutine chapman_integrals(iBlock)
             erfcy(iLon, iLat, iAlt, iSpecies) = (a + b*y)/(c + d*y + y**2)
           else
             erfcy(iLon, iLat, iAlt, iSpecies) = f/(g + y)
-          end if
-        end do
-      end do
-    end do
+          endif
+        enddo
+      enddo
+    enddo
 
     ColumnIntegralRho(1:nLons, 1:nLats, 1:nAlts) = &
       ColumnIntegralRho(1:nLons, 1:nLats, 1:nAlts) + &
@@ -110,7 +110,7 @@ subroutine chapman_integrals(iBlock)
             if (chapman(iLon, iLat, iAlt, iSpecies, iBlock) > &
                 MaxCh(iSpecies)) then
               MaxCh(iSpecies) = chapman(iLon, iLat, iAlt, iSpecies, iBlock)
-            end if
+            endif
 
           else
             ! Determine if the grazing angle (X = 90 deg) lies
@@ -124,7 +124,7 @@ subroutine chapman_integrals(iBlock)
               iiAlt = iAlt
               do while (RadialDistance_GB(iLon, iLat, iiAlt - 1, iBlock) > y)
                 iiAlt = iiAlt - 1
-              end do
+              enddo
               iiAlt = iiAlt - 1
 
               ! Variables for Linear Interpolation:
@@ -171,26 +171,26 @@ subroutine chapman_integrals(iBlock)
               if (chapman(iLon, iLat, iAlt, iSpecies, iBlock) > &
                   MaxCh(iSpecies)) then
                 MaxCh(iSpecies) = chapman(iLon, iLat, iAlt, iSpecies, iBlock)
-              end if
+              endif
 
               ! you're within the "shadow" and so make champan huge
             else
               chapman(iLon, iLat, iAlt, iSpecies, iBlock) = 1.0e26
 
-            end if
+            endif
 
-          end if
+          endif
 
-        end do
-      end do
-    end do
+        enddo
+      enddo
+    enddo
 
     if (MaxCh(iSpecies) == 0.0) &
       MaxCh(iSpecies) = maxval(chapman(:, :, :, iSpecies, iBlock))
     if (iDebugLevel > 3) &
       write(*, *) "====> MaxChapman : ", iSpecies, MaxCh(iSpecies)
 
-  end do
+  enddo
 
   call end_timing("chapman_integrals")
 

--- a/src/check_for_nans.f90
+++ b/src/check_for_nans.f90
@@ -24,17 +24,17 @@ subroutine check_for_nans_ions(cMarker)
             write(*, *) cMarker
             write(*, *) iLon, iLat, iAlt, iProc, iIon
             IsFound = .true.
-          end if
+          endif
           if (iDensityS(iLon, iLat, iAlt, iIon, 1) < 0.0) then
             write(*, *) 'Negative density found in iDensityS : '
             write(*, *) cMarker
             write(*, *) iLon, iLat, iAlt, iProc, iIon
             IsFound = .true.
-          end if
-        end do
-      end do
-    end do
-  end do
+          endif
+        enddo
+      enddo
+    enddo
+  enddo
 
   if (IsFound) call stop_gitm("Stopping...")
 
@@ -63,17 +63,17 @@ subroutine check_for_nans_neutrals(cMarker)
             write(*, *) cMarker
             write(*, *) iLon, iLat, iAlt, iProc, iNeu
             IsFound = .true.
-          end if
+          endif
           if (nDensityS(iLon, iLat, iAlt, iNeu, 1) < 0.0) then
             write(*, *) 'Negative density found in nDensityS : '
             write(*, *) cMarker
             write(*, *) iLon, iLat, iAlt, iProc, iNeu
             IsFound = .true.
-          end if
-        end do
-      end do
-    end do
-  end do
+          endif
+        enddo
+      enddo
+    enddo
+  enddo
 
   if (IsFound) call stop_gitm("Stopping...")
 
@@ -101,41 +101,41 @@ subroutine check_for_nans_temps(cMarker)
           write(*, *) cMarker
           write(*, *) iLon, iLat, iAlt, iProc
           IsFound = .true.
-        end if
+        endif
         if (ieee_is_nan(iTemperature(iLon, iLat, iAlt, 1))) then
           write(*, *) 'Nan found in iTemperature : '
           write(*, *) cMarker
           write(*, *) iLon, iLat, iAlt, iProc
           IsFound = .true.
-        end if
+        endif
         if (ieee_is_nan(eTemperature(iLon, iLat, iAlt, 1))) then
           write(*, *) 'Nan found in eTemperature : '
           write(*, *) cMarker
           write(*, *) iLon, iLat, iAlt, iProc
           IsFound = .true.
-        end if
+        endif
         ! Check for negative Temperatures:
         if (Temperature(iLon, iLat, iAlt, 1) < 0.0) then
           write(*, *) 'Negative found in Temperature : '
           write(*, *) cMarker
           write(*, *) iLon, iLat, iAlt, iProc
           IsFound = .true.
-        end if
+        endif
         if (iTemperature(iLon, iLat, iAlt, 1) < 0.0) then
           write(*, *) 'Negative found in iTemperature : '
           write(*, *) cMarker
           write(*, *) iLon, iLat, iAlt, iProc
           IsFound = .true.
-        end if
+        endif
         if (eTemperature(iLon, iLat, iAlt, 1) < 0.0) then
           write(*, *) 'Negative found in eTemperature : '
           write(*, *) cMarker
           write(*, *) iLon, iLat, iAlt, iProc
           IsFound = .true.
-        end if
-      end do
-    end do
-  end do
+        endif
+      enddo
+    enddo
+  enddo
 
   if (IsFound) call stop_gitm("Stopping...")
 

--- a/src/divergence.f90
+++ b/src/divergence.f90
@@ -55,7 +55,7 @@ subroutine divergence(InArray, OutArray, iBlock)
                        - RadialDistance_GB(i, j, k - 1, iBlock)
         drmodrp(i, j, k) = drm(i, j, k)/drp(i, j, k)
         drr2(i, j, k) = drmodrp(i, j, k)*drmodrp(i, j, k)
-      end do
+      enddo
 
       k = nAlts
       dr(i, j, k) = RadialDistance_GB(i, j, k, iBlock) &
@@ -66,10 +66,10 @@ subroutine divergence(InArray, OutArray, iBlock)
         dtp(i, j, k) = Latitude(j + 1, iBlock) - Latitude(j, iBlock)
         dtmodtp(i, j, k) = dtm(i, j, k)/dtp(i, j, k)
         dtr2(i, j, k) = dtmodtp(i, j, k)*dtmodtp(i, j, k)
-      end do
+      enddo
 
-    end do
-  end do
+    enddo
+  enddo
 
   !\
   ! East First  (same as the gradient)
@@ -82,9 +82,9 @@ subroutine divergence(InArray, OutArray, iBlock)
         OutArray(i, j, k) = ((InArray(i + 1, j, k) - InArray(i - 1, j, k))/ &
                              (Longitude(i + 1, iBlock) - Longitude(i - 1, iBlock)))/ &
                             (maxi*RadialDistance_GB(i, j, k, iBlock))
-      end do
-    end do
-  end do
+      enddo
+    enddo
+  enddo
 
   !\
   ! North Second
@@ -106,9 +106,9 @@ subroutine divergence(InArray, OutArray, iBlock)
         OutArray(i, j, k) = OutArray(i, j, k) + &
                             maxi*InArray(i, j, k)*InvRadialDistance_GB(i, j, k, iBlock)
 
-      end do
-    end do
-  end do
+      enddo
+    enddo
+  enddo
 
   !\
   ! Up Third
@@ -138,7 +138,7 @@ subroutine divergence(InArray, OutArray, iBlock)
         OutArray(i, j, k) = OutArray(i, j, k) + &
                             2.0*InArray(i, j, k)*InvRadialDistance_GB(i, j, k, iBlock)
 
-      end do
+      enddo
 
       k = nAlts
       OutArray(i, j, k) = OutArray(i, j, k) + &
@@ -149,7 +149,7 @@ subroutine divergence(InArray, OutArray, iBlock)
       OutArray(i, j, k) = OutArray(i, j, k) + &
                           2.0*InArray(i, j, k)*InvRadialDistance_GB(i, j, k, iBlock)
 
-    end do
-  end do
+    enddo
+  enddo
 
 end subroutine divergence

--- a/src/exchange_messages_sphere.f90
+++ b/src/exchange_messages_sphere.f90
@@ -17,7 +17,7 @@ subroutine exchange_messages_sphere
   if (.not. isOK) then
     call UAM_write_error()
     call stop_gitm("error in xfer_start")
-  end if
+  endif
 
   !
   ! End the message passing
@@ -27,7 +27,7 @@ subroutine exchange_messages_sphere
   if (.not. isOK) then
     call UAM_write_error()
     call stop_gitm("error in xfer_finish")
-  end if
+  endif
 
   do iBlock = 1, nBlocks
 
@@ -50,9 +50,9 @@ subroutine exchange_messages_sphere
           -IVelocityPar(:, -1:0, :, iNorth_, iBlock)
         IVelocityPar(:, -1:0, :, iEast_, iBlock) = &
           -IVelocityPar(:, -1:0, :, iEast_, iBlock)
-      end if
+      endif
 
-    end if
+    endif
 
     if (Latitude(nLats + 1, iBlock) > pi/2.0) then
 
@@ -71,23 +71,23 @@ subroutine exchange_messages_sphere
           -IVelocityPar(:, nLats + 1:nLats + 2, :, iNorth_, iBlock)
         IVelocityPar(:, nLats + 1:nLats + 2, :, iEast_, iBlock) = &
           -IVelocityPar(:, nLats + 1:nLats + 2, :, iEast_, iBlock)
-      end if
+      endif
 
-    end if
+    endif
 
     if (minval(temperature(1:nLons, 1:nLats, 1:nAlts, iBlock)) < 100.0) then
       write(*, *) "Low Temperature : ", iBlock, &
         minval(temperature(1:nLons, 1:nLats, 1:nAlts, iBlock))
       call stop_gitm("Temperature < 100.0")
-    end if
+    endif
 
     if (minval(rho(1:nLons, 1:nLats, 1:nAlts, iBlock)) < 0.0) then
       write(*, *) "Low mass density : ", iBlock, &
         minval(rho(1:nLons, 1:nLats, 1:nAlts, iBlock))
       call stop_gitm("mass density < 0.0")
-    end if
+    endif
 
-  end do
+  enddo
 
   call end_timing("Message Pass")
 

--- a/src/finalize.f90
+++ b/src/finalize.f90
@@ -18,8 +18,8 @@ subroutine finalize_gitm
   do iOutputType = 1, nOutputTypes
     do iBlock = 1, nBlocks
       call output("UA/data/", iBlock, iOutputType)
-    end do
-  end do
+    enddo
+  enddo
 
   if (IsOpenLogFile) close(iLogFileUnit_)
 
@@ -28,7 +28,7 @@ subroutine finalize_gitm
   if (iProc == 0) then
     open(unit=iOutputUnit_, file="GITM.DONE", status="unknown")
     close(iOutputUnit_)
-  end if
+  endif
 
   call end_timing("GITM")
 
@@ -41,9 +41,9 @@ subroutine finalize_gitm
     if (.not. IsOk) then
       call UAM_write_error()
       if (.not. IsFrameWork) call stop_gitm("problem with finalize")
-    end if
+    endif
 
-  end if
+  endif
 
   ! cleanup mpi
   if (.not. IsFrameWork) call MPI_FINALIZE(iError)

--- a/src/get_glow.f90
+++ b/src/get_glow.f90
@@ -37,17 +37,17 @@ subroutine get_glow(iLon, iLat, iBlock)
   if (iError .gt. 0) then
     write(*, *) "nAlts too large for glow!.. in get_glow"
     call stop_GITM
-  end if
+  endif
 
   if (isFirstGlow) then
     call GL_init
     isFirstGlow = .False.
-  end if
+  endif
 
   if (isInitialGlow) then
     call GL_interp_flux(WaveS, WaveL, Flux_of_EUV, Num_WaveLengths_High)
     isInitialGlow = .False.
-  end if
+  endif
 
   ZRHO(1:nAlts) = Rho(iLon, iLat, 1:nAlts, iBlock)*0.000001*1000.0
   ZO(1:nAlts) = NDensityS(iLon, iLat, 1:nAlts, iO3P, iBlock)*0.000001
@@ -82,7 +82,7 @@ subroutine get_glow(iLon, iLat, iBlock)
     PhotoEFluxU(iLon, iLat, iAlt, :, iBlock) = peup(:, iAlt)*1000000.0
     PhotoEFluxD(iLon, iLat, iAlt, :, iBlock) = pedown(:, iAlt)*1000000.0
     PhotoElectronRate(iLon, iLat, iAlt, :, iBlock) = pespec(:, iAlt)*1000000.0
-  end do
+  enddo
 
   PhotoEFluxTotal = 0
 
@@ -92,6 +92,6 @@ subroutine get_glow(iLon, iLat, iBlock)
                                           PhotoEFluxU(:, :, :, ibin, iBlock)
     PhotoEFluxTotal(:, :, :, iBlock, 2) = PhotoEFluxTotal(:, :, :, iBlock, 2) + &
                                           PhotoEFluxD(:, :, :, iBin, iBlock)
-  end do
+  enddo
 
 end subroutine get_glow

--- a/src/get_location.f90
+++ b/src/get_location.f90
@@ -78,8 +78,8 @@ subroutine LocationIndex(LonFind, LatFind, iiBlock, iiLon, iiLat, rLon, rLat)
             rLon = 1.0 - (LonFind - Longitude(iLon, iBlock))/ &
                    (Longitude(iLon + 1, iBlock) - Longitude(iLon, iBlock))
             exit
-          end if
-        end do
+          endif
+        enddo
 
         do iLat = 0, nLats
           if (Latitude(iLat, iBlock) <= LatFind .and. &
@@ -88,15 +88,15 @@ subroutine LocationIndex(LonFind, LatFind, iiBlock, iiLon, iiLat, rLon, rLat)
             rLat = 1.0 - (LatFind - Latitude(iLat, iBlock))/ &
                    (Latitude(iLat + 1, iBlock) - Latitude(iLat, iBlock))
             exit
-          end if
-        end do
+          endif
+        enddo
 
         if (iiLon >= 0 .and. iiLat >= 0) then
           exit
-        end if
-      end if
-    end if
-  end do
+        endif
+      endif
+    endif
+  enddo
 
 end subroutine LocationIndex
 
@@ -129,8 +129,8 @@ subroutine BlockLocationIndex(LonFind, LatFind, iBlock, iiLon, iiLat, rLon, rLat
           rLon = 1.0 - (LonFind - Longitude(iLon, iBlock))/ &
                  (Longitude(iLon + 1, iBlock) - Longitude(iLon, iBlock))
           exit
-        end if
-      end do
+        endif
+      enddo
 
       do iLat = 0, nLats
         if (Latitude(iLat, iBlock) <= LatFind .and. &
@@ -139,10 +139,10 @@ subroutine BlockLocationIndex(LonFind, LatFind, iBlock, iiLon, iiLat, rLon, rLat
           rLat = 1.0 - (LatFind - Latitude(iLat, iBlock))/ &
                  (Latitude(iLat + 1, iBlock) - Latitude(iLat, iBlock))
           exit
-        end if
-      end do
-    end if
-  end if
+        endif
+      enddo
+    endif
+  endif
 
 end subroutine BlockLocationIndex
 
@@ -168,7 +168,7 @@ subroutine BlockAltIndex(AltFind, iBlock, iLon, iLat, iAlt, rAlt)
              /(Altitude_GB(iLon, iLat, iAlt + 1, iBlock) &
                - Altitude_GB(iLon, iLat, iAlt, iBlock))
       exit
-    end if
-  end do
+    endif
+  enddo
 
 end subroutine BlockAltIndex

--- a/src/get_potential.f90
+++ b/src/get_potential.f90
@@ -36,19 +36,19 @@ subroutine init_get_potential
   if (UseNewellAurora) then
     call init_newell
     UseIMF = .true.
-  end if
+  endif
 
   if (UseOvationSME) then
     call read_ovationsm_files
-  end if
+  endif
 
   if (UseAeModel) then
     call read_ae_model_files(iError)
-  end if
+  endif
 
   if (UseFtaModel) then
     call initialize_fta
-  end if
+  endif
 
   call report("AMIE vs Weimer", 4)
 
@@ -74,7 +74,7 @@ subroutine init_get_potential
     else
       Lines(3) = PotentialModel    ! Change to "zero" if you want
       UseIMF = .true.
-    end if
+    endif
     Lines(4) = AuroralModel
     Lines(5) = "idontknow"
     Lines(6) = ""
@@ -106,9 +106,9 @@ subroutine init_get_potential
 
       UseIMF = .false.
 
-    end if
+    endif
 
-  end if
+  endif
 
   Lines(7) = "#DEBUG"
   call i2s(iDebugLevel, cDebugLevel, 2)
@@ -123,7 +123,7 @@ subroutine init_get_potential
     Lines(14) = "#END"
   else
     Lines(11) = "#END"
-  end if
+  endif
 
   call report("EIE_stuff", 4)
 
@@ -137,7 +137,7 @@ subroutine init_get_potential
       "Code Error in IE_Initialize called from get_potential.f90"
     write(*, *) "Error : ", iError
     call stop_gitm("Stopping in get_potential")
-  end if
+  endif
 
   if (UseRegionalAMIE) then
      !!! read AMIE files
@@ -148,7 +148,7 @@ subroutine init_get_potential
         "Code Error in readAMIEOutput called from get_potential.f90"
       write(*, *) "Error : ", iError
       call stop_gitm("Stopping in get_potential")
-    end if
+    endif
 
     write(*, *) 'done with reading amie north!'
 
@@ -158,7 +158,7 @@ subroutine init_get_potential
     else
       call AMIE_SetFileName(cAMIEFileSouth)
       call readAMIEOutput(1, .false., iDebugLevel, iError)
-    end if
+    endif
 
     call AMIE_GetnLats(nAmieLats)
     call AMIE_GetnMLTs(nAmieMlts)
@@ -170,12 +170,12 @@ subroutine init_get_potential
         "Code Error in EIE_InitGrid called from get_potential.f90"
       write(*, *) "Error : ", iError
       call stop_gitm("Stopping in get_potential")
-    end if
+    endif
 
     call AMIE_GetLats(EIEr3_HaveLats)
     call AMIE_GetMLTs(EIEr3_HaveMLTs)
 
-  end if
+  endif
 
 end subroutine init_get_potential
 
@@ -218,7 +218,7 @@ subroutine set_indices
         "Code Error in get_IMF_Bz called from get_potential.f90"
       write(*, *) "Code : ", iError
       call stop_gitm("Stopping in get_potential")
-    end if
+    endif
 
     if (iDebugLevel > 1) write(*, *) "==> IMF Bz : ", bz
 
@@ -231,7 +231,7 @@ subroutine set_indices
       write(*, *) &
         "Code Error in get_IMF_By called from get_potential.f90"
       call stop_gitm("Stopping in get_potential")
-    end if
+    endif
 
     if (iDebugLevel > 1) write(*, *) "==> IMF By : ", by
 
@@ -243,7 +243,7 @@ subroutine set_indices
     if (iError /= 0) then
       write(*, *) "Code Error in get_sw_v called from get_potential.f90"
       call stop_gitm("Stopping in get_potential")
-    end if
+    endif
 
     if (iDebugLevel > 1) write(*, *) "==> Solar Wind Velocity : ", vx
 
@@ -253,7 +253,7 @@ subroutine set_indices
 
     if (UseNewellAurora) call calc_dfdt(by, bz, vx)
 
-  end if
+  endif
 
   if (UseHPI) then
 
@@ -263,9 +263,9 @@ subroutine set_indices
     if (iError /= 0) then
       write(*, *) "Code Error in get_hpi called from get_potential.f90"
       call stop_gitm("Stopping in get_potential")
-    end if
+    endif
 
-  end if
+  endif
 
   if (index(cAMIEFileNorth, "none") <= 0 .and. &
       index(cAMIEFileNorth, "SPS") <= 0 .and. (.not. UseRegionalAMIE)) then
@@ -274,7 +274,7 @@ subroutine set_indices
     if (iDebugLevel > 1) &
       write(*, *) "==> Reading AMIE values for time :", CurrentTime
     call get_AMIE_values(CurrentTime + TimeDelayHighLat)
-  end if
+  endif
 
 end subroutine set_indices
 
@@ -325,7 +325,7 @@ subroutine get_potential(iBlock)
     ElectronEnergyFlux = 0.0001
     return
 
-  end if
+  endif
 
   if (floor((tSimulation - dt)/DtPotential) /= &
       floor((tsimulation)/DtPotential) .or. IsFirstPotential(iBlock)) then
@@ -353,7 +353,7 @@ subroutine get_potential(iBlock)
         write(*, *) "Error in routine get_potential (UA_SetGrid):"
         write(*, *) iError
         call stop_gitm("Stopping in get_potential")
-      end if
+      endif
 
       if (iDebugLevel > 1 .and. iAlt == 1) &
         write(*, *) "==> Getting IE potential"
@@ -369,7 +369,7 @@ subroutine get_potential(iBlock)
         !write(*,*) iError
         TempPotential = 0.0
 !           call stop_gitm("Stopping in get_potential")
-      end if
+      endif
 
       nDir = 1
       if (UseRegionalAMIE .and. &
@@ -393,7 +393,7 @@ subroutine get_potential(iBlock)
           write(*, *) "Error in get_potential (UA_GetPotential) for AMIE:"
           write(*, *) iError
           call stop_gitm("Stopping in get_potential")
-        end if
+        endif
 
         if (UseTwoAMIEPotentials) then
           if (iDebugLevel > 1) &
@@ -408,13 +408,13 @@ subroutine get_potential(iBlock)
             write(*, *) "Error in get_potential (UA_GetPotential) for AMIE PotentialY:"
             write(*, *) iError
             call stop_gitm("Stopping in get_potential")
-          end if
+          endif
           TempPotential(:, :, 2) = TempPotential(:, :, 1)
           ! two directions for two-potentials
           nDir = 2
         else
           nDir = 1
-        end if
+        endif
 
         ! Two iterations for two-potentials, one iteration for one-potential
         do iDir = 1, nDir
@@ -436,9 +436,9 @@ subroutine get_potential(iBlock)
                 LocalSumDiffPot = LocalSumDiffPot + &
                                   AMIEPotential(iLon, iLat, iDir) - TempPotential(iLon, iLat, iDir)
                 iPot = iPot + 1
-              end if
-            end do
-          end do
+              endif
+            enddo
+          enddo
           call MPI_ALLREDUCE(LocalSumDiffPot, MeanDiffPot, 1, &
                              MPI_REAL, MPI_SUM, iCommGITM, iError)
           call MPI_ALLREDUCE(iPot, nPot, 1, &
@@ -468,7 +468,7 @@ subroutine get_potential(iBlock)
                 TempWeight = (AMIELonStart - MLongitude(iLon, iLat, iAlt, iBlock))/AMIEBoundaryWidth
                 TempPotential(iLon, iLat, iDir) = TempWeight*TempPotential(iLon, iLat, iDir) + &
                                                   (1 - TempWeight)*AMIEPotential(iLon, iLat, iDir)
-              end if
+              endif
 
               if (MLatitude(iLon, iLat, iAlt, iBlock) > AMIELatStart &
                   .and. MLatitude(iLon, iLat, iAlt, iBlock) < AMIELatEnd &
@@ -477,7 +477,7 @@ subroutine get_potential(iBlock)
                 TempWeight = (MLongitude(iLon, iLat, iAlt, iBlock) - AMIELonEnd)/AMIEBoundaryWidth
                 TempPotential(iLon, iLat, iDir) = TempWeight*TempPotential(iLon, iLat, iDir) + &
                                                   (1 - TempWeight)*AMIEPotential(iLon, iLat, iDir)
-              end if
+              endif
 
               ! low and high lat boundaries
               if (MLongitude(iLon, iLat, iAlt, iBlock) > AMIELonStart - AMIEBoundaryWidth &
@@ -487,7 +487,7 @@ subroutine get_potential(iBlock)
                 TempWeight = (AMIELatStart - MLatitude(iLon, iLat, iAlt, iBlock))/AMIEBoundaryWidth
                 TempPotential(iLon, iLat, iDir) = TempWeight*TempPotential(iLon, iLat, iDir) + &
                                                   (1 - TempWeight)*AMIEPotential(iLon, iLat, iDir)
-              end if
+              endif
               if (MLongitude(iLon, iLat, iAlt, iBlock) > AMIELonStart - AMIEBoundaryWidth &
                   .and. MLongitude(iLon, iLat, iAlt, iBlock) < AMIELonEnd + AMIEBoundaryWidth &
                   .and. MLatitude(iLon, iLat, iAlt, iBlock) > AMIELatEnd &
@@ -495,14 +495,14 @@ subroutine get_potential(iBlock)
                 TempWeight = (MLatitude(iLon, iLat, iAlt, iBlock) - AMIELatEnd)/AMIEBoundaryWidth
                 TempPotential(iLon, iLat, iDir) = TempWeight*TempPotential(iLon, iLat, iDir) + &
                                                   (1 - TempWeight)*AMIEPotential(iLon, iLat, iDir)
-              end if
-            end do
-          end do
+              endif
+            enddo
+          enddo
 
-        end do
+        enddo
         ! set back to false for getting Weimer potential at the next iteration
         UAl_UseGridBasedEIE = .false.
-      end if
+      endif
 
       if (UseDynamo .and. .not. Is1D) then
         dynamo = 0.0
@@ -517,7 +517,7 @@ subroutine get_potential(iBlock)
           LatBoundNow = 45.
         else
           LatBoundNow = DynamoHighLatBoundary
-        end if
+        endif
 
         do iDir = 1, nDir
           do iLon = -1, nLons + 2
@@ -531,20 +531,20 @@ subroutine get_potential(iBlock)
                   TempPotential(iLon, iLat, iDir) = &
                     (1.0 - dis)*TempPotential(iLon, iLat, iDir) + &
                     dis*dynamo(iLon, iLat)
-                end if
-              end if
-            end do
-          end do
-        end do
+                endif
+              endif
+            enddo
+          enddo
+        enddo
 
-      end if
+      endif
 
       Potential(:, :, iAlt, iBlock) = TempPotential(:, :, 1)
       if (UseTwoAMIEPotentials) then
         PotentialY(:, :, iAlt, iBlock) = TempPotential(:, :, 2)
       else
         PotentialY(:, :, iAlt, iBlock) = Potential(:, :, iAlt, iBlock)
-      end if
+      endif
 
       !----------------------------------------------
       ! Another example of user output
@@ -553,13 +553,13 @@ subroutine get_potential(iBlock)
 
         UserData2d(1:nLons, 1:nLats, 1, 1, iBlock) = &
           TempPotential(1:nLons, 1:nLats, 1)/1000.0
-      end if
+      endif
 
-    end do
+    enddo
 
     IsFirstPotential(iBlock) = .false.
 
-  end if
+  endif
 
   ! -----------------------------------------------------
   ! Now get the aurora.
@@ -592,14 +592,14 @@ subroutine get_potential(iBlock)
         write(*, *) "Error in routine get_potential (UA_SetGrid):"
         write(*, *) iError
         call stop_gitm("Stopping in get_potential")
-      end if
+      endif
 
       call UA_GetAveE(ElectronAverageEnergy, iError)
       if (iError /= 0) then
         write(*, *) "Error in get_potential (UA_GetAveE):"
         write(*, *) iError
         ElectronAverageEnergy = 1.0
-      end if
+      endif
 
       ! Sometimes, in AMIE, things get messed up in the
       ! Average energy, so go through and fix some of these.
@@ -610,21 +610,21 @@ subroutine get_potential(iBlock)
             ElectronAverageEnergy(iLon, iLat) = 0.1
             write(*, *) "ave e i,j Negative : ", iLon, iLat, &
               ElectronAverageEnergy(iLon, iLat)
-          end if
+          endif
           if (ElectronAverageEnergy(iLon, iLat) > 100.0) then
             write(*, *) "ave e i,j Positive : ", iLon, iLat, &
               ElectronAverageEnergy(iLon, iLat)
             ElectronAverageEnergy(iLon, iLat) = 0.1
-          end if
-        end do
-      end do
+          endif
+        enddo
+      enddo
 
       call UA_GetEFlux(ElectronEnergyFlux, iError)
       if (iError /= 0) then
         write(*, *) "Error in get_potential (UA_GetEFlux):"
         write(*, *) iError
         ElectronEnergyFlux = 0.1
-      end if
+      endif
 
       ! -----------------------------------------------------
       ! Get Ion Precipitation if desired
@@ -637,18 +637,18 @@ subroutine get_potential(iBlock)
           write(*, *) "Error in get_potential (UA_GetAveE):"
           write(*, *) iError
           IonAverageEnergy = 1.0
-        end if
+        endif
 
         call UA_GetIonEFlux(IonEnergyFlux, iError)
         if (iError /= 0) then
           write(*, *) "Error in get_potential (UA_GetEFlux):"
           write(*, *) iError
           IonEnergyFlux = 0.1
-        end if
+        endif
 
-      end if
+      endif
 
-    end if
+    endif
 
     if (UseCusp) then
 
@@ -677,8 +677,8 @@ subroutine get_potential(iBlock)
             CuspLat = 77.2 + 1.1*bz
           else
             CuspLat = 21.7*exp(0.1*bz) + 58.2
-          end if
-        end if
+          endif
+        endif
 
         EFlux = CuspEFlux* &
                 exp(-abs(lats - CuspLat)/CuspLatHalfWidth)* &
@@ -689,13 +689,13 @@ subroutine get_potential(iBlock)
             if (EFlux(iLon, iLat) > 0.1) then
               ElectronEnergyFlux(iLon, iLat) = EFlux(iLon, iLat)
               ElectronAverageEnergy(iLon, iLat) = CuspAveE
-            end if
-          end do
-        end do
+            endif
+          enddo
+        enddo
 
-      end if
+      endif
 
-    end if
+    endif
 
     if (iDebugLevel > 2) &
       write(*, *) "==> Max, electron_ave_ene : ", &
@@ -704,7 +704,7 @@ subroutine get_potential(iBlock)
 
     IsFirstAurora(iBlock) = .false.
 
-  end if
+  endif
 
   if (iDebugLevel > 1) &
     write(*, *) "==> Min, Max, CPC Potential : ", &
@@ -778,15 +778,15 @@ subroutine get_dynamo_potential(lons, lats, pot)
 
               IsFound = .true.
 
-            end if
+            endif
 
             iL = iL + 1
 
-          end do
+          enddo
 
           iM = iM + 1
 
-        end do
+        enddo
 
         ! Check for near pole
         if (.not. IsFound) then
@@ -794,19 +794,19 @@ subroutine get_dynamo_potential(lons, lats, pot)
           if (LatIn > 88.0) then
             IsFound = .true.
             pot(iLon, iLat) = sum(DynamoPotentialMC(:, nMagLats))/(nMagLons + 1)
-          end if
+          endif
 
           if (LatIn < -88.0) then
             IsFound = .true.
             pot(iLon, iLat) = sum(DynamoPotentialMC(:, 0))/(nMagLons + 1)
-          end if
+          endif
 
           write(*, *) "Inside the low latitude, but can't find the point!"
           write(*, *) LatIn, LonIn
 
-        end if
+        endif
 
-      end if
+      endif
 
       if (.not. IsFound) then
         if (abs(LatIn) < MagLatMC(nMagLons, nMagLats)) &
@@ -814,10 +814,10 @@ subroutine get_dynamo_potential(lons, lats, pot)
           LatIn, LonIn, DynamoHighLatBoundary, &
           MagLatMC(nMagLons, nMagLats)
         pot(iLon, iLat) = 0.0
-      end if
+      endif
 
-    end do
+    enddo
 
-  end do
+  enddo
 
 end subroutine get_dynamo_potential

--- a/src/gradient.f90
+++ b/src/gradient.f90
@@ -45,11 +45,11 @@ subroutine UAM_Gradient(Array_G, Gradient_CD, iBlock)
              + GradLon0_CB(iLon, iBlock)*Array_G(iLon, iLat, iAlt) &
              + GradLonP_CB(iLon, iBlock)*Array_G(iLon + 1, iLat, iAlt) &
              )*InvRadialDistance_GB(iLon, iLat, iAlt, iBlock)*InvCosLat
-        end do
-      end do
-    end do
+        enddo
+      enddo
+    enddo
 
-  end if
+  endif
 
   !\
   ! North Second
@@ -64,11 +64,11 @@ subroutine UAM_Gradient(Array_G, Gradient_CD, iBlock)
              + GradLat0_CB(iLat, iBlock)*Array_G(iLon, iLat, iAlt) &
              + GradLatP_CB(iLat, iBlock)*Array_G(iLon, iLat + 1, iAlt) &
              )*InvRadialDistance_GB(iLon, iLat, iAlt, iBlock)
-        end do
-      end do
-    end do
+        enddo
+      enddo
+    enddo
 
-  end if
+  endif
 
   !\
   ! Up Third
@@ -93,11 +93,11 @@ subroutine UAM_Gradient(Array_G, Gradient_CD, iBlock)
              - Array_G(iLon, iLat, iAlt - 1) &
              - (Drr2 - 1)*Array_G(iLon, iLat, iAlt))/Bottom
 
-        end do
-      end do
-    end do
+        enddo
+      enddo
+    enddo
 
-  end if
+  endif
 
 end subroutine UAM_Gradient
 
@@ -146,11 +146,11 @@ subroutine UAM_Gradient_GC(Array_G, Gradient_GC, iBlock)
              + InvDenom*(1 - Ratio2)*Array_G(iLon, iLat, iAlt) &
              + InvDenom*Ratio2*Array_G(iLon + 1, iLat, iAlt) &
              )*InvRadialDistance_GB(iLon, iLat, iAlt, iBlock)*InvCosLat
-        end do
-      end do
-    end do
+        enddo
+      enddo
+    enddo
 
-  end if
+  endif
 
   !\
   ! North Second
@@ -169,11 +169,11 @@ subroutine UAM_Gradient_GC(Array_G, Gradient_GC, iBlock)
              + InvDenom*(1 - Ratio2)*Array_G(iLon, iLat, iAlt) &
              + InvDenom*Ratio2*Array_G(iLon, iLat + 1, iAlt) &
              )*InvRadialDistance_GB(iLon, iLat, iAlt, iBlock)
-        end do
-      end do
-    end do
+        enddo
+      enddo
+    enddo
 
-  end if
+  endif
 
   !\
   ! Up Third
@@ -198,10 +198,10 @@ subroutine UAM_Gradient_GC(Array_G, Gradient_GC, iBlock)
              - Array_G(iLon, iLat, iAlt - 1) &
              - (Drr2 - 1)*Array_G(iLon, iLat, iAlt))/Bottom
 
-        end do
-      end do
-    end do
+        enddo
+      enddo
+    enddo
 
-  end if
+  endif
 
 end subroutine UAM_Gradient_GC

--- a/src/init_altitude.f90
+++ b/src/init_altitude.f90
@@ -27,7 +27,7 @@ subroutine get_temperature(lon, lat, alt, t, h)
       t = tAve + tDiff*tanh((alt/1000.0 - TempHeight)/TempWidth)
     else
       t = tAve + tDiff*tanh((alt/1000.0 - TempHeight)/TempWidth)
-    end if
+    endif
 
     r = RBody + alt
     g = Gravitational_Constant*(RBody/r)**2
@@ -38,12 +38,12 @@ subroutine get_temperature(lon, lat, alt, t, h)
     do iSpecies = 1, nSpecies
       m = m + exp(LogNS0(iSpecies))*mass(iSpecies)
       n = n + exp(LogNS0(iSpecies))
-    end do
+    enddo
 
     m = m/n
     h = Boltzmanns_Constant*t/(m*g)
 
-  end if
+  endif
 
 end subroutine get_temperature
 
@@ -101,7 +101,7 @@ subroutine init_altitude
     call get_temperature(geo_lon, geo_lat, geo_alt, t, h)
     ScaleHeights(iAlt) = h
 
-  end do
+  enddo
 
   Altitude_GB(:, :, 1, 1:nBlocks) = AltMin
   Altitude_GB(:, :, 0, 1:nBlocks) = AltMin - dHFactor*ScaleHeights(1)
@@ -112,7 +112,7 @@ subroutine init_altitude
                                          + dHFactor*ScaleHeights(iAlt - 1)
     if (iDebugLevel > 3) write(*, *) "Altitude, dHFactor, ScaleHeight : ", &
       Altitude_GB(1, 1, iAlt, 1), dHFactor, ScaleHeights(iAlt - 1)
-  end do
+  enddo
 
   Altitude_GB(:, :, nAlts + 2, 1:nBlocks) = Altitude_GB(:, :, nAlts + 1, 1:nBlocks) &
                                             + dHFactor*ScaleHeights(nAlts)
@@ -171,7 +171,7 @@ subroutine init_altitude_old
 
       ScaleHeights(iAlt) = h
 
-    end do
+    enddo
 
     if (abs(geo_alt - AltMax) < 1.0) then
       IsDone = .true.
@@ -184,12 +184,12 @@ subroutine init_altitude_old
           dHFactor*(AltMax - AltMin)/(geo_alt - AltMin)/2.0 + &
           OlddHFactor/2.0
         OlddHFactor = dHFactor
-      end if
-    end if
+      endif
+    endif
 
     iLoop = iLoop + 1
 
-  end do
+  enddo
 
   Altitude_GB(:, :, 1, 1:nBlocks) = AltMin
   Altitude_GB(:, :, 0, 1:nBlocks) = AltMin - dHFactor*ScaleHeights(1)
@@ -200,7 +200,7 @@ subroutine init_altitude_old
                                          + dHFactor*ScaleHeights(iAlt - 1)
     if (iDebugLevel > 3) write(*, *) "Altitude, dHFactor, ScaleHeight : ", &
       Altitude_GB(1, 1, iAlt, 1), dHFactor, ScaleHeights(iAlt - 1)
-  end do
+  enddo
 
   Altitude_GB(:, :, nAlts + 2, 1:nBlocks) = Altitude_GB(:, :, nAlts + 1, 1:nBlocks) &
                                             + dHFactor*ScaleHeights(nAlts)

--- a/src/init_b0.f90
+++ b/src/init_b0.f90
@@ -46,12 +46,12 @@ subroutine init_b0
           if (GeoLat > 90.0) then
             GeoLat = 180.0 - GeoLat
             GeoLon = mod(GeoLon + 180.0, 360.0)
-          end if
+          endif
 
           if (GeoLat < -90.0) then
             GeoLat = -180.0 - GeoLat
             GeoLon = mod(GeoLon + 180.0, 360.0)
-          end if
+          endif
 
           alat = 0.0
           alon = 0.0
@@ -79,7 +79,7 @@ subroutine init_b0
             b0_cD(iLon, iLat, iAlt, iBlock) = cD
             b0_Be3(iLon, iLat, iAlt, iBlock) = &
               B0(iLon, iLat, iAlt, iMag_, iBlock)/cD
-          end if
+          endif
 
           if (B0(iLon, iLat, iAlt, iMag_, iBlock) == 0.0) then
             B0(iLon, iLat, iAlt, iMag_, iBlock) = 1.0e-10
@@ -98,12 +98,12 @@ subroutine init_b0
               sin(DipAngle(iLon, iLat, iAlt, iBlock))
             DecAngle(iLon, iLat, iAlt, iBlock) = atan2(ymag, xmag)*180.0/pi
 
-          end if
+          endif
 
-        end do
-      end do
-    end do
-  end do
+        enddo
+      enddo
+    enddo
+  enddo
 
   if (UseApex .and. IsEarth) &
     call dypol( &
@@ -150,7 +150,7 @@ subroutine get_magfield(GeoLat, GeoLon, GeoAlt, xmag, ymag, zmag)
 !     xmag =     - DipoleStrength * cos(GeoLat*pi/180.0) * r3
 !     zmag = 2.0 * DipoleStrength * sin(GeoLat*pi/180.0) * r3
 
-  end if
+  endif
 
 end subroutine get_magfield
 
@@ -190,7 +190,7 @@ subroutine get_magfield_all(GeoLat, GeoLon, GeoAlt, alat, alon, xmag, ymag, zmag
     xmag = 0.0
     ymag = 0.0
     zmag = 0.0
-  end if
+  endif
 
   if (UseApex .and. IsEarth) then
 
@@ -227,10 +227,10 @@ subroutine get_magfield_all(GeoLat, GeoLon, GeoAlt, alat, alon, xmag, ymag, zmag
     londiff = alonp - alonm
     do while (londiff > 70.0)
       londiff = londiff - 90.0
-    end do
+    enddo
     do while (londiff < -70.0)
       londiff = londiff + 90.0
-    end do
+    enddo
 
     d1(iNorth_) = londiff/twodegrees
     d2(iNorth_) = (alatp - alatm)/twodegrees
@@ -249,10 +249,10 @@ subroutine get_magfield_all(GeoLat, GeoLon, GeoAlt, alat, alon, xmag, ymag, zmag
     londiff = alonp - alonm
     do while (londiff > 70.0)
       londiff = londiff - 90.0
-    end do
+    enddo
     do while (londiff < -70.0)
       londiff = londiff + 90.0
-    end do
+    enddo
 
     d1(iEast_) = (londiff)/(twodegrees*cos(GeoLat*pi/180.0))
     d2(iEast_) = (alatp - alatm)/(twodegrees*cos(GeoLat*pi/180.0))
@@ -273,15 +273,15 @@ subroutine get_magfield_all(GeoLat, GeoLon, GeoAlt, alat, alon, xmag, ymag, zmag
       write(*, *) 'This seems to be too high.  Please change the first few'
       write(*, *) 'lines in get_magfield_all.'
       call stop_gitm("Must Stop!!")
-    end if
+    endif
 
     londiff = alonp - alonm
     do while (londiff > 70.0)
       londiff = londiff - 90.0
-    end do
+    enddo
     do while (londiff < -70.0)
       londiff = londiff + 90.0
-    end do
+    enddo
 
     d1(iUp_) = (RBody + GeoAlt*1000.0)*(londiff)/(2000.0)
     d2(iUp_) = (RBody + GeoAlt*1000.0)*(alatp - alatm)/(2000.0)
@@ -328,10 +328,10 @@ subroutine get_magfield_all(GeoLat, GeoLon, GeoAlt, alat, alon, xmag, ymag, zmag
       londiff = alonp - alonm
       do while (londiff > 70.0)
         londiff = londiff - 90.0
-      end do
+      enddo
       do while (londiff < -70.0)
         londiff = londiff + 90.0
-      end do
+      enddo
 
       d1(iNorth_) = londiff/twodegrees
       d2(iNorth_) = (alatp - alatm)/twodegrees
@@ -344,10 +344,10 @@ subroutine get_magfield_all(GeoLat, GeoLon, GeoAlt, alat, alon, xmag, ymag, zmag
       londiff = alonp - alonm
       do while (londiff > 70.0)
         londiff = londiff - 90.0
-      end do
+      enddo
       do while (londiff < -70.0)
         londiff = londiff + 90.0
-      end do
+      enddo
 
       d1(iEast_) = (londiff)/(twodegrees*cos(GeoLat*pi/180.0))
       d2(iEast_) = (alatp - alatm)/(twodegrees*cos(GeoLat*pi/180.0))
@@ -358,10 +358,10 @@ subroutine get_magfield_all(GeoLat, GeoLon, GeoAlt, alat, alon, xmag, ymag, zmag
       londiff = alonp - alonm
       do while (londiff > 70.0)
         londiff = londiff - 90.0
-      end do
+      enddo
       do while (londiff < -70.0)
         londiff = londiff + 90.0
-      end do
+      enddo
 
       d1(iUp_) = (RBody + GeoAlt*1000.0)*(londiff)/(2000.0)
       d2(iUp_) = (RBody + GeoAlt*1000.0)*(alatp - alatm)/(2000.0)
@@ -383,9 +383,9 @@ subroutine get_magfield_all(GeoLat, GeoLon, GeoAlt, alat, alon, xmag, ymag, zmag
       d2 = 0.0
       LShell0 = rBelow
 
-    end if
+    endif
 
-  end if
+  endif
 
   ! Finish Eqn. 3.8-3.10 from Richmond 1995
 
@@ -405,7 +405,7 @@ subroutine get_magfield_all(GeoLat, GeoLon, GeoAlt, alat, alon, xmag, ymag, zmag
     d3(iUp_) = bz/CapDMag
   else
     d3 = 0.0
-  end if
+  endif
 
   e1(iEast_) = d2(iNorth_)*d3(iUp_) - d3(iNorth_)*d2(iUp_)
   e1(iNorth_) = -(d2(iEast_)*d3(iUp_) - d3(iEast_)*d2(iUp_))
@@ -593,7 +593,7 @@ subroutine test_mag_point(rBelow, LShell, RBody)
     write(*, *) 'This seems to be too high.  Please change the first few'
     write(*, *) 'lines in get_magfield_all.'
     call stop_gitm("Must Stop!!")
-  end if
+  endif
 
 end subroutine test_mag_point
 

--- a/src/init_energy_deposition.f90
+++ b/src/init_energy_deposition.f90
@@ -24,24 +24,24 @@ subroutine init_energy_deposition
 
   if (ierr /= 0) then
     call stop_gitm("Error in initilizing the energy deposition tables")
-  end if
+  endif
 
   if (iDebugLevel > 2) write(*, *) "===> ED_Get_Grid_Size"
   call ED_Get_Grid_Size(ED_N_Alts)
   allocate(ED_grid(ED_N_Alts), stat=ierr)
   if (ierr /= 0) then
     call stop_gitm("Error allocating array ED_grid")
-  end if
+  endif
 
   allocate(ED_Ion(ED_N_Alts), stat=ierr)
   if (ierr /= 0) then
     call stop_gitm("Error allocating array ED_Ion")
-  end if
+  endif
 
   allocate(ED_Heating(ED_N_Alts), stat=ierr)
   if (ierr /= 0) then
     call stop_gitm("Error allocating array ED_Heating")
-  end if
+  endif
 
   if (iDebugLevel > 2) write(*, *) "===> ED_Get_Number_of_Energies"
   call ED_Get_Number_of_Energies(ED_N_Energies)
@@ -50,7 +50,7 @@ subroutine init_energy_deposition
   allocate(ED_delta_energy(ED_N_Energies), stat=ierr)
   if (ierr /= 0) then
     call stop_gitm("Error allocating array ED_Energies")
-  end if
+  endif
 
   allocate(ED_Flux(ED_N_Energies), stat=ierr)
   allocate(ED_EnergyFlux(ED_N_Energies), stat=ierr)
@@ -58,14 +58,14 @@ subroutine init_energy_deposition
   allocate(ED_Ion_EnergyFlux(ED_N_Energies), stat=ierr)
   if (ierr /= 0) then
     call stop_gitm("Error allocating array ED_Flux")
-  end if
+  endif
 
   if (iDebugLevel > 2) write(*, *) "===> ED_Get_Grid"
   call ED_Get_Grid(ED_grid, .true., ierr)
 
   do iAlt = 1, ED_N_Alts
     ED_grid(iAlt) = alog(ED_grid(iAlt))
-  end do
+  enddo
 
   call ED_Get_Energies(ED_Energies)
 
@@ -79,7 +79,7 @@ subroutine init_energy_deposition
       (ED_Energies(iEnergy - 1) + ED_Energies(iEnergy))/2
     ED_delta_energy(iEnergy - 1) = &
       ED_Energy_edges(iEnergy - 1) - ED_Energy_edges(iEnergy)
-  end do
+  enddo
 
   iEnergy = ED_N_Energies
   ED_delta_energy(iEnergy) = ED_Energies(iEnergy - 1) - ED_Energies(iEnergy)

--- a/src/init_grid.f90
+++ b/src/init_grid.f90
@@ -42,11 +42,11 @@ subroutine init_grid
       if (LatEnd >= pi/2) then
         LatEnd = pi/2
         DoTouchNorth = .true.
-      end if
+      endif
       if (LatStart <= -pi/2) then
         LatStart = -pi/2
         DoTouchSouth = .true.
-      end if
+      endif
 
       call UAM_module_setup(iCommGITM, &
                             nLons, nLats, nAlts, &
@@ -56,22 +56,22 @@ subroutine init_grid
                             0.0, 0.0, 0.0, &
                             RBody + AltMin, 5000.0, &
                             ok=IsOk)
-    end if
+    endif
 
     if (.not. IsOk) then
       if (iProc == 0) then
         write(*, *) "--> nBlocksLon, nBlocksLat : ", nBlocksLon, nBlocksLat
         write(*, *) "--> Therefore need nProcs = ", nBlocksLon*nBlocksLat
         write(*, *) "--> nProcs = ", nProcs
-      end if
+      endif
       call stop_gitm("Error in trying to create grid.")
-    end if
+    endif
 
     call UAM_XFER_create(ok=IsOk)
     if (.not. IsOk) then
       call UAM_write_error()
       call stop_gitm("Error with UAM_XFER_create")
-    end if
+    endif
 
     call UAM_ITER_create(r_iter)
     call UAM_ITER_reset(r_iter, iBlock, IsDone)
@@ -80,7 +80,7 @@ subroutine init_grid
     do while (.not. IsDone)
       nBlocks = nBlocks + 1
       call UAM_ITER_next(r_iter, iBlock, IsDone)
-    end do
+    enddo
 
     if (LonStart /= LonEnd) then
 
@@ -93,15 +93,15 @@ subroutine init_grid
         dlPart = dlFull/(2*pi)*range
         iPoint = int((Longitude(:, iBlock) + 3*dlFull/2)/dlFull + 0.5) - 1
         Longitude(:, iBlock) = LonStart + iPoint*dlPart + dlPart/2.0
-      end do
+      enddo
 
-    end if
+    endif
 
   else
     nBlocks = 1
     Latitude = LatStart
     Longitude = LonStart
-  end if
+  endif
 
   call init_mod_gitm
   call init_mod_euv

--- a/src/init_iri.Earth.f90
+++ b/src/init_iri.Earth.f90
@@ -133,7 +133,7 @@ subroutine init_iri
           elseif (geo_lat > 90.0) then
             geo_lat = 180.0 - geo_lat
             geo_lon = mod(geo_lon + 180.0, 360.0)
-          end if
+          endif
 
           !  write(*,*) "iri : ", geo_lat, geo_lon, -f107, -iJulianDay, &
           !             utime/3600.+25.,geo_alt,nzkm
@@ -167,7 +167,7 @@ subroutine init_iri
           else
             eTemperature(iLon, iLat, iAlt, iBlock) = outf(4, 1)
             ITemperature(iLon, iLat, iAlt, iBlock) = outf(3, 1)
-          end if
+          endif
 
           IDensityS(iLon, iLat, iAlt, :, iBlock) = &
             IRIDensity(iLon, iLat, iAlt, :, iBlock)
@@ -177,12 +177,12 @@ subroutine init_iri
             IDensityS(iLon, iLat, iAlt, nIons, iBlock) = &
               IDensityS(iLon, iLat, iAlt, nIons, iBlock) + &
               IDensityS(iLon, iLat, iAlt, iIon, iBlock)
-          end do
+          enddo
 
-        end do
-      end do
-    end do
+        enddo
+      enddo
+    enddo
 
-  end do
+  enddo
 
 end subroutine init_iri

--- a/src/init_iri.LV-426.f90
+++ b/src/init_iri.LV-426.f90
@@ -35,12 +35,12 @@ subroutine init_iri
             IDensityS(iLon, iLat, iAlt, nIons, iBlock) = &
               IDensityS(iLon, iLat, iAlt, nIons, iBlock) + &
               IDensityS(iLon, iLat, iAlt, iIon, iBlock)
-          end do
+          enddo
 
-        end do
-      end do
-    end do
+        enddo
+      enddo
+    enddo
 
-  end do
+  enddo
 
 end subroutine init_iri

--- a/src/init_mpi_w_sami.f90
+++ b/src/init_mpi_w_sami.f90
@@ -59,28 +59,28 @@ subroutine init_mpi_coup
         read(iInputUnit_, *) nBlksLats
         numgitm = nBlksLons*nBlksLats
         HaveGrid = .true.
-      end if
+      endif
 
       if (cLine(1:5) == "#SAMI") then
         read(iInputUnit_, *) numsami
         read(iInputUnit_, *) DtCouple
         HaveSami = .true.
-      end if
+      endif
 
       if (HaveGrid .and. HaveSami) IsDone = .true.
 
-    end if
+    endif
 
-  end do
+  enddo
 
   close(iInputUnit_)
 
   if (.not. HaveGrid) then
     if (iProcGlobal == 0) then
       write(*, *) "Can't seem to find #GRID in UAM.in file...??? How???"
-    end if
+    endif
     stop
-  end if
+  endif
 
   if (.not. HaveSami) then
     if (iProcGlobal == 0) then
@@ -88,9 +88,9 @@ subroutine init_mpi_coup
       write(*, *) "#SAMI"
       write(*, *) "13        numworker + 1 from SAMI - We need to fix this.."
       write(*, *) "300.0     dtcouple"
-    end if
+    endif
     stop
-  end if
+  endif
 
   ! ---------------------------------------------------------------------------
 

--- a/src/init_msis.Earth.f90
+++ b/src/init_msis.Earth.f90
@@ -55,14 +55,14 @@ subroutine get_msis_temperature(lon, lat, alt, t, h)
     write(*, *) "Error in getting F107 value.  Is this set?"
     write(*, *) "Code : ", iError
     call stop_gitm("Stopping in euv_ionization_heat")
-  end if
+  endif
 
   call get_f107a(CurrentTime, f107a, iError)
   if (iError /= 0) then
     write(*, *) "Error in getting F107a value.  Is this set?"
     write(*, *) "Code : ", iError
     call stop_gitm("Stopping in euv_ionization_heat")
-  end if
+  endif
 
   if (RCMRFlag .and. RCMROutType == "F107") then
     CALL GTD7(iJulianDay, utime, AltKm, LatDeg, LonDeg, LST, &
@@ -70,7 +70,7 @@ subroutine get_msis_temperature(lon, lat, alt, t, h)
   else
     call GTD7(iJulianDay, utime, AltKm, LatDeg, LonDeg, LST, &
               F107A, F107, AP, 48, msis_dens, msis_temp)
-  end if
+  endif
 
   t = msis_temp(2)
   nO = msis_dens(2)
@@ -128,14 +128,14 @@ subroutine init_msis
     write(*, *) "Error in getting F107 value (init_msis).  Is this set?"
     write(*, *) "Code : ", iError
     call stop_gitm("Stopping in advance")
-  end if
+  endif
 
   call get_f107a(CurrentTime, f107a, iError)
   if (iError /= 0) then
     write(*, *) "Error in getting F107a value (init_msis).  Is this set?"
     write(*, *) "Code : ", iError
     call stop_gitm("Stopping in advance")
-  end if
+  endif
 
   !--------------------------------------------------------------------------
   !
@@ -178,7 +178,7 @@ subroutine init_msis
     sw_msis = 0
     sw_msis(1) = 1
     sw_msis(9) = 1
-  end if
+  endif
 
   sw_msis(9) = 0
   sw_msis(2) = 0
@@ -220,11 +220,11 @@ subroutine init_msis
           if (geo_lat < -90.0) then
             geo_lat = -180.0 - geo_lat
             geo_lon = mod(geo_lon + 180.0, 360.0)
-          end if
+          endif
           if (geo_lat > 90.0) then
             geo_lat = 180.0 - geo_lat
             geo_lon = mod(geo_lon + 180.0, 360.0)
-          end if
+          endif
 
           geo_alt = Altitude_GB(iLon, iLat, iAlt, iBlock)/1000.0
           geo_lst = mod(utime/3600.0 + geo_lon/15.0, 24.0)
@@ -266,7 +266,7 @@ subroutine init_msis
             MeanMajorMass(iLon, iLat, iAlt) = MeanMajorMass(iLon, iLat, iAlt) + &
                                               Mass(iSpecies)*NDensityS(iLon, iLat, iAlt, iSpecies, iBlock)/ &
                                               sum(NDensityS(iLon, iLat, iAlt, 1:nSpecies, iBlock))
-          end do
+          enddo
 
           TempUnit(iLon, iLat, iAlt) = &
             MeanMajorMass(iLon, iLat, iAlt)/Boltzmanns_Constant
@@ -335,11 +335,11 @@ subroutine init_msis
             Velocity(iLon, iLat, iAlt, iEast_, iBlock) = 0.0
             Velocity(iLon, iLat, iAlt, iNorth_, iBlock) = 0.0
 
-          end if
+          endif
 
-        end do
-      end do
-    end do
+        enddo
+      enddo
+    enddo
 
     Rho(:, :, :, iBlock) = 0.0
     NDensity(:, :, :, iBlock) = 0.0
@@ -352,11 +352,11 @@ subroutine init_msis
       Rho(:, :, :, iBlock) = Rho(:, :, :, iBlock) + &
                              Mass(iSpecies)*NDensityS(:, :, :, iSpecies, iBlock)
 
-    end do
+    enddo
 
     call calc_co2(iBlock)
 
-  end do
+  enddo
 
 end subroutine init_msis
 
@@ -399,11 +399,11 @@ subroutine msis_bcs(iJulianDay, UTime, Alt, LatIn, LonIn, Lst, &
   if (lat > 90) then
     lat = 180 - lat
     lon = mod(lon + 180.0, 360.0)
-  end if
+  endif
   if (lat < -90) then
     lat = -180 - lat
     lon = mod(lon + 180.0, 360.0)
-  end if
+  endif
 
   !----------------------------------------------------------------------------
   AP_I = AP
@@ -424,7 +424,7 @@ subroutine msis_bcs(iJulianDay, UTime, Alt, LatIn, LonIn, Lst, &
     ffactor = 6.36*log(f107) - 13.8
     no = (ffactor*1.0e13 + 8.0e13)
     LogNS(min(nSpecies, iNO_)) = alog(no)
-  end if
+  endif
 
   Temp = msis_temp(2)
   LogRho = alog(msis_dens(6))
@@ -452,7 +452,7 @@ subroutine msis_bcs(iJulianDay, UTime, Alt, LatIn, LonIn, Lst, &
   else
     V(1) = 0.0
     V(2) = 0.0
-  end if
+  endif
 
   ! Do some O experimentation:
 
@@ -489,7 +489,7 @@ subroutine msis_bcs(iJulianDay, UTime, Alt, LatIn, LonIn, Lst, &
 
     LogNS(iO_3P_) = alog(max(oMSIS - oCurrentSeason + oOffsetSeason, 1.0))
 
-  end if
+  endif
 
 end subroutine msis_bcs
 
@@ -536,7 +536,7 @@ subroutine calc_co2(iBlock)
   do iAlt = -1, 0
     NDensityS(:, :, iAlt, iCO2_, iBlock) = &
       CO2ppm*1e-6/(1.0 - CO2ppm*1e-6)*NDensity(:, :, iAlt, iBlock)
-  end do
+  enddo
 
   ! Then do hydrostatic to the top using the inferred scale height.
 
@@ -545,6 +545,6 @@ subroutine calc_co2(iBlock)
       NDensityS(:, :, iAlt - 1, iCO2_, iBlock)* &
       Temperature(:, :, iAlt - 1, iBlock)/Temperature(:, :, iAlt, iBlock)* &
       exp(-dAlt_GB(:, :, iAlt, iBlock)/Hco2(:, :, iAlt))
-  end do
+  enddo
 
 end subroutine calc_co2

--- a/src/init_msis.Jupiter.f90
+++ b/src/init_msis.Jupiter.f90
@@ -23,7 +23,7 @@ subroutine get_msis_temperature(lon, lat, alt, t, h)
   i = 1
   do while (alt >= newalt(i))
     i = i + 1
-  end do
+  enddo
   i = i - 1
 
   t = InTemp(i)
@@ -89,7 +89,7 @@ subroutine init_msis
           NDensityS(iLon, iLat, -1:nAlts + 2, iSpecies, iBlock) = &
             InNDensityS(-1:nAlts + 2, iSpecies)*(1.0e+06)
 
-        end do ! end inner ispecies loop
+        enddo ! end inner ispecies loop
 
         !\
         ! These first few are from the input file read in earlier
@@ -107,14 +107,14 @@ subroutine init_msis
             IDensityS(iLon, iLat, -1:nAlts + 2, ie_, iBlock) + &
             IDensityS(iLon, iLat, -1:nAlts + 2, iIon, iBlock)
 
-        end do ! end inner ispecies loop
+        enddo ! end inner ispecies loop
 
         !
         ! End ion loop
         !/
 
-      end do! end iLon loop
-    end do ! end iLat loop
+      enddo! end iLon loop
+    enddo ! end iLat loop
 
     write(*, *) '============> init_msis.Mars.f90 Major Diagnostics:  Begin'
 
@@ -228,25 +228,25 @@ subroutine init_msis
             NDensity(iLon, iLat, iAlt, iBlock) = &
               NDensity(iLon, iLat, iAlt, iBlock) + &
               NDensityS(iLon, iLat, iAlt, iSpecies, iBlock)
-          end do
+          enddo
 
           do iSpecies = 1, nSpeciesTotal
             MeanMajorMass(iLon, iLat, iAlt) = &
               MeanMajorMass(iLon, iLat, iAlt) + &
               Mass(iSpecies)*NDensityS(iLon, iLat, iAlt, iSpecies, iBlock)/ &
               NDensity(iLon, iLat, iAlt, iBlock)
-          end do
+          enddo
 
           do iIon = 1, nIons - 1
             MeanIonMass(iLon, iLat, iAlt) = &
               MeanIonMass(iLon, iLat, iAlt) + &
               MassI(iIon)*IDensityS(iLon, iLat, iAlt, iIon, iBlock)/ &
               IDensityS(iLon, iLat, iAlt, ie_, iBlock)
-          end do
+          enddo
 
-        end do
-      end do
-    end do
+        enddo
+      enddo
+    enddo
 
     TempUnit(-1:nLons + 2, -1:nLats + 2, -1:nAlts + 2) = &
       MeanMajorMass(-1:nLons + 2, -1:nLats + 2, -1:nAlts + 2)/ &
@@ -268,7 +268,7 @@ subroutine init_msis
 
     write(*, *) '==> Now Completing Mars Background Composition: END', iBlock
 
-  end do
+  enddo
 
 end subroutine init_msis
 

--- a/src/init_msis.LV-426.f90
+++ b/src/init_msis.LV-426.f90
@@ -78,9 +78,9 @@ subroutine init_msis
 
           Velocity(iLon, iLat, iAlt, :, iBlock) = 0.0
 
-        end do
-      end do
-    end do
+        enddo
+      enddo
+    enddo
 
     Rho(:, :, :, iBlock) = 0.0
     NDensity(:, :, :, iBlock) = 0.0
@@ -93,9 +93,9 @@ subroutine init_msis
       Rho(:, :, :, iBlock) = Rho(:, :, :, iBlock) + &
                              Mass(iSpecies)*NDensityS(:, :, :, iSpecies, iBlock)
 
-    end do
+    enddo
 
-  end do
+  enddo
 
 end subroutine init_msis
 

--- a/src/init_msis.Mars.f90
+++ b/src/init_msis.Mars.f90
@@ -31,7 +31,7 @@ subroutine get_msis_temperature(lon, lat, alt, t, h)
 ! do while (alt >= newalt(i))
   do while ((alt >= newalt(i)) .and. (i <= nAlts + 2))
     i = i + 1
-  end do
+  enddo
   i = i - 1
 
   t = InTemp(i)
@@ -88,9 +88,9 @@ subroutine init_msis
         klon = nint((longitude(ilon, iblock)*180.0/pi + 5.0)/10.0)
         SurfaceAlbedo(ilon, ilat, iblock) = dummyalbedo(jlat, klon)
         tinertia(ilon, ilat, iblock) = dummyti(jlat, klon)
-      end do
-    end do
-  end do
+      enddo
+    enddo
+  enddo
 
   if (useDustDistribution) call read_dust
 
@@ -115,7 +115,7 @@ subroutine init_msis
     do while (.not. Done)
       read(iInputUnit_, *) cLine
       if (cline .eq. '#START') Done = .True.
-    end do
+    enddo
 
     Done = .False.
     ialt = 1
@@ -128,11 +128,11 @@ subroutine init_msis
         initialAlt(ialt) = inDensities(1)
         !Convert to m^-3
         initialEDensity(ialt) = inDensities(9)*1.0e6
-      end if
+      endif
 
       iAlt = iAlt + 1
 
-    end do
+    enddo
     close(iInputUnit_)
 
     LogInitialDensity = log10(InitialEDensity)
@@ -179,11 +179,11 @@ subroutine init_msis
                                           LogInitialDensity(ialtlow(1)))*invAltDiff
               LogElectronDensity = LogInitialDensity(ialtlow(1) + 1) - ralt
 
-            end if
-          end if
+            endif
+          endif
           IDensityS(iLon, iLat, iialt, iE_, iBlock) = 10**LogElectronDensity
 
-        end do
+        enddo
 
         where (IDensityS(iLon, iLat, :, iE_, iBlock) .lt. 1.0) IDensityS(iLon, iLat, :, iE_, iBlock) = 1.0
 
@@ -228,10 +228,10 @@ subroutine init_msis
               ralt = (althigh - altFind)*(InTemp(ialtlow(1) + 1) - inTemp(ialtlow(1)))* &
                      invAltDiff
               Temperature(iLon, iLat, iAlt, iBlock) = InTemp(ialtlow(1)) - ralt
-            end if
-          end if
+            endif
+          endif
 
-        end do
+        enddo
 
         !           NDensityS(iLon,iLat,-1:nAlts + 2,1:nSpeciesTotal,iBlock) =  1.0
 
@@ -281,8 +281,8 @@ subroutine init_msis
         ! End ion loop
         !/
 
-      end do! end iLon loop
-    end do ! end iLat loop
+      enddo! end iLon loop
+    enddo ! end iLat loop
 
 !  Initialization of Major Ions for Ion Calculation
     IDensityS(:, :, :, iO2P_, iBlock) = 0.9*IDensityS(:, :, :, iE_, iBlock)
@@ -346,25 +346,25 @@ subroutine init_msis
             NDensity(iLon, iLat, iAlt, iBlock) = &
               NDensity(iLon, iLat, iAlt, iBlock) + &
               NDensityS(iLon, iLat, iAlt, iSpecies, iBlock)
-          end do
+          enddo
 
           do iSpecies = 1, nSpeciesTotal
             MeanMajorMass(iLon, iLat, iAlt) = &
               MeanMajorMass(iLon, iLat, iAlt) + &
               Mass(iSpecies)*NDensityS(iLon, iLat, iAlt, iSpecies, iBlock)/ &
               NDensity(iLon, iLat, iAlt, iBlock)
-          end do
+          enddo
 
           do iIon = 1, nIons - 1
             MeanIonMass(iLon, iLat, iAlt) = &
               MeanIonMass(iLon, iLat, iAlt) + &
               MassI(iIon)*IDensityS(iLon, iLat, iAlt, iIon, iBlock)/ &
               IDensityS(iLon, iLat, iAlt, ie_, iBlock)
-          end do
+          enddo
 
-        end do
-      end do
-    end do
+        enddo
+      enddo
+    enddo
 
     TempUnit(-1:nLons + 2, -1:nLats + 2, -1:nAlts + 2) = &
       MeanMajorMass(-1:nLons + 2, -1:nLats + 2, -1:nAlts + 2)/ &
@@ -396,7 +396,7 @@ subroutine init_msis
 
     call calc_electron_temperature(iBlock)
 
-  end do
+  enddo
 
 end subroutine init_msis
 
@@ -437,9 +437,9 @@ subroutine read_dust
         write(*, *) "Error reading Dust file"
         write(*, *) "Does this file exist?"
         call stop_GITM("In init_msis_Mars")
-      end if
+      endif
       if (cline(1:6) .eq. '#START') notstarted = 0
-    end do
+    enddo
 
     read(iInputUnit_, *, iostat=iError) DustLatitude
 
@@ -483,15 +483,15 @@ subroutine read_dust
                                         TempDust(ilatlow(1)))*invLatDiff
             Dust = TempDust(ilatlow(1) + 1) - rlat
 
-          end if
-        end if
+          endif
+        endif
         HorizontalDustProfile(iline, iLat, iblock) = Dust
 
-      end do
+      enddo
 
       iline = iline + 1
 
-    end do
+    enddo
 
     nDustTimes = iline - 1
     where (TempDust .lt. 0.2)
@@ -508,9 +508,9 @@ subroutine read_dust
         write(*, *) "Error reading Conrath file"
         write(*, *) "Does this file exist?"
         call stop_GITM("In init_msis_Mars")
-      end if
+      endif
       if (cline(1:6) .eq. '#START') notstarted = 0
-    end do
+    enddo
 
     read(iInputUnit_, *, iostat=iError) DustLatitude
 
@@ -556,17 +556,17 @@ subroutine read_dust
                                         TempConrath(ilatlow(1)))*invLatDiff
             Conrath = TempConrath(ilatlow(1) + 1) - rlat
 
-          end if
-        end if
+          endif
+        endif
         HorizontalConrathProfile(iline, iLat, iblock) = Conrath
 
-      end do
+      enddo
 
       iline = iline + 1
 
-    end do
+    enddo
     close(iInputUnit_)
-  end do
+  enddo
 
   nConrathTimes = iline - 1
 

--- a/src/init_msis.Titan.f90
+++ b/src/init_msis.Titan.f90
@@ -22,7 +22,7 @@ subroutine get_msis_temperature(lon, lat, alt, t, h)
   i = 1
   do while ((alt >= newalt(i)) .and. (i <= nAlts + 2))
     i = i + 1
-  end do
+  enddo
   i = i - 1
 
   TempBase = 175.0
@@ -144,10 +144,10 @@ subroutine init_msis
     MinorMixing(iN2_) = 1.0
     do iSpecies = 2, nSpecies
       MinorMixing(iN2_) = MinorMixing(iN2_) - MinorMixing(iSpecies)
-    end do
+    enddo
   else
     MinorMixing(1) = 1.0
-  end if
+  endif
   MinorMixing(i15N2_) = (2.0/167.7)*MinorMixing(iN2_)
 
   ! Just do this once, since nBlocks = 1 most of the time
@@ -156,7 +156,7 @@ subroutine init_msis
   do iSpecies = 1, nSpecies
     MeanMass0 = MeanMass0 + &
                 Mass(iSpecies)*MinorMixing(iSpecies)
-  end do
+  enddo
 
   TempBase = 175.0
 
@@ -186,7 +186,7 @@ subroutine init_msis
           !            iAlt, Altitude_GB(iLon,iLat,iAlt,iBlock), &
           !            RadialDistance_GB(iLon,iLat,iAlt,iBlock), &
           !                  Temperature(iLon,iLat,iAlt,iBlock)
-        end do
+        enddo
 
         ! do iAlt = -1, nAlts + 2
         !   write(*,*) 'iAlt, Gravity = ',iAlt, Gravity_GB(iLon,iLat,iAlt,iBlock)
@@ -204,9 +204,9 @@ subroutine init_msis
         ITemperature(iLon, iLat, -1:nAlts + 2, iBlock) = &
           Temperature(iLon, iLat, -1:nAlts + 2, iBlock)
 
-      end do !iLon = -1, nLons + 2
-    end do !iLat = -1, nLats + 2
-  end do !iBlock = 1, nBlocks
+      enddo !iLon = -1, nLons + 2
+    enddo !iLat = -1, nLats + 2
+  enddo !iBlock = 1, nBlocks
 
 !!! Next, Integrate upward from the -1 Cell
   do iBlock = 1, nBlocks
@@ -221,7 +221,7 @@ subroutine init_msis
           MeanMajorMass(iLon, iLat, iAlt) = &
             MeanMajorMass(iLon, iLat, iAlt) + &
             Mass(iSpecies)*MinorMixing(iSpecies)
-        end do
+        enddo
         !write(*,*) 'iAlt, MeanMass = ', MeanMajorMass(iLat,iLon,iAlt)/AMU
 
         NDensity(iLon, iLat, iAlt, iBlock) = DensityScaleFactor(iLon, iLat)*CIRSDensityValue
@@ -244,16 +244,16 @@ subroutine init_msis
             InvDij = InvDij + &
                      NDensityS(iLon, iLat, iAlt, jSpecies, iBlock)/ &
                      (NDensity(iLon, iLat, iAlt, iBlock)*TempDij)
-          end do !jSpecies = 1, nSpecies
+          enddo !jSpecies = 1, nSpecies
           MeanDs(iSpecies) = 1.0/InvDij
           MeanLambda(iSpecies) = MeanKE/MeanDs(iSpecies)
-        end do !iSpecies = 1, nSpecies
+        enddo !iSpecies = 1, nSpecies
 
 !!! Add the Centrifugal Forces to the Gravity
 
         do iAlt = -1, nAlts + 2
           EffectiveGravity(iAlt) = Gravity_GB(iLon, iLat, iAlt, iBlock)
-        end do
+        enddo
 
         ! write(*,*) 'INIT_MSIS:  NDENSITY LOOP:'
         do iAlt = 0, nAlts + 2
@@ -266,7 +266,7 @@ subroutine init_msis
             MeanMass = MeanMass + &
                        NDensityS(iLon, iLat, iAlt - 1, iSpecies, iBlock)*Mass(iSpecies)/ &
                        NDensity(iLon, iLat, iAlt - 1, iBlock)
-          end do
+          enddo
 
           InvHa = MeanMass*MeanGravity/(MeanTemp*Boltzmanns_Constant)
 
@@ -282,7 +282,7 @@ subroutine init_msis
 
             NDensity(iLon, iLat, iAlt, iBlock) = &
               NDensity(iLon, iLat, iAlt, iBlock) + NDensityS(iLon, iLat, iAlt, iSpecies, iBlock)
-          end do    !iSpecies
+          enddo    !iSpecies
 
           MeanKE = EddyDiffusionCoef* &
                    (NDensity(iLon, iLat, -1, iBlock)/NDensity(iLon, iLat, iAlt, iBlock))**0.50
@@ -302,13 +302,13 @@ subroutine init_msis
                        NDensityS(iLon, iLat, iAlt, jSpecies, iBlock)/ &
                        (NDensity(iLon, iLat, iAlt, iBlock)*TempDij)
 
-            end do !jSpecies = 1, nSpecies
+            enddo !jSpecies = 1, nSpecies
 
             MeanDs(iSpecies) = 1.0/InvDij
 
             MeanLambda(iSpecies) = MeanKE/MeanDs(iSpecies)
 
-          end do !iSpecies = 1, nSpecies
+          enddo !iSpecies = 1, nSpecies
 
           MeanMajorMass(iLon, iLat, iAlt) = 0.0
           do iSpecies = 1, nSpecies
@@ -316,13 +316,13 @@ subroutine init_msis
               MeanMajorMass(iLon, iLat, iAlt) + &
               NDensityS(iLon, iLat, iAlt, iSpecies, iBlock)*Mass(iSpecies)/ &
               NDensity(iLon, iLat, iAlt, iBlock)
-          end do
+          enddo
 
           !write(*,*) 'iAlt, Altitude_GB',iAlt, Altitude_GB(iLon,iLat,iAlt,iBlock)
-        end do  !iAlt
-      end do   ! Lats
-    end do    ! Lons
-  end do    ! Blocks
+        enddo  !iAlt
+      enddo   ! Lats
+    enddo    ! Lons
+  enddo    ! Blocks
 
 !!! Set all of the very minor species to fixed mixing ratios (initially)
   do iBlock = 1, nBlocks
@@ -332,18 +332,18 @@ subroutine init_msis
           do iSpecies = nSpecies + 1, nSpeciesTotal
             NDensityS(iLon, iLat, iAlt, iSpecies, iBlock) = &
               max(1.0e+01, NDensity(iLon, iLat, iAlt, iBlock)*MinorMixing(iSpecies))
-          end do !iSpecies
-        end do  !iAlt
-      end do   ! Lats
-    end do    ! Lons
-  end do    ! Blocks
+          enddo !iSpecies
+        enddo  !iAlt
+      enddo   ! Lats
+    enddo    ! Lons
+  enddo    ! Blocks
 
   do iBlock = 1, nBlocks
     Rho(-1:nLons + 2, -1:nLats + 2, -1:nAlts + 2, iBlock) = &
       MeanMajorMass(-1:nLons + 2, -1:nLats + 2, -1:nAlts + 2)* &
       NDensity(-1:nLons + 2, -1:nLats + 2, -1:nAlts + 2, iBlock)
 
-  end do
+  enddo
 
 !!!!!! Input a Frozen HCN as our initial Settings
 !
@@ -363,14 +363,14 @@ subroutine init_msis
           do iIon = 1, nIons - 1
             IDensityS(iLon, iLat, iAlt, iIon, iBlock) = &
               1.0
-          end do
+          enddo
           IDensityS(iLon, iLat, iAlt, ie_, iBlock) = &
             nIons - 1
 
-        end do
-      end do
-    end do
-  end do
+        enddo
+      enddo
+    enddo
+  enddo
 
 !iBlock = 1
 !        do iAlt = -1, nAlts + 2
@@ -426,8 +426,8 @@ subroutine calc_densityscaling(iBlock, T0, MeanMass, DenScaling)
             (cos(Longitude(iLon, iBlock))**2.0)* &
             (sin(Latitude(iLat, iBlock))**2.0)))
 
-    end do !iLon = -1, nLons+2
-  end do !iLat = -1, nLats+2
+    enddo !iLon = -1, nLons+2
+  enddo !iLat = -1, nLats+2
 
 end subroutine calc_densityscaling
 

--- a/src/init_msis.Venus.f90
+++ b/src/init_msis.Venus.f90
@@ -32,7 +32,7 @@ subroutine get_msis_temperature(lon, lat, alt, t, h)
 ! do while (alt >= newalt(i))
   do while ((alt >= newalt(i)) .and. (i <= nAlts + 2))
     i = i + 1
-  end do
+  enddo
   i = i - 1
 
   t = InTemp(i)
@@ -94,9 +94,9 @@ subroutine init_msis
         klon = nint((longitude(ilon, iblock)*180.0/pi + 5.0)/10.0)
         SurfaceAlbedo(ilon, ilat, iblock) = dummyalbedo(jlat, klon)
         tinertia(ilon, ilat, iblock) = dummyti(jlat, klon)
-      end do
-    end do
-  end do
+      enddo
+    enddo
+  enddo
 
   if (useDustDistribution) call read_dust
 
@@ -121,7 +121,7 @@ subroutine init_msis
     do while (.not. Done)
       read(iInputUnit_, *) cLine
       if (cline .eq. '#START') Done = .True.
-    end do
+    enddo
 
     Done = .False.
     ialt = 1
@@ -134,11 +134,11 @@ subroutine init_msis
         initialAlt(ialt) = inDensities(1)
         !Convert to m^-3
         initialEDensity(ialt) = inDensities(9)*1.0e6
-      end if
+      endif
 
       iAlt = iAlt + 1
 
-    end do
+    enddo
     close(iInputUnit_)
 
     LogInitialDensity = log10(InitialEDensity)
@@ -185,11 +185,11 @@ subroutine init_msis
                                           LogInitialDensity(ialtlow(1)))*invAltDiff
               LogElectronDensity = LogInitialDensity(ialtlow(1) + 1) - ralt
 
-            end if
-          end if
+            endif
+          endif
           IDensityS(iLon, iLat, iialt, iE_, iBlock) = 10**LogElectronDensity
 
-        end do
+        enddo
 
         where (IDensityS(iLon, iLat, :, iE_, iBlock) .lt. 1.0) IDensityS(iLon, iLat, :, iE_, iBlock) = 1.0
 
@@ -234,10 +234,10 @@ subroutine init_msis
               ralt = (althigh - altFind)*(InTemp(ialtlow(1) + 1) - inTemp(ialtlow(1)))* &
                      invAltDiff
               Temperature(iLon, iLat, iAlt, iBlock) = InTemp(ialtlow(1)) - ralt
-            end if
-          end if
+            endif
+          endif
 
-        end do
+        enddo
 
         !           NDensityS(iLon,iLat,-1:nAlts + 2,1:nSpeciesTotal,iBlock) =  1.0
 
@@ -287,8 +287,8 @@ subroutine init_msis
         ! End ion loop
         !/
 
-      end do! end iLon loop
-    end do ! end iLat loop
+      enddo! end iLon loop
+    enddo ! end iLat loop
 
 !  Initialization of Major Ions for Ion Calculation
     IDensityS(:, :, :, iO2P_, iBlock) = 0.9*IDensityS(:, :, :, iE_, iBlock)
@@ -356,25 +356,25 @@ subroutine init_msis
             NDensity(iLon, iLat, iAlt, iBlock) = &
               NDensity(iLon, iLat, iAlt, iBlock) + &
               NDensityS(iLon, iLat, iAlt, iSpecies, iBlock)
-          end do
+          enddo
 
           do iSpecies = 1, nSpeciesTotal
             MeanMajorMass(iLon, iLat, iAlt) = &
               MeanMajorMass(iLon, iLat, iAlt) + &
               Mass(iSpecies)*NDensityS(iLon, iLat, iAlt, iSpecies, iBlock)/ &
               NDensity(iLon, iLat, iAlt, iBlock)
-          end do
+          enddo
 
           do iIon = 1, nIons - 1
             MeanIonMass(iLon, iLat, iAlt) = &
               MeanIonMass(iLon, iLat, iAlt) + &
               MassI(iIon)*IDensityS(iLon, iLat, iAlt, iIon, iBlock)/ &
               IDensityS(iLon, iLat, iAlt, ie_, iBlock)
-          end do
+          enddo
 
-        end do
-      end do
-    end do
+        enddo
+      enddo
+    enddo
 
     TempUnit(-1:nLons + 2, -1:nLats + 2, -1:nAlts + 2) = &
       MeanMajorMass(-1:nLons + 2, -1:nLats + 2, -1:nAlts + 2)/ &
@@ -410,7 +410,7 @@ subroutine init_msis
     !  write(*,*) IDensityS(:,:,:,ie_,iBlock)
     !endif
 
-  end do
+  enddo
 
 end subroutine init_msis
 
@@ -443,7 +443,7 @@ subroutine read_dust
   call readDustHeader
   do iBlock = 1, nBlocks
     call setTau(iBlock)
-  end do
+  enddo
 
   call cleanDust
 
@@ -465,10 +465,10 @@ subroutine readDustHeader
       write(*, *) "Error reading Dust file"
       write(*, *) "Is the header missing?"
       call stop_GITM("In init_msis_Mars")
-    end if
+    endif
     if (cline(1:7) .eq. '#HEADER') notstarted = .False.
 
-  end do
+  enddo
 
   if (DustFileType .eq. "FullHorizontal") then
     read(iInputUnit_, *, iostat=iError) nDustLats
@@ -488,7 +488,7 @@ subroutine readDustHeader
     nDustLons = 1
 
     allocate(DustLatitude(nDustLats))
-  end if
+  endif
 
   close(iInputUnit_)
 
@@ -520,7 +520,7 @@ subroutine setTau(iBlock)
   do while (notstarted)
     read(iInputUnit_, *, iostat=iError) cLine
     if (cline(1:6) .eq. '#START') notstarted = .False.
-  end do
+  enddo
 
   if (DustFileType .eq. "FullHorizontal") then
 
@@ -529,14 +529,14 @@ subroutine setTau(iBlock)
       read(iInputUnit_, *, iostat=iError) TimeArray(1:6), Temp
       if (iproc .eq. 0) then
         write(*, *) TimeArray(1:6)
-      end if
+      endif
       i = 1
       do iLat = 1, ndustlats
         do iLon = 1, ndustlons
           TempDust(iLat, iLon) = Temp(i)
           i = i + 1
-        end do
-      end do
+        enddo
+      enddo
       TimeArray(7) = 0
       call time_int_to_real(TimeArray, TimeDust(iLine))
 
@@ -571,7 +571,7 @@ subroutine setTau(iBlock)
             write(*, *) 'Dust grid does not cover GITM grid'
             write(*, *) 'Stopping...'
             call stop_gitm('Stopping in init_msis.Mars')
-          end if
+          endif
 
           V11 = TempDust(ilatlow(1), ilonlow(1))
           V12 = TempDust(ilatlow(1) + 1, ilonlow(1))
@@ -593,11 +593,11 @@ subroutine setTau(iBlock)
 !           endif
           HorizontalDustProfile(iline, iLat, iLon, iblock) = Dust
 
-        end do
-      end do
+        enddo
+      enddo
       iline = iline + 1
 
-    end do
+    enddo
     nDustTimes = iline - 1
 
     nConrathTimes = nDustTimes
@@ -613,19 +613,19 @@ subroutine setTau(iBlock)
           if (iError .ne. 0) then
             write(*, *) "Error reading dustfile"
             call stop_gitm('Stopping in init_msis.Mars')
-          end if
+          endif
           DustPressureLevel(iAlt) = MCSTemp(3)
           CumulativeTau(iTime, iLat, iAlt) = MCSTemp(4)
           DustMixingRatio(iTime, iLat, iAlt) = MCSTemp(5)
 
-        end do
+        enddo
         DustLatitude(iLat) = MCSTemp(1)
-      end do
+      enddo
 
       TimeArray(7) = 0
       call time_int_to_real(TimeArray, rTime)
       TimeDust(iTime) = rtime
-    end do
+    enddo
 
     do iLat = 1, nLats
       latFind = Latitude(ilat, iBlock)*180/pi
@@ -670,10 +670,10 @@ subroutine setTau(iBlock)
           (Lathigh - LatFind)*0.999*invLatDiff* &
           (DustMixingRatio(1:nDustTimes, ilatlow(1) + 1, 1:nDustAlts) - &
            DustMixingRatio(1:nDustTimes, ilatlow(1), 1:nDustAlts))
-      end if
+      endif
 
-    end do
-  end if
+    enddo
+  endif
 
   close(iInputUnit_)
 
@@ -733,9 +733,9 @@ subroutine cleanDust
 
   if (allocated(DustLatitude)) then
     deallocate(DustLatitude)
-  end if
+  endif
   if (allocated(DustLongitude)) then
     deallocate(DustLongitude)
-  end if
+  endif
 
 end subroutine cleanDust

--- a/src/initialize.f90
+++ b/src/initialize.f90
@@ -39,7 +39,7 @@ subroutine initialize_gitm(TimeIn)
 
   if (.not. (index(cPlanet, "Titan") == 0)) then
     call init_radcooling
-  end if
+  endif
 
   if (.not. IsFirstTime) return
 
@@ -56,7 +56,7 @@ subroutine initialize_gitm(TimeIn)
     CurrentTime = TimeIn
     call time_real_to_int(CurrentTime, iTimeArray)
     call fix_vernal_time
-  end if
+  endif
 
   call get_f107(CurrentTime, f107, iError)
   call get_f107a(CurrentTime, f107a, iError)
@@ -69,7 +69,7 @@ subroutine initialize_gitm(TimeIn)
     call read_restart(restartInDir)
     call init_msis
 !     if (UsePerturbation) call user_create_perturbation
-  end if
+  endif
 
   call set_RrTempInd
 
@@ -77,7 +77,7 @@ subroutine initialize_gitm(TimeIn)
   if (IsThere .and. iProc == 0) then
     open(iOutputUnit_, file='GITM.STOP', status='OLD')
     close(iOutputUnit_, status='DELETE')
-  end if
+  endif
 
   !\
   ! Initialize the EUV wave spectrum
@@ -97,7 +97,7 @@ subroutine initialize_gitm(TimeIn)
           write(*, *) 'When using topography, the minimum altitude'
           write(*, *) 'must be zero.  Stopping...'
           call stop_gitm('Incorrect minimum altitude')
-        end if
+        endif
         altzero = 0.0
         call init_topography
 
@@ -116,29 +116,29 @@ subroutine initialize_gitm(TimeIn)
                 dAlt = (AltMinUniform - AltZero(iiLon, iiLat, iBlock))/nAltsmean
                 Altitude_GB(iLon, iLat, iAlt, iBlock) = &
                   AltZero(iiLon, iiLat, iBlock) + ialt*dAlt
-              end do
+              enddo
 
-            end do
-          end do
+            enddo
+          enddo
 
           dAlt = (AltMax - AltMinUniform)/(nAlts - naltsmean)
 
           do iAlt = 1, (nAlts + 2) - naltsmean
             Altitude_GB(:, :, iAlt + naltsmean, 1:nBlocks) = &
               AltMinUniform + iAlt*dAlt
-          end do
-        end do
+          enddo
+        enddo
 
       else
         ! Uniform grid
         do iAlt = -1, nAlts + 2
           Altitude_GB(:, :, iAlt, 1:nBlocks) = &
             AltMin + (iAlt - 0.5)*(AltMax - AltMin)/nAlts
-        end do
-      end if
+        enddo
+      endif
 
-    end if
-  end if
+    endif
+  endif
 
   ! Calculate vertical cell sizes
   do iAlt = 0, nAlts + 1
@@ -148,7 +148,7 @@ subroutine initialize_gitm(TimeIn)
     dAlt_GB(:, :, iAlt, 1:nBlocks) = 0.5* &
                                      (Altitude_GB(:, :, iAlt + 1, 1:nBlocks) &
                                       - Altitude_GB(:, :, iAlt - 1, 1:nBlocks))
-  end do
+  enddo
   dAlt_GB(:, :, -1, 1:nBlocks) = dAlt_GB(:, :, 0, 1:nBlocks)
   dAlt_GB(:, :, nAlts + 2, 1:nBlocks) = dAlt_GB(:, :, nAlts + 1, 1:nBlocks)
 
@@ -162,16 +162,16 @@ subroutine initialize_gitm(TimeIn)
     do iAlt = 1, nAlts
       Gravity_GB(:, :, iAlt, :) = -Gravitational_Constant &
                                   *(rBody/RadialDistance_GB(:, :, iAlt, :))**2
-    end do
-  end if
+    enddo
+  endif
 
   if (iDebugLevel > 2) then
     do iAlt = -1, nAlts + 2
       write(*, *) "===>Altitude : ", &
         iAlt, Altitude_GB(1, 1, iAlt, 1), RadialDistance_GB(1, 1, iAlt, 1), &
         Gravity_GB(1, 1, iAlt, 1)
-    end do
-  end if
+    enddo
+  endif
 
   if (Is1D) then
     Latitude(0, 1) = Latitude(1, 1) - 1.0*pi/180.0
@@ -183,7 +183,7 @@ subroutine initialize_gitm(TimeIn)
     Longitude(-1, 1) = Longitude(0, 1) - 1.0*pi/180.0
     Longitude(2, 1) = Longitude(1, 1) + 1.0*pi/180.0
     Longitude(3, 1) = Longitude(2, 1) + 1.0*pi/180.0
-  end if
+  endif
 
   ! Precalculate the limited tangent and unlimited cosine of the latitude
   TanLatitude(:, 1:nBlocks) = min(abs(tan(Latitude(:, 1:nBlocks))), 100.0)* &
@@ -233,7 +233,7 @@ subroutine initialize_gitm(TimeIn)
             dLatDist_GB(iLon, iLat, iAlt, iBlock)* &
             dAlt_GB(iLon, iLat, iAlt, iBlock)
 
-        end do
+        enddo
 
         ! Fill in longitude ghost cells
         dLonDist_FB(-1, iLat, iAlt, iBlock) = &
@@ -244,7 +244,7 @@ subroutine initialize_gitm(TimeIn)
           dLatDist_FB(0, iLat, iAlt, iBlock)
         dLatDist_FB(nLons + 2, iLat, iAlt, iBlock) = &
           dLatDist_FB(nLons + 1, iLat, iAlt, iBlock)
-      end do
+      enddo
       ! Fill in latitude ghost cells
       dLonDist_FB(:, -1, iAlt, iBlock) = &
         dLonDist_FB(:, 0, iAlt, iBlock)
@@ -254,8 +254,8 @@ subroutine initialize_gitm(TimeIn)
         dLatDist_FB(:, 0, iAlt, iBlock)
       dLatDist_FB(:, nLats + 2, iAlt, iBlock) = &
         dLatDist_FB(:, nLats + 1, iAlt, iBlock)
-    end do
-  end do
+    enddo
+  enddo
 
   InvDLatDist_GB = 1.0/dLatDist_GB
   InvDLatDist_FB = 1.0/dLatDist_FB
@@ -273,7 +273,7 @@ subroutine initialize_gitm(TimeIn)
       GradLonP_CB(iLon, iBlock) = InvDenom*Ratio2
       GradLon0_CB(iLon, iBlock) = InvDenom*(1 - Ratio2)
       GradLonM_CB(iLon, iBlock) = -InvDenom
-    end do
+    enddo
 
     do iLat = 1, nLats
       DistM = Latitude(iLat, iBlock) - Latitude(iLat - 1, iBlock)
@@ -284,8 +284,8 @@ subroutine initialize_gitm(TimeIn)
       GradLatP_CB(iLat, iBlock) = InvDenom*Ratio2
       GradLat0_CB(iLat, iBlock) = InvDenom*(1 - Ratio2)
       GradLatM_CB(iLat, iBlock) = -InvDenom
-    end do
-  end do
+    enddo
+  enddo
 
   if (UseTopography) then
      !!! What about the maxi tricks ??? Why is that there???
@@ -293,11 +293,11 @@ subroutine initialize_gitm(TimeIn)
       call UAM_gradient(Altitude_GB, GradAlt_CD, iBlock)
       dAltDLon_CB(:, :, :, iBlock) = GradAlt_CD(:, :, :, iEast_)
       dAltDLat_CB(:, :, :, iBlock) = GradAlt_CD(:, :, :, iNorth_)
-    end do
+    enddo
   else
     dAltDLon_CB = 0.
     dAltDLat_CB = 0.
-  end if
+  endif
 
   call init_heating_efficiency
 
@@ -307,11 +307,11 @@ subroutine initialize_gitm(TimeIn)
     call init_magheat
     call init_isochem
     call init_aerosol
-  end if
+  endif
 
   if (.not. (index(cPlanet, "Mars") == 0)) then
     call init_isochem
-  end if
+  endif
 
   if (.not. DoRestart) then
 
@@ -335,7 +335,7 @@ subroutine initialize_gitm(TimeIn)
           Temperature(:, :, iAlt, iBlock) = t/TempUnit_const
           eTemperature(:, :, iAlt, iBlock) = t
           iTemperature(:, :, iAlt, iBlock) = t
-        end do
+        enddo
 
         do iAlt = -1, nAlts + 2
 
@@ -370,12 +370,12 @@ subroutine initialize_gitm(TimeIn)
                 - (Temperature(:, :, iAlt, iBlock) &
                    - Temperature(:, :, iAlt - 1, iBlock)) &
                 /(Temperature(:, :, iAlt, iBlock))
-            end if
+            endif
 
             NewSumRho = NewSumRho + &
                         Mass(iSpecies)*exp(LogNS(:, :, iAlt, iSpecies, iBlock))
 
-          end do
+          enddo
 
           do iSpecies = 1, nSpecies
 
@@ -388,13 +388,13 @@ subroutine initialize_gitm(TimeIn)
             Rho(:, :, iAlt, iBlock) = Rho(:, :, iAlt, iBlock) + &
                                       Mass(iSpecies)*NDensityS(:, :, iAlt, iSpecies, iBlock)
 
-          end do
+          enddo
 
-        end do
+        enddo
 
-      end do
+      enddo
 
-    end if
+    endif
 
     if (UseIRI .and. IsEarth) then
       call init_iri
@@ -405,27 +405,27 @@ subroutine initialize_gitm(TimeIn)
           IDensityS(:, :, :, ie_, iBlock) = 1.00e8*(nIons - 1)
           eTemperature(:, :, :, iBlock) = 500.0
           iTemperature(:, :, :, iBlock) = 500.0
-        end do
-      end if
-    end if
+        enddo
+      endif
+    endif
 
-  end if
+  endif
 
   if (UseWACCMTides) then
     call read_waccm_tides
     call update_waccm_tides
-  end if
+  endif
 
   if (UseGSWMTides) then
     call read_tides
     call update_tides
-  end if
+  endif
 
   if (UseHmeTides) then
     call init_hme
     call update_hme_tides
     call modify_initial_after_tides
-  end if
+  endif
 
   call init_b0
   if (IsEarth) call init_energy_deposition
@@ -435,7 +435,7 @@ subroutine initialize_gitm(TimeIn)
     call SUBSOLR(iTimeArray(1), iJulianDay, iTimeArray(4), &
                  iTimeArray(5), iTimeArray(6), SubsolarLatitude, &
                  SubsolarLongitude)
-  end if
+  endif
 
   if (.not. Is1D) call exchange_messages_sphere
 
@@ -448,7 +448,7 @@ subroutine initialize_gitm(TimeIn)
   do iBlock = 1, nBlocks
     call calc_eddy_diffusion_coefficient(iBlock)
     call calc_rates(iBlock)
-  end do
+  enddo
 
   call end_timing("initialize")
 

--- a/src/library.f90
+++ b/src/library.f90
@@ -19,7 +19,7 @@ subroutine report(str, iLevel)
 
   do i = 1, iLevel
     cArrow(i:i) = "="
-  end do
+  enddo
   cArrow(iLevel + 1:iLevel + 1) = ">"
 
   write(*, *) cArrow(1:iLevel + 1), " ", str
@@ -48,7 +48,7 @@ subroutine stop_gitm(str)
     write(*, *) 'Stopping execution! iProc=', iProc, ' with msg=', str
     call MPI_abort(iCommGITM, erno, ierror)
     stop
-  end if
+  endif
 
 end subroutine stop_gitm
 
@@ -67,12 +67,12 @@ subroutine i2s(iValue, cOut, iLength)
     write(cFormat, "('(I',I1,')')") iLength
   else
     write(cFormat, "('(I',I2,')')") iLength
-  end if
+  endif
 
   write(cOut, cFormat) iValue
 
   do i = 1, iLength
     if (cOut(i:i) == ' ') cOut(i:i) = '0'
-  end do
+  enddo
 
 end subroutine i2s

--- a/src/logfile.f90
+++ b/src/logfile.f90
@@ -71,11 +71,11 @@ subroutine get_log_info(SSLon, SSLat, GlobalMinTemp, GlobalMaxTemp, &
       AverageVertVel = AverageVertVel + &
                        sum(VerticalVelocity(1:nLons, 1:nLats, 1:nAlts, iSpecies, iBlock) &
                            *CellVolume(1:nLons, 1:nLats, 1:nAlts, iBlock))
-    end do
+    enddo
 
     TotalVolume = TotalVolume + &
                   sum(CellVolume(1:nLons, 1:nLats, 1:nAlts, iBlock))
-  end do
+  enddo
 
   call calc_single_vtec_interp(SSLon, SSLat, SSVTEC)
 
@@ -139,7 +139,7 @@ subroutine logfile(dir)
         cEUVFile
     else
       write(iLogFileUnit_, '(a,L2)') "# EUV Data: ", useEUVdata
-    end if
+    endif
     write(iLogFileUnit_, '(a,a15)') "# AMIE: ", cAmieFileNorth, cAmieFileSouth
     write(iLogFileUnit_, '(3(a,L2))') "# Solar Heating: ", useSolarHeating, &
       " Joule Heating: ", useJouleHeating, &
@@ -163,7 +163,7 @@ subroutine logfile(dir)
       "   iStep yyyy mm dd hh mm ss  ms      dt "// &
       "min(T) max(T) mean(T) min(VV) max(VV) mean(VV) F107 F107A "// &
       "By Bz Vx HP HPn HPs SubsolarLon SubsolarLat SubsolarVTEC"
-  end if
+  endif
 
   call get_subsolar(CurrentTime, VernalTime, SSLon, SSLat)
   call get_log_info(SSLon, SSLat, MinTemp, MaxTemp, MinVertVel, MaxVertVel, &
@@ -230,7 +230,7 @@ subroutine logfile(dir)
       HPs/1.0e9, SSLon, SSLat, SSVTEC
 
     call flush_unit(iLogFileUnit_)
-  end if
+  endif
 
 end subroutine logfile
 
@@ -268,13 +268,13 @@ subroutine write_code_information(dir)
     write(iCodeInfoFileUnit_, *) "nSpeciesTotal", nSpeciesTotal
     do i = 1, nSpeciesTotal
       write(iCodeInfoFileUnit_, *) "Mass of Species ", cSpecies(i), Mass(i)/AMU
-    end do
+    enddo
     write(iCodeInfoFileUnit_, *) ""
     write(iCodeInfoFileUnit_, *) "nIons", nIons
     write(iCodeInfoFileUnit_, *) "nIonsAdvect", nIonsAdvect
     do i = 1, nIons
       write(iCodeInfoFileUnit_, *) "Ion Species ", cIons(i)
-    end do
+    enddo
 
     write(iCodeInfoFileUnit_, *) ""
     write(iCodeInfoFileUnit_, *) "Inputs from UAM.in:"
@@ -404,7 +404,7 @@ subroutine write_code_information(dir)
     write(iCodeInfoFileUnit_, *) "#GSWMCOMP"
     do i = 1, 4
       write(iCodeInfoFileUnit_, *) UseGswmComp(i)
-    end do
+    enddo
     write(iCodeInfoFileUnit_, *) ""
 
     write(iCodeInfoFileUnit_, *) "#USEPERTURBATION"
@@ -554,6 +554,6 @@ subroutine write_code_information(dir)
 
     close(iCodeInfoFileUnit_)
 
-  end if
+  endif
 
 end subroutine write_code_information

--- a/src/main.f90
+++ b/src/main.f90
@@ -60,25 +60,25 @@ program GITM
       Dt = 2
     else
       Dt = FixedDt
-    end if
+    endif
 
     call calc_timestep_vertical
     if (.not. Is1D) call calc_timestep_horizontal
 
     if (RCMRFlag) then
       call run_RCMR
-    end if
+    endif
 
     call advance
 
     if (.not. IsFramework) then
       call check_stop
-    end if
+    endif
 
     iStep = iStep + 1
 
     call write_output
-  end do
+  enddo
 
   ! ------------------------------------------------------------------------
   ! Finish run

--- a/src/main_w_sami.f90
+++ b/src/main_w_sami.f90
@@ -80,7 +80,7 @@ program GITM
 
     if (taskid == 0) master_sami = iprocglob
 
-  end if
+  endif
 
   ! broadcast CurrentTime to global procs
   call mpi_bcast(EndTime, 1, MPI_REAL, 0, iCommGlobal, iError)
@@ -109,26 +109,26 @@ program GITM
           Dt = 2
         else
           Dt = FixedDt
-        end if
+        endif
 
         call calc_timestep_vertical
         if (.not. Is1D) call calc_timestep_horizontal
 
         if (RCMRFlag) then
           call run_RCMR
-        end if
+        endif
 
         call advance
 
         if (.not. IsFramework) then
           call check_stop
-        end if
+        endif
 
         iStep = iStep + 1
 
         call write_output
 
-      end do
+      enddo
 
     else if (iCommSAMI0 /= MPI_COMM_NULL) then
 
@@ -140,7 +140,7 @@ program GITM
 
           call Sami_run(IsValidTime, DtCouple)
 
-        end do
+        enddo
 
         if (taskid == 1) &
           print *, '---- SAMI3 completed one iter', (hrut - hrinit)*3600.0, nIter*DtCouple, IsValidTime, taskid
@@ -150,8 +150,8 @@ program GITM
                       iCommSami, iError)
         if (taskid == 1) &
           write(*, *) '---- Done with sending xxx !!!', taskid
-      end if
-    end if
+      endif
+    endif
 
     ! turn on coupling flags and exchange data
 
@@ -168,7 +168,7 @@ program GITM
 
       if (taskid > 0) IsCoupGITM = .true.
 
-    end if
+    endif
 
     call MPI_BARRIER(iCommGlobal, iError)
 
@@ -179,7 +179,7 @@ program GITM
     if (iCommSAMI0 /= MPI_COMM_NULL) then
       if (taskid > 0 .and. IsCoupGITM) &
         call init_coup
-    end if
+    endif
 
     call MPI_BARRIER(iCommGlobal, iError)
 
@@ -187,7 +187,7 @@ program GITM
 
     nIter = nIter + 1
 
-  end do !(end while gobal)
+  enddo !(end while gobal)
 
   ! ------------------------------------------------------------------------
   ! Finish run

--- a/src/output_common.f90
+++ b/src/output_common.f90
@@ -46,16 +46,16 @@ integer function bad_outputtype()
       if (index(OutputType(iOutputType), NameValidTypes(j)) /= 0) then
         IsFound = .true.
         exit strloop
-      end if
-    end do strloop
+      endif
+    enddo strloop
 
     ! If not found, set error code and return:
     if (.not. IsFound) then
       bad_outputtype = iOutputType
       return
-    end if
+    endif
 
-  end do
+  enddo
 
   bad_outputtype = 0
   return
@@ -112,15 +112,15 @@ subroutine output(dir, iBlock, iOutputType)
     cType = OutputType(iOutputType)
     if (cType(1:2) == "3D" .and. Is1D) then
       cType(1:2) = "1D"
-    end if
-  end if
+    endif
+  endif
 
   if (Is1D) then
     iiLat = 1
     iiLon = 1
     rLon = 1.0
     rLat = 1.0
-  end if
+  endif
 
   ! If there are satellites, initialize the current satellite so that
   ! the maximum from all processors will contain the real value.  This is
@@ -129,7 +129,7 @@ subroutine output(dir, iBlock, iOutputType)
 
   if (CurrSat > 0 .and. RCMRFlag) then
     SatAltDat(CurrSat) = -1.0e32
-  end if
+  endif
 
   if (iOutputType <= -1) then
     LatFind = CurrentSatellitePosition(iNorth_)
@@ -141,17 +141,17 @@ subroutine output(dir, iBlock, iOutputType)
       call BlockAltIndex(AltFind, iBlock, iiLon, iiLat, iiAlt, rAlt)
 
       if (iiAlt < 0) return
-    end if
+    endif
 
     if (iDebugLevel > 2) then
       write(*, *) 'For BlockLocationIndex:'
       write(*, *) 'LonFind, LatFind = ', LonFind, LatFind
       write(*, *) 'Found iBlock, iiLon, iiLat, rLon, rLat =', &
         iBlock, iiLon, iiLat, rLon, rLat
-    end if
+    endif
 
     if (iiLon < 0 .or. iiLat < 0) return
-  end if
+  endif
 
   ! Xing Meng 2020-03-16: HIME type output, save output for user-defined region only
   ! It only works under the assumption of one block per processor
@@ -167,13 +167,13 @@ subroutine output(dir, iBlock, iOutputType)
             .and. Latitude(iLat, iBlock) <= HIMEPlotLatEnd*pi/180.) then
           DoSaveHIMEPlot = .true.
           EXIT
-        end if
-      end do
-    end do
+        endif
+      enddo
+    enddo
     ! Do not write output at all if the current block is outside of the
     ! user-defined region. iProc=0 writes the header file
     if (iProc /= 0 .and. .not. DoSaveHIMEPlot) return
-  end if
+  endif
 
   if ((iProc == 0 .and. iBlock == 1) .and. (iOutputType > -1)) &
     write(*, '(a,i7,i5,5i3)') &
@@ -223,12 +223,12 @@ subroutine output(dir, iBlock, iOutputType)
     else
       cTime = "t"//cYear//cMonth//cDay//"_"//cHour//cMinute//cSecond
       cL = 14
-    end if
+    endif
 
     if (IsFirstTime) cTimeSave = cTime
   else
     cTime = cTimeSave
-  end if
+  endif
 
   !! ---------------------------------------------
   !! Write the binary data files
@@ -245,7 +245,7 @@ subroutine output(dir, iBlock, iOutputType)
       open(unit=iOutputUnit_, form="unformatted", &
            file=trim(dir)//"/"//trim(CurrentSatelliteName)//"_"//cTime(1:cL)//".sat", &
            status="unknown", position='append')
-    end if
+    endif
   else
     ! For HME type output, open file only if DoSaveHIMEPlot=T. This is for iProc=0,
     ! because other iProcs with DoSaveHIMEPlot=F exit the subroutine earlier.
@@ -261,9 +261,9 @@ subroutine output(dir, iBlock, iOutputType)
         open(unit=iOutputUnit_, form="unformatted", &
              file=trim(dir)//"/"//cType//"_"//cTime(1:cL)//"."//cBlock, &
              status="unknown", position='append')
-      end if
-    end if
-  end if
+      endif
+    endif
+  endif
 
   nGCs = 2
 
@@ -280,19 +280,19 @@ subroutine output(dir, iBlock, iOutputType)
     if (iRhoOutputList) nvars_to_write = nvars_to_write + 1
     do iSpecies = 1, nSpeciesTotal
       if (iNeutralDensityOutputList(iSpecies)) nvars_to_write = nvars_to_write + 1
-    end do
+    enddo
     do i = 1, 3
       if (iNeutralWindOutputList(i)) nvars_to_write = nvars_to_write + 1
-    end do
+    enddo
     do iSpecies = 1, nIons
       if (iIonDensityOutputList(iSpecies)) nvars_to_write = nvars_to_write + 1
-    end do
+    enddo
     do i = 1, 3
       if (iIonWindOutputList(i)) nvars_to_write = nvars_to_write + 1
-    end do
+    enddo
     do i = 1, 3
       if (iTemperatureOutputList(i)) nvars_to_write = nvars_to_write + 1
-    end do
+    enddo
 
     call output_3dlst(iBlock)
 
@@ -439,7 +439,7 @@ subroutine output(dir, iBlock, iOutputType)
         open(unit=iOutputUnit_, &
              file=trim(dir)//"/"//trim(CurrentSatelliteName)//"_"//cTime(1:cL)//".header", &
              status="unknown", position='append')
-      end if
+      endif
     else
       inquire(file=trim(dir)//"/"//cType//"_"//cTime(1:cL)//".header", &
               EXIST=IsThere)
@@ -451,8 +451,8 @@ subroutine output(dir, iBlock, iOutputType)
         open(unit=iOutputUnit_, &
              file=trim(dir)//"/"//cType//"_"//cTime(1:cL)//".header", &
              status="unknown", position='append')
-      end if
-    end if
+      endif
+    endif
 
     call write_head_blocks
     call write_head_time
@@ -464,7 +464,7 @@ subroutine output(dir, iBlock, iOutputType)
       call output_header_new
     else
       call output_header
-    end if
+    endif
 
     write(iOutputUnit_, *) ""
     write(iOutputUnit_, *) "END"
@@ -472,7 +472,7 @@ subroutine output(dir, iBlock, iOutputType)
 
     close(unit=iOutputUnit_)
 
-  end if
+  endif
 
   IsFirstTime = .false.
 
@@ -495,7 +495,7 @@ contains
       write(iOutputUnit_, "(I7,7A)") nAlts + 4, " nAltitudes"
     else
       write(iOutputUnit_, "(I7,7A)") 1, " nAltitudes"
-    end if
+    endif
     if (cType(1:2) == "1D" .or. cType(1:2) == '0D') then
       write(iOutputUnit_, "(I7,7A)") 1, " nLatitudes"
       write(iOutputUnit_, "(I7,7A)") 1, " nLongitudes"
@@ -517,8 +517,8 @@ contains
       else
         write(iOutputUnit_, "(I7,7A)") nLats + nGCs*2, " nLatitudes"
         write(iOutputUnit_, "(I7,7A)") nLons + nGCs*2, " nLongitudes"
-      end if
-    end if
+      endif
+    endif
     write(iOutputUnit_, *) ""
 
     write(iOutputUnit_, *) "VARIABLE LIST"
@@ -532,62 +532,62 @@ contains
       if (iRhoOutputList) then
         write(iOutputUnit_, "(I7,A1,a)") iOff, " ", "Rho (kg/m3)"
         iOff = iOff + 1
-      end if
+      endif
       do iSpecies = 1, nSpeciesTotal
         if (iNeutralDensityOutputList(iSpecies)) then
           write(iOutputUnit_, "(I7,A1,a)") iOff, " ", &
             "["//cSpecies(iSpecies)//"] (/m3)"
           iOff = iOff + 1
-        end if
-      end do
+        endif
+      enddo
       if (iNeutralWindOutputList(1)) then
         write(iOutputUnit_, "(I7,A1,a)") iOff, " ", "Vn (east) (m/s)"
         iOff = iOff + 1
-      end if
+      endif
       if (iNeutralWindOutputList(2)) then
         write(iOutputUnit_, "(I7,A1,a)") iOff, " ", "Vn (north) (m/s)"
         iOff = iOff + 1
-      end if
+      endif
       if (iNeutralWindOutputList(3)) then
         write(iOutputUnit_, "(I7,A1,a)") iOff, " ", "Vn (up) (m/s)"
         iOff = iOff + 1
-      end if
+      endif
 
       do iSpecies = 1, nIons
         if (iIonDensityOutputList(iSpecies)) then
           write(iOutputUnit_, "(I7,A1,a)") iOff, " ", &
             "["//cIons(iSpecies)//"] (/m3)"
           iOff = iOff + 1
-        end if
-      end do
+        endif
+      enddo
 
       if (iIonWindOutputList(1)) then
         write(iOutputUnit_, "(I7,A1,a)") iOff, " ", "Vi (east) (m/s)"
         iOff = iOff + 1
-      end if
+      endif
       if (iIonWindOutputList(2)) then
         write(iOutputUnit_, "(I7,A1,a)") iOff, " ", "Vi (north) (m/s)"
         iOff = iOff + 1
-      end if
+      endif
       if (iIonWindOutputList(3)) then
         write(iOutputUnit_, "(I7,A1,a)") iOff, " ", "Vi (up) (m/s)"
         iOff = iOff + 1
-      end if
+      endif
 
       if (iTemperatureOutputList(1)) then
         write(iOutputUnit_, "(I7,A1,a)") iOff, " ", "Neutral Temperature (K)"
         iOff = iOff + 1
-      end if
+      endif
       if (iTemperatureOutputList(2)) then
         write(iOutputUnit_, "(I7,A1,a)") iOff, " ", "Ion Temperature (K)"
         iOff = iOff + 1
-      end if
+      endif
       if (iTemperatureOutputList(3)) then
         write(iOutputUnit_, "(I7,A1,a)") iOff, " ", "Electron Temperature (K)"
         iOff = iOff + 1
-      end if
+      endif
 
-    end if
+    endif
 
     if (cType(3:5) == "MAG") then
       write(iOutputUnit_, "(I7,A1,a)") 4, " ", "Magnetic Latitude"
@@ -596,7 +596,7 @@ contains
       write(iOutputUnit_, "(I7,A1,a)") 7, " ", "B.F. North"
       write(iOutputUnit_, "(I7,A1,a)") 8, " ", "B.F. Vertical"
       write(iOutputUnit_, "(I7,A1,a)") 9, " ", "B.F. Magnitude"
-    end if
+    endif
 
     if (cType(3:5) == "GEL") then
 
@@ -611,7 +611,7 @@ contains
       write(iOutputUnit_, "(I7,A1,a)") 12, " ", "DivJu FL"
       write(iOutputUnit_, "(I7,A1,a)") 13, " ", "FL Length"
 
-    end if
+    endif
 
     if (cType(1:5) == "2DANC") then
 
@@ -628,14 +628,14 @@ contains
       write(iOutputUnit_, "(I7,A1,a)") 12, " ", "AltIntNOCooling (W/m2)"
       write(iOutputUnit_, "(I7,A1,a)") 12, " ", "AltIntOCooling (W/m2)"
 
-    end if
+    endif
 
     if (cType(3:5) == "TEC") then
 
       write(iOutputUnit_, "(I7,A1,a)") 4, " ", "Solar Zenith Angle"
       write(iOutputUnit_, "(I7,A1,a)") 5, " ", "Vertical TEC"
 
-    end if
+    endif
 
     if (cType(3:5) == "THM") then
 
@@ -654,20 +654,20 @@ contains
         do iSpecies = 1, nSpeciesTotal
           write(iOutputUnit_, "(I7,A1,a,a)") 11 + iSpecies, " ", &
             "Production Rate ", cSpecies(iSpecies)
-        end do
+        enddo
         do iSpecies = 1, nSpeciesTotal
           write(iOutputUnit_, "(I7,A1,a,a)") 11 + nSpeciesTotal + iSpecies, " ", &
             "Loss Rate ", cSpecies(iSpecies)
 
-        end do
+        enddo
       else
         write(iOutputUnit_, "(I7,A1,a)") 15, " ", "Cp"
         write(iOutputUnit_, "(I7,A1,a)") 16, " ", "Rho"
         write(iOutputUnit_, "(I7,A1,a)") 17, " ", "E-Field Mag"
         write(iOutputUnit_, "(I7,A1,a)") 18, " ", "Sigma Ped"
-      end if
+      endif
 
-    end if
+    endif
 
     if (cType(3:5) == "CHM") then
 
@@ -699,7 +699,7 @@ contains
       write(iOutputUnit_, "(I7,A1,a)") 29, " ", "O!U+!N(2P) + N!D2!N"
       write(iOutputUnit_, "(I7,A1,a)") 30, " ", "Chemical Heating Rate"
 
-    end if
+    endif
 
     if (cType(3:5) == "GLO") then
 
@@ -707,7 +707,7 @@ contains
       write(iOutputUnit_, "(I7,A1,a)") 5, " ", "PhotoElectronUp"
       write(iOutputUnit_, "(I7,A1,a)") 6, " ", "PhotoElectronDown"
 
-    end if
+    endif
 
     if (cType(3:5) == "MEL") then
 
@@ -738,7 +738,7 @@ contains
       write(iOutputUnit_, "(I7,A1,a)") 28, " ", "Kphi"
       write(iOutputUnit_, "(I7,A1,a)") 29, " ", "Klamda"
 
-    end if
+    endif
 
     if (cType(3:5) == "ALL" .or. cType(3:5) == "NEU") then
 
@@ -748,7 +748,7 @@ contains
       do iSpecies = 1, nSpeciesTotal
         write(iOutputUnit_, "(I7,A1,a)") iOff + iSpecies, " ", &
           "["//cSpecies(iSpecies)//"]"
-      end do
+      enddo
 
       iOff = 4 + nSpeciesTotal
       write(iOutputUnit_, "(I7,A1,a)") iOff + 1, " ", "Temperature"
@@ -760,9 +760,9 @@ contains
       do iSpecies = 1, nSpecies
         write(iOutputUnit_, "(I7,A1,a)") iOff + iSpecies, " ", &
           "V!Dn!N (up,"//cSpecies(iSpecies)//")"
-      end do
+      enddo
 
-    end if
+    endif
 
     if (cType(3:5) == "ALL" .or. cType(3:5) == "ION") then
 
@@ -770,7 +770,7 @@ contains
       if (cType(3:5) == "ALL") iOff = 8 + nSpeciesTotal + nSpecies
       do iIon = 1, nIons
         write(iOutputUnit_, "(I7,A1,a)") iOff + iIon, " ", "["//cIons(iIon)//"]"
-      end do
+      enddo
 
       iOff = iOff + nIons
 
@@ -825,9 +825,9 @@ contains
         write(iOutputUnit_, "(I7,A1,a)") iOff + 17, " ", "PressGrad (east)"
         write(iOutputUnit_, "(I7,A1,a)") iOff + 18, " ", "PressGrad (north)"
         write(iOutputUnit_, "(I7,A1,a)") iOff + 19, " ", "PressGrad (up)"
-      end if
+      endif
 
-    end if
+    endif
 
     if (cType == "3DHME") then
 
@@ -837,7 +837,7 @@ contains
       do iSpecies = 1, nSpeciesTotal
         write(iOutputUnit_, "(I7,A1,a)") iOff + iSpecies, " ", &
           "["//cSpecies(iSpecies)//"]"
-      end do
+      enddo
 
       iOff = 4 + nSpeciesTotal
       write(iOutputUnit_, "(I7,A1,a)") iOff + 1, " ", "Temperature"
@@ -849,12 +849,12 @@ contains
       do iSpecies = 1, nSpecies
         write(iOutputUnit_, "(I7,A1,a)") iOff + iSpecies, " ", &
           "V!Dn!N (up,"//cSpecies(iSpecies)//")"
-      end do
+      enddo
 
       iOff = 8 + nSpeciesTotal + nSpecies
       do iIon = 1, nIons
         write(iOutputUnit_, "(I7,A1,a)") iOff + iIon, " ", "["//cIons(iIon)//"]"
-      end do
+      enddo
 
       iOff = iOff + nIons
       write(iOutputUnit_, "(I7,A1,a)") iOff + 1, " ", "eTemperature"
@@ -880,14 +880,14 @@ contains
       write(iOutputUnit_, "(I7,A1,a)") iOff + 14, " ", "E.F. North"
       write(iOutputUnit_, "(I7,A1,a)") iOff + 15, " ", "E.F. Vertical"
 
-    end if
+    endif
 
     if (cType == "2DHME") then
 
       write(iOutputUnit_, "(I7,A1,a)") 4, " ", "Local Time"
       write(iOutputUnit_, "(I7,A1,a)") 5, " ", "Vertical TEC"
 
-    end if
+    endif
 
   end subroutine output_header
 
@@ -916,7 +916,7 @@ contains
     do iSpecies = 1, nSpeciesTotal
       write(iOutputUnit_, "(I7,A1,a)") iOff + iSpecies, " ", &
         "["//cSpecies(iSpecies)//"]"
-    end do
+    enddo
 
     iOff = iOff + nSpeciesTotal
     write(iOutputUnit_, "(I7,A1,a)") iOff + 1, " ", "Temperature"
@@ -928,12 +928,12 @@ contains
     do iSpecies = 1, nSpecies
       write(iOutputUnit_, "(I7,A1,a)") iOff + iSpecies, " ", &
         "V!Dn!N (up,"//cSpecies(iSpecies)//")"
-    end do
+    enddo
 
     iOff = iOff + nSpecies
     do iIon = 1, nIons
       write(iOutputUnit_, "(I7,A1,a)") iOff + iIon, " ", "["//cIons(iIon)//"]"
-    end do
+    enddo
 
     iOff = iOff + nIons
     write(iOutputUnit_, "(I7,A1,a)") iOff + 1, " ", "eTemperature"
@@ -967,7 +967,7 @@ contains
     else
       write(iOutputUnit_, "(I7,A)") 1, " nBlocksLat"
       write(iOutputUnit_, "(I7,A)") 1, " nBlocksLon"
-    end if
+    endif
     write(iOutputUnit_, *) ""
 
   end subroutine write_head_blocks
@@ -1142,9 +1142,9 @@ subroutine output_3dall(iBlock)
           eTemperature(iLon, iLat, iAlt, iBlock), &
           ITemperature(iLon, iLat, iAlt, iBlock), &
           (Ivelocity(iLon, iLat, iAlt, i, iBlock), i=1, 3)
-      end do
-    end do
-  end do
+      enddo
+    enddo
+  enddo
 
 end subroutine output_3dall
 
@@ -1180,54 +1180,54 @@ subroutine output_3dlst(iBlock)
         if (iRhoOutputList) then
           iOff = iOff + 1
           tmp(iOff) = Rho(iLon, iLat, iAlt, iBlock)
-        end if
+        endif
 
         do iSpecies = 1, nSpeciesTotal
           if (iNeutralDensityOutputList(iSpecies)) then
             iOff = iOff + 1
             tmp(iOff) = NDensityS(iLon, iLat, iAlt, iSpecies, iBlock)
-          end if
-        end do
+          endif
+        enddo
 
         do i = 1, 3
           if (iNeutralWindOutputList(i)) then
             iOff = iOff + 1
             tmp(iOff) = Velocity(iLon, iLat, iAlt, i, iBlock)
-          end if
-        end do
+          endif
+        enddo
 
         do iSpecies = 1, nIons
           if (iIonDensityOutputList(iSpecies)) then
             iOff = iOff + 1
             tmp(iOff) = IDensityS(iLon, iLat, iAlt, iSpecies, iBlock)
-          end if
-        end do
+          endif
+        enddo
 
         do i = 1, 3
           if (iIonWindOutputList(i)) then
             iOff = iOff + 1
             tmp(iOff) = IVelocity(iLon, iLat, iAlt, i, iBlock)
-          end if
-        end do
+          endif
+        enddo
 
         if (iTemperatureOutputList(1)) then
           iOff = iOff + 1
           tmp(iOff) = Temperature(iLon, iLat, iAlt, iBlock)*TempUnit(iLon, iLat, iAlt)
-        end if
+        endif
         if (iTemperatureOutputList(2)) then
           iOff = iOff + 1
           tmp(iOff) = ITemperature(iLon, iLat, iAlt, iBlock)
-        end if
+        endif
         if (iTemperatureOutputList(3)) then
           iOff = iOff + 1
           tmp(iOff) = eTemperature(iLon, iLat, iAlt, iBlock)
-        end if
+        endif
 
         write(iOutputUnit_) tmp(1:iOff)
 
-      end do
-    end do
-  end do
+      enddo
+    enddo
+  enddo
 
 end subroutine output_3dlst
 
@@ -1260,9 +1260,9 @@ subroutine output_3dneu(iBlock)
           Temperature(iLon, iLat, iAlt, iBlock)*TempUnit(iLon, iLat, iAlt), &
           velocity(iLon, iLat, iAlt, :, iBlock), &
           VerticalVelocity(iLon, iLat, iAlt, :, iBlock)
-      end do
-    end do
-  end do
+      enddo
+    enddo
+  enddo
 
 end subroutine output_3dneu
 
@@ -1305,9 +1305,9 @@ subroutine output_3dion(iBlock)
           sqrt(sum(EField(iLon, iLat, iAlt, :)**2)), & ! magnitude of E.F.
           Collisions(iLon, iLat, iAlt, iVIN_), & ! AGB: nu_in
           IonPressureGradient(iLon, iLat, iAlt, :, iBlock) ! AGB: 3D Grad P
-      end do
-    end do
-  end do
+      enddo
+    enddo
+  enddo
 
 end subroutine output_3dion
 
@@ -1353,9 +1353,9 @@ subroutine output_3dthm(iBlock)
           sqrt(sum(EField(iLon, iLat, iAlt, :)**2)), & ! magnitude of E.F.
           Sigma_Pedersen(iLon, iLat, iAlt)
 
-      end do
-    end do
-  end do
+      enddo
+    enddo
+  enddo
 
 end subroutine output_3dthm
 
@@ -1402,9 +1402,9 @@ subroutine output_3dhme(iBlock)
           Potential(iLon, iLat, iAlt, iBlock), &
           PotentialY(iLon, iLat, iAlt, iBlock), &
           EField(iLon, iLat, iAlt, :)
-      end do
-    end do
-  end do
+      enddo
+    enddo
+  enddo
 
 end subroutine output_3dhme
 
@@ -1428,7 +1428,7 @@ subroutine output_1dthm
     do iSpecies = 1, nSpeciesTotal
       varsS(iSpecies) = NeutralSourcesTotal(iialt, iSpecies)
       varsL(iSpecies) = NeutralLossesTotal(iialt, iSpecies)
-    end do
+    enddo
 
     write(iOutputUnit_) &
       Longitude(1, 1), &
@@ -1447,7 +1447,7 @@ subroutine output_1dthm
       EuvTotal(1, 1, iiAlt, 1)*dt, &
       varsS, varsL
 
-  end do
+  enddo
 
 end subroutine output_1dthm
 
@@ -1471,7 +1471,7 @@ subroutine output_1dchm(iBlock)
     do iReact = 1, nReactions
       vars(iReact) = ChemicalHeatingSpecies(1, 1, iiAlt, iReact)/ &
                      Element_Charge
-    end do
+    enddo
 
     write(iOutputUnit_) &
       Longitude(1, iBlock), &
@@ -1482,7 +1482,7 @@ subroutine output_1dchm(iBlock)
       cp(1, 1, iiAlt, iBlock)* &
       Rho(1, 1, iiAlt, iBlock)*TempUnit(1, 1, iiAlt)/ &
       Element_Charge
-  end do
+  enddo
 
 end subroutine output_1dchm
 
@@ -1512,7 +1512,7 @@ subroutine output_3dchm(iBlock)
           vars(iReact) = ChemicalHeatingSpecies(iiLon, iiLat, iiAlt, iReact)/ &
                          Element_Charge
 
-        end do
+        enddo
 
         write(iOutputUnit_) &
           Longitude(iLon, iBlock), &
@@ -1523,9 +1523,9 @@ subroutine output_3dchm(iBlock)
           cp(iilon, iiLat, iiAlt, iBlock)* &
           Rho(iilon, iiLat, iiAlt, iBlock)*TempUnit(iilon, iiLat, iiAlt)/ &
           Element_Charge
-      end do
-    end do
-  end do
+      enddo
+    enddo
+  enddo
 
 end subroutine output_3dchm
 
@@ -1627,8 +1627,8 @@ subroutine output_2dgel(iBlock)
         HallFieldLine(iLon, iLat), &
         DivJuFieldLine(iLon, iLat), &
         LengthFieldLine(iLon, iLat)
-    end do
-  end do
+    enddo
+  enddo
 
 end subroutine output_2dgel
 
@@ -1658,8 +1658,8 @@ subroutine output_2dtec(iBlock)
         Altitude_GB(iLon, iLat, iAlt, iBlock), &
         Sza(iLon, iLat, iBlock), &
         VTEC(iLon, iLat, iBlock)
-    end do
-  end do
+    enddo
+  enddo
 
 end subroutine output_2dtec
 
@@ -1702,8 +1702,8 @@ subroutine output_2danc(iBlock)
         CO2Cooling2d(iLon, iLat), &
         NOCooling2d(iLon, iLat), &
         OCooling2d(iLon, iLat)
-    end do
-  end do
+    enddo
+  enddo
 
 end subroutine output_2danc
 
@@ -1732,9 +1732,9 @@ subroutine output_3dmag(iBlock)
           mLongitude(iLon, iLat, iAlt, iBlock), &
           B0(iLon, iLat, iAlt, :, iBlock)
         ! B0 has 4 elements of the geomag field, the E, N, Up, and magnitude
-      end do
-    end do
-  end do
+      enddo
+    enddo
+  enddo
 
 end subroutine output_3dmag
 
@@ -1786,8 +1786,8 @@ subroutine output_2dmel(iBlock)
         Ed2new(iLon, iLat), &
         kpmMC(iLon, iLat), &
         klmMC(iLon, iLat)
-    end do
-  end do
+    enddo
+  enddo
 
 end subroutine output_2dmel
 
@@ -1817,8 +1817,8 @@ subroutine output_2dhme(iBlock)
         Altitude_GB(iLon, iLat, iAlt, iBlock), &
         LocalTime(iLon), &
         VTEC(iLon, iLat, iBlock)
-    end do
-  end do
+    enddo
+  enddo
 
 end subroutine output_2dhme
 
@@ -1861,7 +1861,7 @@ subroutine output_1dall(iiLon, iiLat, iBlock, rLon, rLat, iUnit)
     do iSpecies = 1, nSpeciesTotal
       Tmp = NDensityS(0:nLons + 1, 0:nLats + 1, iAlt, iSpecies, iBlock)
       Vars(iOff + iSpecies) = inter(Tmp, iiLon, iiLat, rlon, rlat)
-    end do
+    enddo
 
     Tmp = Temperature(0:nLons + 1, 0:nLats + 1, iAlt, iBlock)* &
           TempUnit(0:nLons + 1, 0:nLats + 1, iAlt)
@@ -1871,19 +1871,19 @@ subroutine output_1dall(iiLon, iiLat, iBlock, rLon, rLat, iUnit)
     do iDir = 1, 3
       Tmp = Velocity(0:nLons + 1, 0:nLats + 1, iAlt, iDir, iBlock)
       Vars(iOff + iDir) = inter(Tmp, iiLon, iiLat, rlon, rlat)
-    end do
+    enddo
 
     iOff = 8 + nSpeciesTotal
     do iSpecies = 1, nSpecies
       Tmp = VerticalVelocity(0:nLons + 1, 0:nLats + 1, iAlt, iSpecies, iBlock)
       Vars(iOff + iSpecies) = inter(Tmp, iiLon, iiLat, rlon, rlat)
-    end do
+    enddo
 
     iOff = 8 + nSpeciesTotal + nSpecies
     do iIon = 1, nIons
       Tmp = IDensityS(0:nLons + 1, 0:nLats + 1, iAlt, iIon, iBlock)
       Vars(iOff + iIon) = inter(Tmp, iiLon, iiLat, rlon, rlat)
-    end do
+    enddo
 
     iOff = 8 + nSpeciesTotal + nSpecies + nIons + 1
     Tmp = eTemperature(0:nLons + 1, 0:nLats + 1, iAlt, iBlock)
@@ -1934,7 +1934,7 @@ subroutine output_1dall(iiLon, iiLat, iBlock, rLon, rLat, iUnit)
 
     write(iOutputUnit_) Vars
 
-  end do
+  enddo
 
 contains
 
@@ -1994,7 +1994,7 @@ subroutine output_0dall(iiLon, iiLat, iiAlt, iBlock, rLon, rLat, rAlt, iUnit)
   do iSpecies = 1, nSpeciesTotal
     Tmp = NDensityS(0:nLons + 1, 0:nLats + 1, 0:nAlts + 1, iSpecies, iBlock)
     Vars(iOff + iSpecies) = inter(Tmp, iiLon, iiLat, iiAlt, rLon, rLat, rAlt)
-  end do
+  enddo
 
   Tmp = Temperature(0:nLons + 1, 0:nLats + 1, 0:nAlts + 1, iBlock)* &
         TempUnit(0:nLons + 1, 0:nLats + 1, 0:nAlts + 1)
@@ -2004,19 +2004,19 @@ subroutine output_0dall(iiLon, iiLat, iiAlt, iBlock, rLon, rLat, rAlt, iUnit)
   do iDir = 1, 3
     Tmp = Velocity(0:nLons + 1, 0:nLats + 1, 0:nAlts + 1, iDir, iBlock)
     Vars(iOff + iDir) = inter(Tmp, iiLon, iiLat, iiAlt, rLon, rLat, rAlt)
-  end do
+  enddo
 
   iOff = 8 + nSpeciesTotal
   do iSpecies = 1, nSpecies
     Tmp = VerticalVelocity(0:nLons + 1, 0:nLats + 1, 0:nAlts + 1, iSpecies, iBlock)
     Vars(iOff + iSpecies) = inter(Tmp, iiLon, iiLat, iiAlt, rLon, rLat, rAlt)
-  end do
+  enddo
 
   iOff = 8 + nSpeciesTotal + nSpecies
   do iIon = 1, nIons
     Tmp = IDensityS(0:nLons + 1, 0:nLats + 1, 0:nAlts + 1, iIon, iBlock)
     Vars(iOff + iIon) = inter(Tmp, iiLon, iiLat, iiAlt, rLon, rLat, rAlt)
-  end do
+  enddo
 
   iOff = 8 + nSpeciesTotal + nSpecies + nIons + 1
   Tmp = eTemperature(0:nLons + 1, 0:nLats + 1, 0:nAlts + 1, iBlock)
@@ -2042,7 +2042,7 @@ subroutine output_0dall(iiLon, iiLat, iiAlt, iBlock, rLon, rLat, rAlt, iUnit)
     Tmp = NDensityS(0:nLons + 1, 0:nLats + 1, 0:nAlts + 1, iSpecies, iBlock) &
           /NDensity(0:nLons + 1, 0:nLats + 1, 0:nAlts + 1, iBlock)
     Vars(iOff + iSpecies) = inter(Tmp, iiLon, iiLat, iiAlt, rLon, rLat, rAlt)
-  end do
+  enddo
 
   iOff = iOff + nSpecies
   Vars(iOff + 1) = Dt*RadCooling(1, 1, jAlt, iBlock)*TempUnit(1, 1, jAlt)
@@ -2121,7 +2121,7 @@ subroutine output_1dnew(iiLon, iiLat, iBlock, rLon, rLat, iUnit)
     do iSpecies = 1, nSpeciesTotal
       Tmp = NDensityS(0:nLons + 1, 0:nLats + 1, iAlt, iSpecies, iBlock)
       Vars(iOff + iSpecies) = inter(Tmp, iiLon, iiLat, rlon, rlat)
-    end do
+    enddo
 
     Tmp = Temperature(0:nLons + 1, 0:nLats + 1, iAlt, iBlock)* &
           TempUnit(0:nLons + 1, 0:nLats + 1, iAlt)
@@ -2131,19 +2131,19 @@ subroutine output_1dnew(iiLon, iiLat, iBlock, rLon, rLat, iUnit)
     do iDir = 1, 3
       Tmp = Velocity(0:nLons + 1, 0:nLats + 1, iAlt, iDir, iBlock)
       Vars(iOff + iDir) = inter(Tmp, iiLon, iiLat, rlon, rlat)
-    end do
+    enddo
 
     iOff = 10 + nSpeciesTotal
     do iSpecies = 1, nSpecies
       Tmp = VerticalVelocity(0:nLons + 1, 0:nLats + 1, iAlt, iSpecies, iBlock)
       Vars(iOff + iSpecies) = inter(Tmp, iiLon, iiLat, rlon, rlat)
-    end do
+    enddo
 
     iOff = 10 + nSpeciesTotal + nSpecies
     do iIon = 1, nIons
       Tmp = IDensityS(0:nLons + 1, 0:nLats + 1, iAlt, iIon, iBlock)
       Vars(iOff + iIon) = inter(Tmp, iiLon, iiLat, rlon, rlat)
-    end do
+    enddo
 
     iOff = iOff + 1
     Tmp = eTemperature(0:nLons + 1, 0:nLats + 1, iAlt, iBlock)
@@ -2157,18 +2157,18 @@ subroutine output_1dnew(iiLon, iiLat, iBlock, rLon, rLat, iUnit)
     do iDir = 1, 3
       Tmp = IVelocity(0:nLons + 1, 0:nLats + 1, iAlt, iDir, iBlock)
       Vars(iOff + iDir) = inter(Tmp, iiLon, iiLat, rlon, rlat)
-    end do
+    enddo
 
     iOff = iOff
     do iSpecies = 1, nSpecies
       Tmp = NDensityS(0:nLons + 1, 0:nLats + 1, iAlt, iSpecies, iBlock) &
             /NDensity(0:nLons + 1, 0:nLats + 1, iAlt, iBlock)
       Vars(iOff + iSpecies) = inter(Tmp, iiLon, iiLat, rlon, rlat)
-    end do
+    enddo
 
     write(iOutputUnit_) Vars
 
-  end do
+  enddo
 
 contains
 

--- a/src/overwrite.Earth.f90
+++ b/src/overwrite.Earth.f90
@@ -23,8 +23,8 @@ subroutine overwrite_ionosphere
     call report('Overwriting Ionosphere with SAMI-3!', 0)
     do iBlock = 1, nBlocks
       call ionosphere_overwrite_sami(iBlock)
-    end do
-  end if
+    enddo
+  endif
 
 end subroutine overwrite_ionosphere
 
@@ -86,9 +86,9 @@ subroutine ionosphere_overwrite_sami(iBlock)
           GitmLats(iPoint) = latitude(iLat, iBlock)
           GitmAlts(iPoint) = Altitude_GB(iLon, iLat, iAlt, iBlock)
           iPoint = iPoint + 1
-        end do
-      end do
-    end do
+        enddo
+      enddo
+    enddo
 
     if (iPoint > 1) then
 
@@ -99,11 +99,11 @@ subroutine ionosphere_overwrite_sami(iBlock)
 
       call SamiSetGrid(GitmLons, GitmLats, GitmAlts)
 
-    end if
+    endif
 
     IsFirstTime = .false.
 
-  end if
+  endif
 
   if (CorotationAdded) then
     ! This then implies that the grid is in local time, so we need to
@@ -117,18 +117,18 @@ subroutine ionosphere_overwrite_sami(iBlock)
           GitmLons(iPoint) = LocalTime(iLon)*15.0
           if (iAlt == 1 .and. iLat == 1) write(*, *) iLon, LocalTime(iLon), GitmLons(iPoint)
           iPoint = iPoint + 1
-        end do
-      end do
-    end do
+        enddo
+      enddo
+    enddo
 
     if (iPoint > 1) call SamiSetGrid(GitmLons, GitmLats, GitmAlts)
 
-  end if
+  endif
 
   call SamiUpdateTime(CurrentTime, iErr)
   if (iErr == 0) then
     call SamiGetData(SamiFileData)
-  end if
+  endif
 
   iPoint = 1
 
@@ -149,8 +149,8 @@ subroutine ionosphere_overwrite_sami(iBlock)
         iTemperature(iLon, iLat, iAlt, iBlock) = SamiFileData(iPoint, iSami_Ti_)
 
         iPoint = iPoint + 1
-      end do
-    end do
-  end do
+      enddo
+    enddo
+  enddo
 
 end subroutine ionosphere_overwrite_sami

--- a/src/read_ACE_data.f90
+++ b/src/read_ACE_data.f90
@@ -44,7 +44,7 @@ subroutine read_ACE_data(iOutputError)
   if (ierror .ne. 0) then
     iOutputError = 1
     return
-  end if
+  endif
 
   done = .false.
 
@@ -54,7 +54,7 @@ subroutine read_ACE_data(iOutputError)
     if (ierror .ne. 0) done = .true.
     if (index(line, 'BEGIN DATA') > 0) done = .true.
 
-  end do
+  enddo
 
   if (ierror == 0) then
 
@@ -91,13 +91,13 @@ subroutine read_ACE_data(iOutputError)
 
           iIMF = iIMF + 1
 
-        end if
+        endif
 
-      end if
+      endif
 
-    end do
+    enddo
 
-  end if
+  endif
 
   close(LunIndices_)
 
@@ -106,7 +106,7 @@ subroutine read_ACE_data(iOutputError)
   if (ierror .ne. 0) then
     iOutputError = 1
     return
-  end if
+  endif
 
   done = .false.
 
@@ -116,7 +116,7 @@ subroutine read_ACE_data(iOutputError)
     if (ierror .ne. 0) done = .true.
     if (index(line, 'BEGIN DATA') > 0) done = .true.
 
-  end do
+  enddo
 
   if (ierror == 0) then
 
@@ -163,13 +163,13 @@ subroutine read_ACE_data(iOutputError)
 
           iSW = iSW + 1
 
-        end if
+        endif
 
-      end if
+      endif
 
-    end do
+    enddo
 
-  end if
+  endif
 
   close(LunIndices_)
 
@@ -187,7 +187,7 @@ subroutine read_ACE_data(iOutputError)
 
   do iSW = 1, nIndices_V(sw_vx_)
     avevx = avevx + Indices_TV(iSW, sw_v_)/nIndices_V(sw_vx_)
-  end do
+  enddo
 
   TimeDelay = 1.5e6/avevx
 
@@ -206,7 +206,7 @@ subroutine read_ACE_data(iOutputError)
                                 + TimeDelay
     IndexTimes_TV(iSW, sw_t_) = IndexTimes_TV(iSW, sw_t_) &
                                 + TimeDelay
-  end do
+  enddo
 
   do iIMF = 1, nIndices_V(imf_bx_)
     IndexTimes_TV(iIMF, imf_bx_) = IndexTimes_TV(iIMF, imf_bx_) + &
@@ -215,7 +215,7 @@ subroutine read_ACE_data(iOutputError)
                                    TimeDelay
     IndexTimes_TV(iIMF, imf_bz_) = IndexTimes_TV(iIMF, imf_bz_) + &
                                    TimeDelay
-  end do
+  enddo
 
 end subroutine read_ACE_data
 

--- a/src/read_MHDIMF_Indices_new copy.f90
+++ b/src/read_MHDIMF_Indices_new copy.f90
@@ -39,7 +39,7 @@ subroutine read_MHDIMF_Indices_new(iOutputError, StartTime, EndTime)
     EndTimeFake = 1e32
   else
     EndTimeFake = EndTime
-  end if
+  endif
 
   ! Problem - we have to figure out whether we are being called with no IMF
   ! file at all or whether we actually have an index file to read (or reread)
@@ -62,7 +62,7 @@ subroutine read_MHDIMF_Indices_new(iOutputError, StartTime, EndTime)
     ! If we still have a lot of data in memory, then don't bother
     ! reading more.
     if (StartTime + BufferTime < IndexTimes_TV(nIndices_V(imf_bx_), imf_by_)) return
-  end if
+  endif
 
   ! Assume that we can read the entire file
   ReReadIMFFile = .false.
@@ -75,7 +75,7 @@ subroutine read_MHDIMF_Indices_new(iOutputError, StartTime, EndTime)
   if (ierror .ne. 0) then
     iOutputError = 1
     return
-  end if
+  endif
 
   do while (.not. done)
 
@@ -86,7 +86,7 @@ subroutine read_MHDIMF_Indices_new(iOutputError, StartTime, EndTime)
     if (index(line, '#DELAY') > 0) then
       read(LunIndices_, *, iostat=iError) TimeDelay
       if (iError /= 0) done = .true.
-    end if
+    endif
 
     if (index(line, '#START') > 0) then
 
@@ -116,7 +116,7 @@ subroutine read_MHDIMF_Indices_new(iOutputError, StartTime, EndTime)
           if (StartTime > IndexTimes_TV(iIMF, imf_bx_)) then
             iIMF = iIMF + 1
             iSW = iSW + 1
-          end if
+          endif
 
         else
 
@@ -129,8 +129,8 @@ subroutine read_MHDIMF_Indices_new(iOutputError, StartTime, EndTime)
             if (DeltaT == -1.0e32) then
               DeltaT = IndexTimes_TV(iIMF, imf_bx_) - FirstTime
               if (DeltaT > BufferTime) BufferTime = 10.0*DeltaT
-            end if
-          end if
+            endif
+          endif
 
           IndexTimes_TV(iIMF, imf_bx_) = IndexTimes_TV(iIMF, imf_bx_) &
                                          + TimeDelay
@@ -174,18 +174,18 @@ subroutine read_MHDIMF_Indices_new(iOutputError, StartTime, EndTime)
               iIMF = iIMF + 1
               iSW = iSW + 1
               print *, "COUNTERS ADDED TO"
-            end if
-          end if
+            endif
+          endif
 
-        end if
+        endif
 
-      end do
+      enddo
 
       done = done_inner
 
-    end if
+    endif
 
-  end do
+  enddo
 
   close(LunIndices_)
 
@@ -203,7 +203,7 @@ subroutine read_MHDIMF_Indices_new(iOutputError, StartTime, EndTime)
 
   if (isIgnoreEndTime) then
     EndTimeFake = IndexTimes_TV(iIMF - 2, imf_bx_)
-  end if
+  endif
   ! If we have gotten to this point and we have no data,
   ! there is something wrong!
   if (nIndices_V(imf_bz_) < 2) iOutputError = 1
@@ -215,11 +215,11 @@ subroutine read_MHDIMF_Indices_new(iOutputError, StartTime, EndTime)
   if (iError == 0) then
     call check_all_indices(EndTimeFake, iError)
     print *, CurrentTime, EndTimeFake, EndTime, iError
-  end if
+  endif
   if (iError /= 0) then
     print *, CurrentTime, EndTimeFake, EndTime, iError
     call stop_gitm("Issue with Indices! Check the file(s) times!")
-  end if
+  endif
 
 end subroutine read_MHDIMF_Indices_new
 

--- a/src/read_MHDIMF_Indices_new.f90
+++ b/src/read_MHDIMF_Indices_new.f90
@@ -50,7 +50,7 @@ subroutine read_MHDIMF_Indices_new(iOutputError, StartTime, EndTime)
     ! If we still have a lot of data in memory, then don't bother
     ! reading more.
     if (StartTime + BufferTime < IndexTimes_TV(nIndices_V(imf_bx_), imf_by_)) return
-  end if
+  endif
 
   ! Assume that we can read the entire file
   ReReadIMFFile = .false.
@@ -63,7 +63,7 @@ subroutine read_MHDIMF_Indices_new(iOutputError, StartTime, EndTime)
   if (ierror .ne. 0) then
     iOutputError = 1
     return
-  end if
+  endif
 
   do while (.not. done)
 
@@ -73,7 +73,7 @@ subroutine read_MHDIMF_Indices_new(iOutputError, StartTime, EndTime)
     if (index(line, '#DELAY') > 0) then
       read(LunIndices_, *, iostat=iError) TimeDelay
       if (iError /= 0) done = .true.
-    end if
+    endif
 
     if (index(line, '#START') > 0) then
 
@@ -103,7 +103,7 @@ subroutine read_MHDIMF_Indices_new(iOutputError, StartTime, EndTime)
           if (StartTime > IndexTimes_TV(iIMF, imf_bx_)) then
             iIMF = iIMF + 1
             iSW = iSW + 1
-          end if
+          endif
 
         else
 
@@ -116,8 +116,8 @@ subroutine read_MHDIMF_Indices_new(iOutputError, StartTime, EndTime)
             if (DeltaT == -1.0e32) then
               DeltaT = IndexTimes_TV(iIMF, imf_bx_) - FirstTime
               if (DeltaT > BufferTime) BufferTime = 10.0*DeltaT
-            end if
-          end if
+            endif
+          endif
 
           IndexTimes_TV(iIMF, imf_bx_) = IndexTimes_TV(iIMF, imf_bx_) &
                                          + TimeDelay
@@ -160,19 +160,19 @@ subroutine read_MHDIMF_Indices_new(iOutputError, StartTime, EndTime)
             if (EndTime < IndexTimes_TV(iIMF, imf_bx_) .and. iIMF == 1) then
               iIMF = iIMF + 1
               iSW = iSW + 1
-            end if
+            endif
 
-          end if
+          endif
 
-        end if
+        endif
 
-      end do
+      enddo
 
       done = done_inner
 
-    end if
+    endif
 
-  end do
+  enddo
 
   close(LunIndices_)
 

--- a/src/read_NGDC_Indices_new.f90
+++ b/src/read_NGDC_Indices_new.f90
@@ -38,7 +38,7 @@ subroutine read_NGDC_Indices_new(iOutputError, StartTime, EndTime)
   if (ierror .ne. 0) then
     iOutputError = 1
     return
-  end if
+  endif
 
   done = .false.
 
@@ -56,78 +56,78 @@ subroutine read_NGDC_Indices_new(iOutputError, StartTime, EndTime)
     if (index(line, '#Element: dst') > 0) then
       call read_values
       call Insert_into_Indices_Array(tmp, dst_)
-    end if
+    endif
 
     if (index(line, '#Element: kp') > 0) then
       call read_values
       call Insert_into_Indices_Array(tmp, kp_)
-    end if
+    endif
 
     if (index(line, '#Element: ap') > 0) then
       call read_values
       call Insert_into_Indices_Array(tmp, ap_)
-    end if
+    endif
 
     if (index(line, '#Element: bx') > 0) then
       read(LunIndices_, '(a)', iostat=ierror) line
       if (index(line, '#Table: IMFMin') > 0) then
         call read_values
         call Insert_into_Indices_Array(tmp, imf_bx_)
-      end if
-    end if
+      endif
+    endif
 
     if (index(line, '#Element: by') > 0) then
       read(LunIndices_, '(a)', iostat=ierror) line
       if (index(line, '#Table: IMFMin') > 0) then
         call read_values
         call Insert_into_Indices_Array(tmp, imf_by_)
-      end if
-    end if
+      endif
+    endif
 
     if (index(line, '#Element: bz') > 0) then
       read(LunIndices_, '(a)', iostat=ierror) line
       if (index(line, '#Table: IMFMin') > 0) then
         call read_values
         call Insert_into_Indices_Array(tmp, imf_bz_)
-      end if
-    end if
+      endif
+    endif
 
     if (index(line, '#Element: flow') > 0) then
       call read_values
       call Insert_into_Indices_Array(tmp, sw_v_)
-    end if
+    endif
 
     if (index(line, '#Element: swVelX') > 0) then
       call read_values
       call Insert_into_Indices_Array(tmp, sw_vx_)
-    end if
+    endif
 
     if (index(line, '#Element: swVelY') > 0) then
       call read_values
       call Insert_into_Indices_Array(tmp, sw_vy_)
-    end if
+    endif
 
     if (index(line, '#Element: swVelZ') > 0) then
       call read_values
       call Insert_into_Indices_Array(tmp, sw_vz_)
-    end if
+    endif
 
     if (index(line, '#Element: observed') > 0) then
       call read_values
       call Insert_into_Indices_Array(tmp, f107_)
-    end if
+    endif
 
     if (index(line, '#Element: adjusted') > 0) then
       BufferTime = 81.0*24.0*3600.0
       call read_values
       call Insert_into_Indices_Array(tmp, f107_)
-    end if
+    endif
 
     if (index(line, '#Element: flux') > 0 .or. index(line, '#Table: Flux') > 0) then
       BufferTime = 81.0*24.0*3600.0
       call read_values
       call Insert_into_Indices_Array(tmp, f107_)
-    end if
+    endif
 
     ! This has to be before the DMSP stuff because of the
     ! extra N and S on the end of the Element line.
@@ -139,7 +139,7 @@ subroutine read_NGDC_Indices_new(iOutputError, StartTime, EndTime)
       call read_values
       call merge_hpi_data
 !           endif
-    end if
+    endif
 !     else
 !        if(index(line,'#Element: power')>0)then
 !           read(LunIndices_,'(a)', iostat = ierror ) line
@@ -158,7 +158,7 @@ subroutine read_NGDC_Indices_new(iOutputError, StartTime, EndTime)
 !        endif
 !     endif
 
-  end do
+  enddo
 
   close(LunIndices_)
 
@@ -170,7 +170,7 @@ subroutine read_NGDC_Indices_new(iOutputError, StartTime, EndTime)
       call time_real_to_int(ut_keep(i), itime)
       tmp(1:5, i) = itime(1:5)
       tmp(6, i) = data_keep(i)
-    end do
+    enddo
 
     call Insert_into_Indices_Array(tmp, hpi_)
 
@@ -183,10 +183,10 @@ subroutine read_NGDC_Indices_new(iOutputError, StartTime, EndTime)
       if (Indices_TV(i, hpi_) > 0) then
         Indices_TV(i, hpi_norm_) = &
           2.09*ALOG(Indices_TV(i, hpi_))*1.0475
-      end if
-    end do
+      endif
+    enddo
 
-  end if
+  endif
 
   if (Input_Coor_System == GSE_) then
 
@@ -202,9 +202,9 @@ subroutine read_NGDC_Indices_new(iOutputError, StartTime, EndTime)
       Indices_TV(i, imf_bx_:imf_bz_) = &
         matmul(GsmGse_DD, Indices_TV(i, imf_bx_:imf_bz_))
 
-    end do
+    enddo
 
-  end if
+  endif
 
 contains
 
@@ -229,7 +229,7 @@ contains
 
       if (index(line, 'GSE') > 0) Input_Coor_System = GSE_
 
-    end do
+    enddo
 
     missingPlusTol = missing + abs(missing)*0.01
     missingMinusTol = missing - abs(missing)*0.01
@@ -259,17 +259,17 @@ contains
               i = i + 1
             else
               tmp(1:6, i) = 0.0
-            end if
+            endif
           else
             tmp(1:6, i) = 0.0
-          end if
-        end if
+          endif
+        endif
 
-      end do
+      enddo
 
       npts = i - 1
 
-    end if
+    endif
 
   end subroutine read_values
 
@@ -281,7 +281,7 @@ contains
       itime(1:5) = tmp(1:5, i)
       call time_int_to_real(itime, ut_new(i))
       data_new(i) = tmp(6, i)
-    end do
+    enddo
 
     if (npts_hpi == 0) then
       npts_hpi = npts
@@ -323,15 +323,15 @@ contains
               data_keep(k) = data_new(i)
               k = k + 1
               i = i + 1
-            end if
-          end if
-        end if
+            endif
+          endif
+        endif
 
-      end do
+      enddo
 
       npts_hpi = npts_hpi + npts
 
-    end if
+    endif
 
   end subroutine merge_hpi_data
 

--- a/src/read_NOAAHPI_Indices_new.f90
+++ b/src/read_NOAAHPI_Indices_new.f90
@@ -58,7 +58,7 @@ subroutine read_NOAAHPI_Indices_new(iOutputError, StartTime, EndTime)
     ! If we still have a lot of data in memory, then don't bother
     ! reading more.
     if (StartTime + BufferTime < IndexTimes_TV(nIndices_V(hpi_), hpi_)) return
-  end if
+  endif
 
   ! Assume that we can read the entire file
   ReReadIMFFile = .false.
@@ -70,7 +70,7 @@ subroutine read_NOAAHPI_Indices_new(iOutputError, StartTime, EndTime)
   if (ierror .ne. 0) then
     iOutputError = 1
     return
-  end if
+  endif
 
   done = .false.
 
@@ -87,9 +87,9 @@ subroutine read_NOAAHPI_Indices_new(iOutputError, StartTime, EndTime)
 
       call read_values
       call merge_hpi_data
-    end if
+    endif
 
-  end do
+  enddo
 
   close(LunIndices_)
 
@@ -101,7 +101,7 @@ subroutine read_NOAAHPI_Indices_new(iOutputError, StartTime, EndTime)
       call time_real_to_int(ut_keep(i), itime)
       tmp(1:5, i) = itime(1:5)
       tmp(6, i) = data_keep(i)
-    end do
+    enddo
 
     call Insert_into_Indices_Array(tmp, hpi_)
 
@@ -114,11 +114,11 @@ subroutine read_NOAAHPI_Indices_new(iOutputError, StartTime, EndTime)
       if (Indices_TV(i, hpi_) > 0) then
         Indices_TV(i, hpi_norm_) = &
           2.09*ALOG(Indices_TV(i, hpi_))*1.0475
-      end if
+      endif
 
-    end do
+    enddo
 
-  end if
+  endif
 
 contains
 
@@ -150,13 +150,13 @@ contains
           if (IsFirstTime) then
             read(LunIndices_, '(i4)', iostat=ierror) iYear
             IsFirstTime = .false.
-          end if
+          endif
           tmp(1, i) = iYear
           tmp(2, i) = 1
           read(LunIndices_, '(a10,f3.0,f2.0,f2.0,f8.1)', iostat=ierror) &
             line, tmp(3:6, i)
           if (tmp(3, i) < 1) iError = 1
-        end if
+        endif
 
         if (datatype .eq. 2) then
           ! NEW NOAA HPI FILES
@@ -165,7 +165,7 @@ contains
             tmp(1, i), line, tmp(2, i), line, tmp(3, i), line, tmp(4, i), line, tmp(5, i), line, tmp(6, i), &
             line, tmp(6, i)
 
-        end if
+        endif
 
         if (ierror /= 0) then
           done_inner = .true.
@@ -184,16 +184,16 @@ contains
             ! This means that the GITM time is all BEFORE the first
             ! line in the file!
             if (EndTime < time_now .and. i == 1) i = i + 1
-          end if
+          endif
 
-        end if
+        endif
 
-      end do
+      enddo
 
       npts = i - 1
       if (npts + 1 >= MaxIndicesEntries) ReReadHPIFile = .true.
 
-    end if
+    endif
 
   end subroutine read_values
 
@@ -205,7 +205,7 @@ contains
       itime(1:5) = tmp(1:5, i)
       call time_int_to_real(itime, ut_new(i))
       data_new(i) = tmp(6, i)
-    end do
+    enddo
 
     if (npts_hpi == 0) then
       npts_hpi = npts
@@ -247,15 +247,15 @@ contains
               data_keep(k) = data_new(i)
               k = k + 1
               i = i + 1
-            end if
-          end if
-        end if
+            endif
+          endif
+        endif
 
-      end do
+      enddo
 
       npts_hpi = npts_hpi + npts
 
-    end if
+    endif
 
   end subroutine merge_hpi_data
 

--- a/src/read_OMNIWEB_Ap_Indices_new.f90
+++ b/src/read_OMNIWEB_Ap_Indices_new.f90
@@ -36,7 +36,7 @@ subroutine read_OMNIWEB_Ap_Indices_new(iOutputError, StartTime, EndTime)
   if (ierror .ne. 0) then
     iOutputError = 1
     return
-  end if
+  endif
 
   iAp = 1
 
@@ -73,15 +73,15 @@ subroutine read_OMNIWEB_Ap_Indices_new(iOutputError, StartTime, EndTime)
         ! line in the file!
         if (EndTime < IndexTimes_TV(iAp, ap_) .and. iAp == 1) then
           iAp = iAp + 1
-        end if
+        endif
 
-      end if
+      endif
 
       if (iAp >= MaxIndicesEntries) done = .true.
 
-    end if
+    endif
 
-  end do
+  enddo
 
   close(LunIndices_)
 

--- a/src/read_f107.f90
+++ b/src/read_f107.f90
@@ -29,11 +29,11 @@ subroutine read_f107(iOutputError)
   if (ierror .ne. 0) then
     iOutputError = 1
     return
-  end if
+  endif
 
   do iPt = 1, 15
     read(LunIndices_, *) line
-  end do
+  enddo
 
   done = .false.
 
@@ -44,9 +44,9 @@ subroutine read_f107(iOutputError)
     tmp_all(6, iPt) = tmp(7)
     if (ierror /= 0) then
       done = .true.
-    end if
+    endif
     iPt = iPt + 1
-  end do
+  enddo
   npts = iPt - 1
 
   call Insert_into_Indices_Array(tmp_all, f107_)

--- a/src/read_gitm.f90
+++ b/src/read_gitm.f90
@@ -33,7 +33,7 @@ program read_gitm
     lons(iPoint) = 360 - 5.0*(iPoint - 1)
     lats(iPoint) = -90.0 + 2.0*(iPoint - 1)
     alts(iPoint) = 100.0 + 10.0*(iPoint - 1)
-  end do
+  enddo
 
   call GitmSetnPointsToGet(nPoints)
 
@@ -46,10 +46,10 @@ program read_gitm
     if (iErr == 0) then
       call GitmGetData(data)
       write(*, *) data(:, 1)/dtor
-    end if
+    endif
     time = time + 60.0
     lons = lons - 1.0
-  end do
+  enddo
 
   write(*, *) data(:, 2)/dtor
   write(*, *) data(:, 3)/1000

--- a/src/read_inputs.f90
+++ b/src/read_inputs.f90
@@ -37,14 +37,14 @@ subroutine read_inputs(cFile)
       cInputText(nInputLines) = line
       nInputLines = nInputLines + 1
 
-    end do
+    enddo
 
     close(iInputUnit_)
 
     if (nInputLines == 0) &
       call stop_gitm("No lines of input read by read_inputs")
 
-  end if
+  endif
 
   ! Broadcast the number of lines and the text itself to all processors
   call MPI_Bcast(nInputLines, 1, MPI_Integer, 0, iCommGITM, ierror)

--- a/src/read_sami.f90
+++ b/src/read_sami.f90
@@ -37,7 +37,7 @@ program read_sami
     lons(iPoint) = 360 - 5.0*(iPoint - 1)
     lats(iPoint) = -90.0 + 2.0*(iPoint - 1)
     alts(iPoint) = 100.0 + 10.0*(iPoint - 1)
-  end do
+  enddo
 
   call SamiSetnPointsToGet(nPoints)
   call SamiSetGrid(lons, lats, alts)
@@ -51,9 +51,9 @@ program read_sami
     if (iErr == 0) then
       call SamiGetData(data)
       write(*, *) data(:, 1)
-    end if
+    endif
     time = time + 600.0
-  end do
+  enddo
 
   call SamiShutDown
 

--- a/src/read_sme.f90
+++ b/src/read_sme.f90
@@ -36,7 +36,7 @@ subroutine read_al_onset_list(iOutputError, StartTime, EndTime)
   if (NameOfSecondIndexFile == "none" .and. nIndices_V(onsetut_) == 0) then
     nIndices_V(onsetut_) = 1
     return
-  end if
+  endif
 
   call init_mod_indices
 
@@ -50,7 +50,7 @@ subroutine read_al_onset_list(iOutputError, StartTime, EndTime)
     ! reading more.
     if (StartTime + BufferTime < IndexTimes_TV(nIndices_V(onsetut_), onsetut_)) &
       return
-  end if
+  endif
 
   ! Assume that we can read the entire file
   ReReadOnsetFile = .false.
@@ -62,7 +62,7 @@ subroutine read_al_onset_list(iOutputError, StartTime, EndTime)
   if (ierror .ne. 0) then
     iOutputError = 1
     return
-  end if
+  endif
 
   iAE = 1
   iTime = 0
@@ -82,7 +82,7 @@ subroutine read_al_onset_list(iOutputError, StartTime, EndTime)
       ! line in the file!
       if (StartTime > IndexTimes_TV(iAE, onsetut_)) then
         iAE = iAE + 1
-      end if
+      endif
 
     else
 
@@ -108,13 +108,13 @@ subroutine read_al_onset_list(iOutputError, StartTime, EndTime)
         ! line in the file!
         if (EndTime < IndexTimes_TV(iAE, onsetut_) .and. iAE == 1) then
           iAE = iAE + 1
-        end if
+        endif
 
-      end if
+      endif
 
-    end if
+    endif
 
-  end do
+  enddo
 
   close(LunIndices_)
 
@@ -175,7 +175,7 @@ subroutine read_sme(iOutputError, StartTime, EndTime, doUseAeForHp)
     ! reading more.
     if (StartTime + BufferTime < IndexTimes_TV(nIndices_V(ae_), ae_)) &
       return
-  end if
+  endif
 
   ! Assume that we can read the entire file
   ReReadSMEFile = .false.
@@ -192,16 +192,16 @@ subroutine read_sme(iOutputError, StartTime, EndTime, doUseAeForHp)
       read(LunIndices_, *, iostat=iError) line
       if (iError /= 0) IsDone = .true.
       if (line(1:6) == "<year>") IsDone = .true.
-    end do
+    enddo
     IsDone = .false.
   else
     rewind(LunIndices_)
-  end if
+  endif
 
   if (ierror .ne. 0) then
     iOutputError = 1
     return
-  end if
+  endif
 
   iAE = 1
   iTime = 0
@@ -220,7 +220,7 @@ subroutine read_sme(iOutputError, StartTime, EndTime, doUseAeForHp)
       ! line in the file!
       if (StartTime > IndexTimes_TV(iAE, ae_)) then
         iAE = iAE + 1
-      end if
+      endif
 
     else
 
@@ -243,7 +243,7 @@ subroutine read_sme(iOutputError, StartTime, EndTime, doUseAeForHp)
           if (hp > 0) Indices_TV(iAE, hpi_norm_) = 2.09*ALOG(hp)*1.0475
           IndexTimes_TV(iAE, hpi_norm_) = IndexTimes_TV(iAE, ae_)
           IndexTimes_TV(iAE, hpi_) = IndexTimes_TV(iAE, ae_)
-        end if
+        endif
 
         IndexTimes_TV(iAE, al_) = IndexTimes_TV(iAE, ae_)
         IndexTimes_TV(iAE, au_) = IndexTimes_TV(iAE, ae_)
@@ -255,13 +255,13 @@ subroutine read_sme(iOutputError, StartTime, EndTime, doUseAeForHp)
         ! line in the file!
         if (EndTime < IndexTimes_TV(iAE, ae_) .and. iAE == 1) then
           iAE = iAE + 1
-        end if
+        endif
 
-      end if
+      endif
 
-    end if
+    endif
 
-  end do
+  enddo
 
   close(LunIndices_)
 

--- a/src/restart.f90
+++ b/src/restart.f90
@@ -65,7 +65,7 @@ subroutine write_restart(dir)
     write(iRestartUnit_, '(a)') "#TIMESTART"
     do i = 1, 6
       write(iRestartUnit_, *) iStartTime(i)
-    end do
+    enddo
 
     write(iRestartUnit_, *) ""
     write(iRestartUnit_, '(a)') "#SPHERE"
@@ -81,7 +81,7 @@ subroutine write_restart(dir)
 
     close(iRestartUnit_)
 
-  end if
+  endif
 
   do iBlock = 1, nBlocks
 
@@ -97,15 +97,15 @@ subroutine write_restart(dir)
       write(iRestartUnit_) Altitude_GB(:, :, :, iBlock)
     else
       write(iRestartUnit_) Altitude_GB(1, 1, :, iBlock)
-    end if
+    endif
 
     do iSpecies = 1, nSpeciesTotal
       write(iRestartUnit_) NDensityS(:, :, :, iSpecies, iBlock)
-    end do
+    enddo
 
     do iSpecies = 1, nIons
       write(iRestartUnit_) IDensityS(:, :, :, iSpecies, iBlock)
-    end do
+    enddo
 
     !alexey start
     MeanMajorMass(:, :, :) = 0
@@ -113,7 +113,7 @@ subroutine write_restart(dir)
       MeanMajorMass(:, :, :) = MeanMajorMass(:, :, :) + &
                                Mass(iSpecies)*NDensityS(:, :, :, iSpecies, iBlock)/ &
                                sum(NDensityS(:, :, :, 1:3, iBlock), 4)
-    end do
+    enddo
     TempUnit(:, :, :) = &
       MeanMajorMass(:, :, :)/Boltzmanns_Constant
     write(iRestartUnit_) Temperature(:, :, :, iBlock)*TempUnit(:, :, :)
@@ -181,7 +181,7 @@ subroutine write_restart(dir)
             call sleep(1.0)
             inquire(file='../advance_temp_e'//trim(adjustl(ens_cs))//'/here.txt', &
                     EXIST=IsThere)
-          end do
+          enddo
 
           if (iDebugLevel > 4) write(*, *) '=====> rst.f90: here.txt file found. Continuing  in advance_temp_e' &
             //trim(adjustl(ens_cs))
@@ -196,7 +196,7 @@ subroutine write_restart(dir)
           read(103, *) f_tmp(ens_c)
           close(103, status='DELETE')
           if (iDebugLevel > 4) write(*, *) '=====> rst.f90: f_tmp', f_tmp
-        end do
+        enddo
 
         mean_f = samp_mean(f_tmp)
         var_f = samp_var(f_tmp)
@@ -247,7 +247,7 @@ subroutine write_restart(dir)
           if (iDebugLevel > 4) &
             write(*, *) '=====> rst.f90: wrote here2.txt in ../advance_temp_e' &
             //trim(adjustl(ens_cs))//' with iostat of', iError
-        end do
+        enddo
 
         f107 = f_tmp2(1) !master should read his inflated f107
         if (iDebugLevel > 4) &
@@ -255,7 +255,7 @@ subroutine write_restart(dir)
 
         deallocate(f_tmp) !clean up
         deallocate(f_tmp2)
-      end if
+      endif
       !+ this is b-casted so that all blocks have the same f107
       call MPI_BCAST(f107, 1, MPI_Real, 0, iCommGITM, iError)
       if (iDebugLevel > 4) &
@@ -287,7 +287,7 @@ subroutine write_restart(dir)
           write(*, *) '=====> rst.f90: here2.txt file NOT found. Waiting.'
           call sleep(1.0)
           inquire(file='here2.txt', EXIST=IsThere)
-        end do
+        enddo
 
         if (iDebugLevel > 4) &
           write(*, *) '=====> rst.f90: here2.txt file found. Continuing.'
@@ -304,14 +304,14 @@ subroutine write_restart(dir)
         if (iDebugLevel > 4) &
           write(*, *) '=====> rst.f90: write_rst_f107', f107
 
-      end if
+      endif
       !+ this is b-casted so that all blocks have the same f107
       call MPI_BCAST(f107, 1, MPI_Real, 0, iCommGITM, iError)
       if (iDebugLevel > 4) &
         write(*, *) '=====> rst.f90: broadcasted to iproc, f107:', &
         iProc, f107
 
-    end if
+    endif
 
     !alexey write f107 into the restart file (for DART)
     write(iRestartUnit_) f107
@@ -323,10 +323,10 @@ subroutine write_restart(dir)
       write(iRestartUnit_) SubSurfaceTemp(:, :, iBlock)
       write(iRestartUnit_) dSurfaceTemp(:, :, iBlock)
       write(iRestartUnit_) dSubSurfaceTemp(:, :, iBlock)
-    end if
+    endif
     close(iRestartUnit_)
 
-  end do
+  enddo
 
 !routines alexey needed
 contains
@@ -389,15 +389,15 @@ subroutine read_restart(dir)
       read(iRestartUnit_) Altitude_GB(1, 1, :, iBlock)
       do iAlt = -1, nAlts + 2
         Altitude_GB(:, :, iAlt, iBlock) = Altitude_GB(1, 1, iAlt, iBlock)
-      end do
-    end if
+      enddo
+    endif
 !     read(iRestartUnit_) Altitude_GB(:,:,:,iBlock)
 
     do iSpecies = 1, nSpeciesTotal
       if (iDebugLevel > 3) &
         write(*, *) "====> Reading Species", iSpecies, Mass(iSpecies)
       read(iRestartUnit_) NDensityS(:, :, :, iSpecies, iBlock)
-    end do
+    enddo
 
     Rho(:, :, :, iBlock) = 0.0
     NDensity(:, :, :, iBlock) = 0.0
@@ -406,13 +406,13 @@ subroutine read_restart(dir)
                              Mass(iSpecies)*NDensityS(:, :, :, iSpecies, iBlock)
       NDensity(:, :, :, iBlock) = NDensity(:, :, :, iBlock) + &
                                   NDensityS(:, :, :, iSpecies, iBlock)
-    end do
+    enddo
 
     do iSpecies = 1, nIons
       if (iDebugLevel > 4) &
         write(*, *) "=====> Reading Ion Species", iSpecies, Mass(iSpecies)
       read(iRestartUnit_) IDensityS(:, :, :, iSpecies, iBlock)
-    end do
+    enddo
 
     if (iDebugLevel > 4) write(*, *) "=====> Reading Temperature"
     read(iRestartUnit_) Temperature(:, :, :, iBlock)
@@ -423,7 +423,7 @@ subroutine read_restart(dir)
       MeanMajorMass(:, :, :) = MeanMajorMass(:, :, :) + &
                                Mass(iSpecies)*NDensityS(:, :, :, iSpecies, iBlock)/ &
                                sum(NDensityS(:, :, :, 1:3, iBlock), 4)
-    end do
+    enddo
     TempUnit(:, :, :) = &
       MeanMajorMass(:, :, :)/Boltzmanns_Constant
     Temperature(:, :, :, iBlock) = Temperature(:, :, :, iBlock)/TempUnit(:, :, :)
@@ -451,7 +451,7 @@ subroutine read_restart(dir)
       call IO_set_f107_single(f107)
       !replace f107 81-day average with the SAME estimate
       call IO_set_f107a_single(f107)
-    end if
+    endif
 
     !read Rho, but hope DART will affect GITM via other vars instead
     read(iRestartUnit_) Rho(:, :, :, iBlock)
@@ -463,10 +463,10 @@ subroutine read_restart(dir)
       read(iRestartUnit_) SubSurfaceTemp(:, :, iBlock)
       read(iRestartUnit_) dSurfaceTemp(:, :, iBlock)
       read(iRestartUnit_) dSubSurfaceTemp(:, :, iBlock)
-    end if
+    endif
     close(iRestartUnit_)
 
-  end do
+  enddo
 
   if (.not. Is1D) call exchange_messages_sphere
 

--- a/src/satellites.f90
+++ b/src/satellites.f90
@@ -53,7 +53,7 @@ subroutine read_satellites(iError)
     call init_mod_satellites_rcmr
   else
     call init_mod_satellites
-  end if
+  endif
 
   iError = 0
   nSatLines = 0
@@ -70,7 +70,7 @@ subroutine read_satellites(iError)
     if (iError /= 0) then
       write(*, *) "Error opening satellite file : ", cSatFileName(iSat)
       return
-    end if
+    endif
 
     IsStartFound = .false.
 
@@ -79,14 +79,14 @@ subroutine read_satellites(iError)
       read(iSatUnit, *, iostat=iError) cLine
       if (iError /= 0) IsStartFound = .true.
       if (index(cline, "#START") > 0) IsStartFound = .true.
-    end do
+    enddo
 
     if (iError /= 0) then
       write(*, *) "Error finding #START in satellite file : ", &
         cSatFileName(iSat)
       close(iSatUnit)
       return
-    end if
+    endif
 
     OldTime = 0.0
     IsFine = .false.
@@ -98,7 +98,7 @@ subroutine read_satellites(iError)
         read(iSatUnit, *, iostat=iError) iTime, Pos, dat
       else
         read(iSatUnit, *, iostat=iError) iTime, Pos
-      end if
+      endif
 
       if (iError == 0) then
 
@@ -129,7 +129,7 @@ subroutine read_satellites(iError)
             SatTime(iSat, nSatLines(iSat)) = NewTime
 
             if (RCMRFlag) SatDat(iSat, nSatLines(iSat)) = dat
-          end if
+          endif
         else
           nSatPos(iSat, nSatLines(iSat)) = nSatPos(iSat, nSatLines(iSat)) + 1
           if (nSatPos(iSat, nSatLines(iSat)) > nMaxSatPos - 2) then
@@ -141,19 +141,19 @@ subroutine read_satellites(iError)
             SatPos(iSat, :, nSatPos(iSat, nSatLines(iSat)), nSatLines(iSat)) = &
               Pos
             if (RCMRFlag) SatDat(iSat, nSatLines(iSat)) = dat
-          end if
-        end if
+          endif
+        endif
 
         OldTime = NewTime
 
-      end if
+      endif
 
-    end do
+    enddo
 
     close(iSatUnit)
     if (IsFine) iError = 0
 
-  end do
+  enddo
 
   if (iDebugLevel > 1) then
 
@@ -163,11 +163,11 @@ subroutine read_satellites(iError)
       iMax = 1
       do i = 1, nSatLines(iSat)
         if (nSatPos(iSat, i) > iMax) iMax = nSatPos(iSat, i)
-      end do
+      enddo
       write(*, *) iSat, ". Max number of Positions : ", iMax
-    end do
+    enddo
 
-  end if
+  endif
 
 end subroutine read_satellites
 
@@ -218,22 +218,22 @@ subroutine move_satellites
           else
             do while (SatTime(iSat, iLine) < CurrentTime)
               iLine = iLine + 1
-            end do
+            enddo
             iLine = iLine - 1
 
-          end if
+          endif
           iSatCurrentIndex(iSat) = iLine
           iLine = 0
-        end if
+        endif
       else
         if (CurrentTime > SatTime(iSat, iSatCurrentIndex(iSat) + 1) .and. &
             (CurrentTime - dt) < SatTime(iSat, iSatCurrentIndex(iSat) + 1)) then
 
           iSatCurrentIndex(iSat) = iSatCurrentIndex(iSat) + 1
 
-        end if
+        endif
 
-      end if
+      endif
 
       if (iSatCurrentIndex(iSat) /= iLine) then
 !only plot if the index has changed!
@@ -251,8 +251,8 @@ subroutine move_satellites
           SatCurrentPos(iSat, i, iPos) = &
             SatPos(iSat, i, iPos, iLine)
 
-        end if
-        end do
+        endif
+        enddo
 
         do iBlock = 1, nBlocks
 
@@ -262,9 +262,9 @@ subroutine move_satellites
           CurrentSatellitePosition = SatCurrentPos(iSat, :, iPos)
           CurrentSatelliteName = cName
           call output("UA/data/", iBlock, -1)
-        end do
-        end do
-      end if
+        enddo
+        enddo
+      endif
 
     else
 
@@ -283,11 +283,11 @@ subroutine move_satellites
             else
               do while (SatTime(iSat, iLine) < CurrentTime)
                 iLine = iLine + 1
-              end do
+              enddo
               iLine = iLine - 1
-            end if
+            endif
             iSatCurrentIndex(iSat) = iLine
-          end if
+          endif
         else
           iLine = iSatCurrentIndex(iSat)
           if (SatTime(iSat, nSatLines(iSat)) >= CurrentTime) then
@@ -296,14 +296,14 @@ subroutine move_satellites
             else
               do while (SatTime(iSat, iLine) < CurrentTime)
                 iLine = iLine + 1
-              end do
+              enddo
               iLine = iLine - 1
-            end if
+            endif
           else
             iLine = 0
-          end if
+          endif
           iSatCurrentIndex(iSat) = iLine
-        end if
+        endif
 
         if (iSatCurrentIndex(iSat) > 0) then
 
@@ -315,13 +315,13 @@ subroutine move_satellites
             iLine = iSatCurrentIndex(iSat) - 1
             r = 1 - (CurrentTime - SatTime(iSat, iLine))/ &
                 (SatTime(iSat, iLine + 1) - SatTime(iSat, iLine))
-          end if
+          endif
 
           if (RCMRFlag) then
             ! Asad: Estimate the current time's data value for each satellite
             SatCurrentDat(iSat) = r*SatDat(iSat, iLine) + &
                                   (1 - r)*SatDat(iSat, iLine + 1)
-          end if
+          endif
 
           do iPos = 1, nSatPos(iSat, iLine)
             do i = 1, 3
@@ -335,12 +335,12 @@ subroutine move_satellites
                 SatCurrentPos(iSat, i, iPos) = &
                   (r)*SatPos(iSat, i, iPos, iLine) + &
                   (1 - r)*SatPos(iSat, i, iPos, iLine + 1)
-              end if
+              endif
 
 !                write(*,*) "Satellite : ",iSat, iSatCurrentIndex(iSat), &
 !                     CurrentTime - SatTime(iSat,iSatCurrentIndex(iSat)), &
 !                     iPos, i, SatCurrentPos(iSat, i, iPos)
-            end do
+            enddo
             write(cPos, '(i3.3)') iPos
 
             l1 = index(cSatFileName(iSat), '/', back=.true.) + 1
@@ -354,14 +354,14 @@ subroutine move_satellites
 !                 call output_1d("UA/data/",cName,iBlock, &
 !                      SatCurrentPos(iSat,:,iPos))
               call output("UA/data/", iBlock, iOut)
-            end do
-          end do
+            enddo
+          enddo
 
-        end if
-      end if
-    end if
+        endif
+      endif
+    endif
 
-  end do
+  enddo
 
 end subroutine move_satellites
 

--- a/src/set_bcs.f90
+++ b/src/set_bcs.f90
@@ -37,9 +37,9 @@ subroutine set_bcs
           Velocity(iLon, iLat, nAlts + 1, iUp_, iBlock) = 0.0 ! -Vel(nAlts)
           Velocity(iLon, iLat, nAlts + 2, iUp_, iBlock) = 0.0 ! -Vel(nAlts-1)
 
-        end if
-      end do
-    end do
+        endif
+      enddo
+    enddo
 
 !     Temperature(:,:,nAlts+1,iBlock) = TempMax/TempUnit
 !     Temperature(:,:,nAlts+2,iBlock) = TempMax/TempUnit
@@ -54,7 +54,7 @@ subroutine set_bcs
       LogNS(:, :, nAlts + 1, iSpecies, iBlock) = &
         LogNS(:, :, nAlts, iSpecies, iBlock) + &
         2*dAlt(nAlts)*Gravity(nAlts)/Temperature(:, :, nAlts, iBlock)
-    end do
+    enddo
 
     LogRho(:, :, nAlts + 1, iBlock) = &
       LogRho(:, :, nAlts, iBlock) + &
@@ -63,6 +63,6 @@ subroutine set_bcs
       LogRho(:, :, nAlts, iBlock) + &
       2*dAlt(nAlts)*Gravity(nAlts)/Temperature(:, :, nAlts, iBlock)
 
-  end do
+  enddo
 
 end subroutine set_bcs

--- a/src/set_horizontal_bcs.f90
+++ b/src/set_horizontal_bcs.f90
@@ -36,17 +36,17 @@ subroutine set_horizontal_bcs(iBlock)
     call GetGitmFileList(iErr)
     if (iErr /= 0) then
       call stop_gitm("Error in trying to read GITM 3D Filelist in horizontal bcs")
-    end if
+    endif
 
     call GetGitmGeneralHeaderInfo(iErr)
     if (iErr /= 0) then
       call stop_gitm("Error in reading gitm header information in horizontal bcs")
-    end if
+    endif
 
     call GitmGetnVars(nVars)
     if (iErr /= 0) then
       call stop_gitm("Error in getting number of variables in horizontal bcs")
-    end if
+    endif
 
     allocate(vars(nVars))
     call GitmGetVars(vars)
@@ -60,28 +60,28 @@ subroutine set_horizontal_bcs(iBlock)
         minval(Longitude(:, iBlock)) < LonStart) then
       nPoints = nPoints + (nAlts + 4)*(nLats + 4)*2
       IsWestBC = .true.
-    end if
+    endif
 
     ! Eastern Boundary
     if (LonStart /= LonEnd .and. &
         maxval(Longitude(:, iBlock)) > LonEnd) then
       nPoints = nPoints + (nAlts + 4)*(nLats + 4)*2
       IsEastBC = .true.
-    end if
+    endif
 
     ! South Boundary
     if (LatStart > -pi/2.0 .and. &
         minval(Latitude(:, iBlock)) < LatStart) then
       nPoints = nPoints + (nAlts + 4)*(nLons + 4)*2
       IsSouthBC = .true.
-    end if
+    endif
 
     ! North Boundary
     if (LatStart > -pi/2.0 .and. &
         maxval(Latitude(:, iBlocK)) > LatEnd) then
       nPoints = nPoints + (nAlts + 4)*(nLons + 4)*2
       IsNorthBC = .true.
-    end if
+    endif
 
     call GitmSetnPointsToGet(nPoints)
 
@@ -100,10 +100,10 @@ subroutine set_horizontal_bcs(iBlock)
             latsBCs(iPoint) = latitude(iLat, iBlock)
             altsBCs(iPoint) = Altitude_GB(iLon, iLat, iAlt, iBlock)
             iPoint = iPoint + 1
-          end do
-        end do
-      end do
-    end if
+          enddo
+        enddo
+      enddo
+    endif
 
     if (IsEastBC) then
       do iLon = nLons + 1, nLons + 2
@@ -113,10 +113,10 @@ subroutine set_horizontal_bcs(iBlock)
             latsBCs(iPoint) = latitude(iLat, iBlock)
             altsBCs(iPoint) = Altitude_GB(iLon, iLat, iAlt, iBlock)
             iPoint = iPoint + 1
-          end do
-        end do
-      end do
-    end if
+          enddo
+        enddo
+      enddo
+    endif
 
     if (IsSouthBC) then
       do iLon = -1, nLons + 2
@@ -126,10 +126,10 @@ subroutine set_horizontal_bcs(iBlock)
             latsBCs(iPoint) = latitude(iLat, iBlock)
             altsBCs(iPoint) = Altitude_GB(iLon, iLat, iAlt, iBlock)
             iPoint = iPoint + 1
-          end do
-        end do
-      end do
-    end if
+          enddo
+        enddo
+      enddo
+    endif
 
     if (IsNorthBC) then
       do iLon = -1, nLons + 2
@@ -139,10 +139,10 @@ subroutine set_horizontal_bcs(iBlock)
             latsBCs(iPoint) = latitude(iLat, iBlock)
             altsBCs(iPoint) = Altitude_GB(iLon, iLat, iAlt, iBlock)
             iPoint = iPoint + 1
-          end do
-        end do
-      end do
-    end if
+          enddo
+        enddo
+      enddo
+    endif
 
     if (iPoint > 1) then
 
@@ -153,11 +153,11 @@ subroutine set_horizontal_bcs(iBlock)
 
       call GitmSetGrid(lonsBCs, latsBCs, altsBCs)
 
-    end if
+    endif
 
     IsFirstTime = .false.
 
-  end if
+  endif
 
   if (UseGitmBCs) then
 
@@ -167,7 +167,7 @@ subroutine set_horizontal_bcs(iBlock)
     else
       write(*, *) 'Error in getting GITM data in set_horizontal_BCs!'
       call stop_gitm('Must Stop!')
-    end if
+    endif
 
     iPoint = 1
 
@@ -177,10 +177,10 @@ subroutine set_horizontal_bcs(iBlock)
           do iAlt = -1, nAlts + 2
             call set_horizontal_bcs_1point(iLon, iLat, iAlt, iBlock, iPoint)
             iPoint = iPoint + 1
-          end do
-        end do
-      end do
-    end if
+          enddo
+        enddo
+      enddo
+    endif
 
     if (IsEastBC) then
       do iLon = nLons + 1, nLons + 2
@@ -188,10 +188,10 @@ subroutine set_horizontal_bcs(iBlock)
           do iAlt = -1, nAlts + 2
             call set_horizontal_bcs_1point(iLon, iLat, iAlt, iBlock, iPoint)
             iPoint = iPoint + 1
-          end do
-        end do
-      end do
-    end if
+          enddo
+        enddo
+      enddo
+    endif
 
     if (IsSouthBC) then
       do iLon = -1, nLons + 2
@@ -199,10 +199,10 @@ subroutine set_horizontal_bcs(iBlock)
           do iAlt = -1, nAlts + 2
             call set_horizontal_bcs_1point(iLon, iLat, iAlt, iBlock, iPoint)
             iPoint = iPoint + 1
-          end do
-        end do
-      end do
-    end if
+          enddo
+        enddo
+      enddo
+    endif
 
     if (IsNorthBC) then
       do iLon = -1, nLons + 2
@@ -210,10 +210,10 @@ subroutine set_horizontal_bcs(iBlock)
           do iAlt = -1, nAlts + 2
             call set_horizontal_bcs_1point(iLon, iLat, iAlt, iBlock, iPoint)
             iPoint = iPoint + 1
-          end do
-        end do
-      end do
-    end if
+          enddo
+        enddo
+      enddo
+    endif
 
   else
 
@@ -230,7 +230,7 @@ subroutine set_horizontal_bcs(iBlock)
               VerticalVelocity(iLon + 1, :, iAlt, iSpecies, iBlock)
             nDensityS(iLon, :, iAlt, iSpecies, iBlock) = &
               nDensityS(iLon + 1, :, iAlt, iSpecies, iBlock)
-          end do
+          enddo
 
           Rho(iLon, :, iAlt, iBlock) = &
             Rho(iLon + 1, :, iAlt, iBlock)
@@ -244,7 +244,7 @@ subroutine set_horizontal_bcs(iBlock)
           do iIon = 1, nIons
             IDensityS(iLon, :, iAlt, iIon, iBlock) = &
               IDensityS(iLon + 1, :, iAlt, iIon, iBlock)
-          end do
+          enddo
 
           Velocity(iLon, :, iAlt, iNorth_, iBlock) = &
             Velocity(iLon + 1, :, iAlt, iNorth_, iBlock)
@@ -260,9 +260,9 @@ subroutine set_horizontal_bcs(iBlock)
           iVelocity(iLon, :, iAlt, iUp_, iBlock) = &
             iVelocity(iLon + 1, :, iAlt, iUp_, iBlock)
 
-        end do
-      end do
-    end if
+        enddo
+      enddo
+    endif
 
     if (LonStart /= LonEnd .and. &
         maxval(Longitude(:, iBlock)) > LonEnd) then
@@ -278,7 +278,7 @@ subroutine set_horizontal_bcs(iBlock)
 !              nDensityS(iLon,:,iAlt,iSpecies,iBlock) = &
 !                   2*nDensityS(iLon-1,:,iAlt,iSpecies,iBlock) - &
 !                   nDensityS(iLon-2,:,iAlt,iSpecies,iBlock)
-          end do
+          enddo
 
           Rho(iLon, :, iAlt, iBlock) = &
             Rho(iLon - 1, :, iAlt, iBlock)
@@ -308,7 +308,7 @@ subroutine set_horizontal_bcs(iBlock)
 !              IDensityS(iLon,:,iAlt,iIon,iBlock) = &
 !                   2*IDensityS(iLon-1,:,iAlt,iIon,iBlock) - &
 !                   IDensityS(iLon-2,:,iAlt,iIon,iBlock)
-          end do
+          enddo
 
           Velocity(iLon, :, iAlt, iNorth_, iBlock) = &
             Velocity(iLon - 1, :, iAlt, iNorth_, iBlock)
@@ -324,9 +324,9 @@ subroutine set_horizontal_bcs(iBlock)
           iVelocity(iLon, :, iAlt, iUp_, iBlock) = &
             iVelocity(iLon - 1, :, iAlt, iUp_, iBlock)
 
-        end do
-      end do
-    end if
+        enddo
+      enddo
+    endif
 
     ! Southern Boundary
 
@@ -344,7 +344,7 @@ subroutine set_horizontal_bcs(iBlock)
 !              nDensityS(:,iLat,iAlt,iSpecies,iBlock) = &
 !                   2*nDensityS(:,iLat+1,iAlt,iSpecies,iBlock)- &
 !                   nDensityS(:,iLat+2,iAlt,iSpecies,iBlock)
-          end do
+          enddo
 
           Rho(:, iLat, iAlt, iBlock) = &
             Rho(:, iLat + 1, iAlt, iBlock)
@@ -362,7 +362,7 @@ subroutine set_horizontal_bcs(iBlock)
           do iIon = 1, nIons
             IDensityS(:, iLat, iAlt, iIon, iBlock) = &
               IDensityS(:, iLat + 1, iAlt, iIon, iBlock)
-          end do
+          enddo
 
           Velocity(:, iLat, iAlt, iNorth_, iBlock) = &
             Velocity(:, iLat + 1, iAlt, iNorth_, iBlock)
@@ -378,9 +378,9 @@ subroutine set_horizontal_bcs(iBlock)
           iVelocity(:, iLat, iAlt, iUp_, iBlock) = &
             iVelocity(:, iLat + 1, iAlt, iUp_, iBlock)
 
-        end do
-      end do
-    end if
+        enddo
+      enddo
+    endif
 
     if (LatEnd < pi/2.0 .and. &
         maxval(Latitude(:, iBlocK)) > LatEnd) then
@@ -396,7 +396,7 @@ subroutine set_horizontal_bcs(iBlock)
 !              nDensityS(:,iLat,iAlt,iSpecies,iBlock) = &
 !                   2*nDensityS(:,iLat-1,iAlt,iSpecies,iBlock) - &
 !                   nDensityS(:,iLat-2,iAlt,iSpecies,iBlock)
-          end do
+          enddo
 
           Rho(:, iLat, iAlt, iBlock) = &
             Rho(:, iLat - 1, iAlt, iBlock)
@@ -414,7 +414,7 @@ subroutine set_horizontal_bcs(iBlock)
           do iIon = 1, nIons
             IDensityS(:, iLat, iAlt, iIon, iBlock) = &
               IDensityS(:, iLat - 1, iAlt, iIon, iBlock)
-          end do
+          enddo
 
           Velocity(:, iLat, iAlt, iNorth_, iBlock) = &
             Velocity(:, iLat - 1, iAlt, iNorth_, iBlock)
@@ -430,11 +430,11 @@ subroutine set_horizontal_bcs(iBlock)
           iVelocity(:, iLat, iAlt, iUp_, iBlock) = &
             iVelocity(:, iLat - 1, iAlt, iUp_, iBlock)
 
-        end do
-      end do
-    end if
+        enddo
+      enddo
+    endif
 
-  end if
+  endif
 
 end subroutine set_horizontal_bcs
 
@@ -457,14 +457,14 @@ subroutine set_horizontal_bcs_1point(iLon, iLat, iAlt, iBlock, iPoint)
 !     if (iProc == 0) then
 !        write(*,*) 'ndensity : ',iSpecies, GitmFileData(iPoint,iSpecies+iNeutralStart_-1)
 !     endif
-  end do
+  enddo
   do iSpecies = 1, nIons
     IDensityS(iLon, iLat, iAlt, iSpecies, iBlock) = &
       GitmFileData(iPoint, iSpecies + iIonStart_ - 1)
 !     if (iProc == 0) then
 !        write(*,*) 'idensity : ',iSpecies, GitmFileData(iPoint,iSpecies+iIonStart_-1)
 !     endif
-  end do
+  enddo
 
   ! Need to calculate tempunit to get normalized temperature
   MeanMajorMass(iLon, iLat, iAlt) = 0.0
@@ -473,7 +473,7 @@ subroutine set_horizontal_bcs_1point(iLon, iLat, iAlt, iBlock, iPoint)
       MeanMajorMass(iLon, iLat, iAlt) + &
       Mass(iSpecies)*NDensityS(iLon, iLat, iAlt, iSpecies, iBlock)/ &
       sum(NDensityS(iLon, iLat, iAlt, :, iBlock))
-  end do
+  enddo
   TempUnit(iLon, iLat, iAlt) = MeanMajorMass(iLon, iLat, iAlt)/Boltzmanns_Constant
   Temperature(iLon, iLat, iAlt, iBlock) = &
     GitmFileData(iPoint, iTn_)/TempUnit(iLon, iLat, iAlt)
@@ -486,12 +486,12 @@ subroutine set_horizontal_bcs_1point(iLon, iLat, iAlt, iBlock, iPoint)
       GitmFileData(iPoint, iVn_ + iDir - 1)
     iVelocity(iLon, iLat, iAlt, iDir, iBlock) = &
       GitmFileData(iPoint, iVi_ + iDir - 1)
-  end do
+  enddo
   ! Vertical Velocities
   do iSpecies = 1, nSpecies
     VerticalVelocity(iLon, iLat, iAlt, iSpecies, iBlock) = &
       GitmFileData(iPoint, iVn_ + 3 + iSpecies - 1)
-  end do
+  enddo
 
 end subroutine set_horizontal_bcs_1point
 

--- a/src/set_inputs.f90
+++ b/src/set_inputs.f90
@@ -84,14 +84,14 @@ subroutine set_inputs
             write(*, *) "-   UAM trying to set STARTTIME  -"
             write(*, *) "-          Ignoring              -"
             write(*, *) "----------------------------------"
-          end if
+          endif
 
         else
 
           iStartTime = 0
           do i = 1, 6
             call read_in_int(iStartTime(i), iError)
-          end do
+          enddo
 
           if (iError /= 0) then
             write(*, *) 'Incorrect format for #STARTTIME:'
@@ -114,13 +114,13 @@ subroutine set_inputs
             if (tSimulation > 0) then
               CurrentTime = CurrentTime + tSimulation
               call time_real_to_int(CurrentTime, iTimeArray)
-            end if
+            endif
 
             call fix_vernal_time
 
-          end if
+          endif
 
-        end if
+        endif
 
       case ("#TIMEEND", "#ENDTIME")
 
@@ -130,13 +130,13 @@ subroutine set_inputs
             write(*, *) "-   UAM trying to set ENDTIME  -"
             write(*, *) "-          Ignoring            -"
             write(*, *) "--------------------------------"
-          end if
+          endif
         else
 
           iTimeEnd = 0
           do i = 1, 6
             call read_in_int(iTimeEnd(i), iError)
-          end do
+          enddo
 
           if (iError /= 0) then
             write(*, *) 'Incorrect format for #ENDTIME:'
@@ -152,9 +152,9 @@ subroutine set_inputs
           else
             call time_int_to_real(iTimeEnd, EndTime)
             PauseTime = EndTime + 1.0
-          end if
+          endif
 
-        end if
+        endif
 
       case ("#PAUSETIME")
         call read_in_time(PauseTime, iError)
@@ -165,7 +165,7 @@ subroutine set_inputs
           write(*, *) '#PAUSETIME'
           write(*, *) 'iYear iMonth iDay iHour iMinute iSecond'
           IsDone = .true.
-        end if
+        endif
 
       case ("#ISTEP")
         call read_in_int(iStep, iError)
@@ -177,7 +177,7 @@ subroutine set_inputs
           write(*, *) '#ISTEP'
           write(*, *) 'iStep     (integer)'
           IsDone = .true.
-        end if
+        endif
 
       case ("#CPUTIMEMAX")
         call read_in_real(CPUTIMEMAX, iError)
@@ -192,7 +192,7 @@ subroutine set_inputs
           write(*, *) 'the restart files.'
           write(*, *) '#CPUTIMEMAX'
           write(*, *) 'CPUTimeMax    (real)'
-        end if
+        endif
 
       case ("#STATISTICALMODELSONLY")
         call read_in_logical(UseStatisticalModelsOnly, iError)
@@ -212,7 +212,7 @@ subroutine set_inputs
           write(*, *) '#STATISTICALMODELSONLY'
           write(*, *) 'UseStatisticalModelsOnly    (logical)'
           write(*, *) 'DtStatisticalModels         (real)'
-        end if
+        endif
 
       case ("#TSIMULATION")
 
@@ -222,7 +222,7 @@ subroutine set_inputs
             write(*, *) "-   UAM trying to set tsimulation  -"
             write(*, *) "-          Ignoring                -"
             write(*, *) "------------------------------------"
-          end if
+          endif
         else
           call read_in_real(tSim_temp, iError)
           tSimulation = tSim_temp
@@ -238,8 +238,8 @@ subroutine set_inputs
           else
             CurrentTime = CurrentTime + tsimulation
             call time_real_to_int(CurrentTime, iTimeArray)
-          end if
-        end if
+          endif
+        endif
 
       case ("#F107")
         if (RCMROutType == "F107") then
@@ -248,7 +248,7 @@ subroutine set_inputs
         else
           call read_in_real(f107, iError)
           call read_in_real(f107a, iError)
-        end if
+        endif
 
         if (iError /= 0) then
           write(*, *) 'Incorrect format for #F107:'
@@ -264,9 +264,9 @@ subroutine set_inputs
           else
             f107 = 150.0
             f107a = 150.0
-          end if
+          endif
           IsDone = .true.
-        end if
+        endif
 
         ! AGB: Added switch for initializing the GITM f107 depending on
         !      the data assimilation (RCMR) flags
@@ -274,7 +274,7 @@ subroutine set_inputs
         if (RCMROutType /= "F107") then
           call IO_set_f107_single(f107)
           call IO_set_f107a_single(f107a)
-        end if
+        endif
 
       case ("#INITIAL")
 
@@ -288,14 +288,14 @@ subroutine set_inputs
           do i = 1, nSpecies
             call read_in_real(LogNS0(i), iError)
             if (iError == 0) LogNS0(i) = alog(LogNS0(i))
-          end do
+          enddo
           LogRho0 = 0.0
           do iSpecies = 1, nSpecies
             LogRho0 = LogRho0 + &
                       exp(LogNS0(iSpecies))*Mass(iSpecies)
-          end do
+          enddo
           LogRho0 = alog(LogRho0)
-        end if
+        endif
         if (iError /= 0) then
           write(*, *) 'Incorrect format for #INITIAL:'
           write(*, *) 'This specifies the initial conditions and the'
@@ -312,8 +312,8 @@ subroutine set_inputs
           write(*, *) 'TempWidth      (real, Width of the temperature gradient)'
           do i = 1, nSpecies
             write(*, *) 'Bottom N Density (real), species', i
-          end do
-        end if
+          enddo
+        endif
 
       case ("#TIDES")
         call read_in_logical(UseMSISOnly, iError)
@@ -343,8 +343,8 @@ subroutine set_inputs
             UseMSISDiurnal = .false.
             UseMSISSemidiurnal = .false.
             UseMSISTerdiurnal = .false.
-          end if
-        end if
+          endif
+        endif
 
       case ("#MSISTIDES")
         call read_in_logical(UseMSISDiurnal, iError)
@@ -360,7 +360,7 @@ subroutine set_inputs
           write(*, *) 'UseMSISDiurnal        (logical)'
           write(*, *) 'UseMSISSemidiurnal    (logical)'
           write(*, *) 'UseMSISTerdiurnal     (logical)'
-        end if
+        endif
 
       case ("#MSISOBC")
         call read_in_logical(UseOBCExperiment, iError)
@@ -372,7 +372,7 @@ subroutine set_inputs
           write(*, *) '#MSISOBC'
           write(*, *) 'UseOBCExperiment        (logical)'
           write(*, *) 'MsisOblateFactor           (real)'
-        end if
+        endif
 
         !xianjing
       case ("#USESECONDSINFILENAME")
@@ -383,7 +383,7 @@ subroutine set_inputs
           write(*, *) 'name. F means no seconds in output file name.'
         else
           if (UseSecondsInFilename) UseSecondsInFilename = .false.
-        end if
+        endif
 
       case ("#DUSTDATA")
         call read_in_logical(UseDustDistribution, iError)
@@ -394,7 +394,7 @@ subroutine set_inputs
           write(*, *) '#DUST'
           write(*, *) 'cDustFile'
           write(*, *) 'cConrathFile'
-        end if
+        endif
 
       case ("#OVERWRITEIONOSPHERE")
         call read_in_logical(DoOverwriteIonosphere, iError)
@@ -409,7 +409,7 @@ subroutine set_inputs
           write(*, *) 'DoOverwriteWithIRI'
           write(*, *) 'DoOverwriteWithSami'
           write(*, *) 'SamiInFile'
-        end if
+        endif
 
       case ("#DIRECTORIES")
         call read_in_string(outputDir, iError)
@@ -425,7 +425,7 @@ subroutine set_inputs
           write(*, *) '#GITMBCS'
           write(*, *) 'UseGitmBCs'
           write(*, *) 'GitmBCsDir'
-        end if
+        endif
 
       case ("#DUST")
         call read_in_real(tautot_temp, iError)
@@ -435,12 +435,12 @@ subroutine set_inputs
           write(*, *) '#DUST'
           write(*, *) 'TauTot'
           write(*, *) 'Conrnu'
-        end if
+        endif
 
       CASE ("#GSWMCOMP")
         DO i = 1, 4
           CALL read_in_logical(UseGswmComp(i), iError)
-        end do
+        enddo
         IF (iError /= 0) then
           write(*, *) 'Incorrect format for #GSWMCOMP:'
           write(*, *) 'If you selected to use GSWM tides above, you'
@@ -450,7 +450,7 @@ subroutine set_inputs
           write(*, *) 'GSWMdiurnal(2)        (logical)'
           write(*, *) 'GSWMsemidiurnal(1)    (logical)'
           write(*, *) 'GSWMsemidiurnal(2)    (logical)'
-        END IF
+        ENDIF
 
       case ("#USEPERTURBATION")
         call read_in_logical(UsePerturbation, iError)
@@ -461,7 +461,7 @@ subroutine set_inputs
           write(*, *) '#USEPERTURBATION'
           write(*, *) 'UsePerturbation        (logical)'
           IsDone = .true.
-        end if
+        endif
 
         ! For WP-GITM
       case ("#USEBCPERTURBATION")
@@ -491,8 +491,8 @@ subroutine set_inputs
             call read_in_real(SeisWaveTimeDelay, iError)
             call read_in_real(EpiDistance, iError)
             call read_in_string(cSurfacePerturbFileName, iError)
-          end if
-        end if
+          endif
+        endif
         if (iError /= 0) then
           write(*, *) 'Incorrect format for #USEBCPERTURBATION":'
           write(*, *) ''
@@ -516,12 +516,12 @@ subroutine set_inputs
             read(iUnitFile, *, iostat=iErrorFile) cLine
             if (iErrorFile /= 0) IsStartFound = .true.
             if (index(cline, "#START") > 0) IsStartFound = .true.
-          end do
+          enddo
           if (iErrorFile /= 0) then
             write(*, *) "Error finding #START in surface perturbation file: ", &
               cSurfacePerturbFileName
             call stop_gitm("Must Stop!")
-          end if
+          endif
           iFreq = 0
           do while (iErrorFile == 0)
             iFreq = iFreq + 1
@@ -535,8 +535,8 @@ subroutine set_inputs
                 nMaxPerturbFreq
               write(*, *) "Increase nMaxPerturbFreq in ModInputs.f90 !!!"
               call stop_gitm("Must Stop!")
-            end if
-          end do
+            endif
+          enddo
           close(iUnitFile)
           ! the number of frequecies to use
           nPerturbFreq = iFreq - 1
@@ -546,7 +546,7 @@ subroutine set_inputs
             write(*, *) 'For WP: nPerturbFreq = ', &
             nPerturbFreq, 'PerturbWaveFreq(1:nPerturbFreq) = ', &
             PerturbWaveFreq(1:nPerturbFreq)
-        end if
+        endif
 
       case ("#DAMPING")
         call read_in_logical(UseDamping, iError)
@@ -557,7 +557,7 @@ subroutine set_inputs
           write(*, *) '#DAMPING'
           write(*, *) 'UseDamping        (logical)'
           IsDone = .true.
-        end if
+        endif
 
       case ("#GRAVITYWAVE")
         call read_in_logical(UseGravityWave, iError)
@@ -568,7 +568,7 @@ subroutine set_inputs
           write(*, *) '#GRAVITYWAVE'
           write(*, *) 'UseGravityWave        (logical)'
           IsDone = .true.
-        end if
+        endif
 
       case ("#HPI")
         call read_in_real(HemisphericPower, iError)
@@ -582,7 +582,7 @@ subroutine set_inputs
           IsDone = .true.
         else
           call IO_set_hpi_single(HemisphericPower)
-        end if
+        endif
 
       case ("#KP")
         call read_in_real(kp, iError)
@@ -595,7 +595,7 @@ subroutine set_inputs
           IsDone = .true.
         else
           call IO_set_kp_single(kp)
-        end if
+        endif
 
       case ("#CFL")
         call read_in_real(cfl, iError)
@@ -608,7 +608,7 @@ subroutine set_inputs
           write(*, *) '#CFL'
           write(*, *) 'cfl  (real)'
           IsDone = .true.
-        end if
+        endif
 
       case ("#FIXEDDT")
         call read_in_real(fixeddt, iError)
@@ -620,7 +620,7 @@ subroutine set_inputs
           write(*, *) '#FIXEDDT'
           write(*, *) 'FixedDt  (real)'
           IsDone = .true.
-        end if
+        endif
 
       case ("#SOLARWIND")
         call read_in_real(bx, iError)
@@ -643,7 +643,7 @@ subroutine set_inputs
           call IO_set_imf_by_single(by)
           call IO_set_imf_bz_single(bz)
           call IO_set_sw_v_single(abs(vx))
-        end if
+        endif
 
       case ("#MHD_INDICES")
 
@@ -671,15 +671,15 @@ subroutine set_inputs
             call read_MHDIMF_Indices(iError)
           else
             call read_MHDIMF_Indices_new(iError, CurrentTime, EndTime)
-          end if
+          endif
           if (iError /= 0) then
             write(*, *) "read indices was NOT successful (imf file)"
             IsDone = .true.
           else
             UseVariableInputs = .true.
-          end if
+          endif
 
-        end if
+        endif
 
       case ("#AURORA")
         call read_in_string(cAuroralModel, iError)
@@ -705,7 +705,7 @@ subroutine set_inputs
           write(*, *) 'AveEFactor    (real)'
           write(*, *) 'IsKappaAurora     (logical)'
           write(*, *) 'AuroraKappa    (real)'
-        end if
+        endif
 
       case ("#NEWELLAURORA")
         call read_in_logical(UseNewellAurora, iError)
@@ -715,7 +715,7 @@ subroutine set_inputs
           call read_in_logical(UseNewellWave, iError)
           call read_in_logical(DoNewellRemoveSpikes, iError)
           call read_in_logical(DoNewellAverage, iError)
-        end if
+        endif
         if (iError /= 0) then
           write(*, *) 'Incorrect format for #NEWELLAURORA'
           write(*, *) 'This is for using Pat Newells aurora (Ovation).'
@@ -731,7 +731,7 @@ subroutine set_inputs
         else
           if (UseNewellAurora .and. .not. HasSetAuroraMods) &
             NormalizeAuroraToHP = .false.
-        end if
+        endif
 
       case ("#OVATIONSME")
         call read_in_logical(UseOvationSME, iError)
@@ -751,7 +751,7 @@ subroutine set_inputs
         else
           if (UseOvationSME .and. .not. HasSetAuroraMods) &
             NormalizeAuroraToHP = .false.
-        end if
+        endif
 
       case ("#AEMODEL")
         call read_in_logical(UseAeModel, iError)
@@ -765,7 +765,7 @@ subroutine set_inputs
         else
           if (UseAeModel .and. .not. HasSetAuroraMods) &
             NormalizeAuroraToHP = .false.
-        end if
+        endif
 
       case ("#FTAMODEL")
         call read_in_logical(UseFtaModel, iError)
@@ -779,7 +779,7 @@ subroutine set_inputs
         else
           if (UseFtaModel .and. .not. HasSetAuroraMods) &
             NormalizeAuroraToHP = .false.
-        end if
+        endif
 
       case ("#FANGENERGY")
         call read_in_logical(UseFangEnergyDeposition, iError)
@@ -790,7 +790,7 @@ subroutine set_inputs
           write(*, *) '#FANGENERGY'
           write(*, *) 'UseFangEnergyDeposition        (logical)'
           IsDone = .true.
-        end if
+        endif
 
       case ("#USECUSP")
         call read_in_logical(UseCusp, iError)
@@ -805,7 +805,7 @@ subroutine set_inputs
           write(*, *) 'CuspAveE       (real)'
           write(*, *) 'CuspEFlux      (real)'
           IsDone = .true.
-        end if
+        endif
 
       case ("#AMIEFILES")
         call read_in_string(cAMIEFileNorth, iError)
@@ -821,7 +821,7 @@ subroutine set_inputs
           if (index(cAMIEFileNorth, "none") == 0 .and. &
               .not. HasSetAuroraMods) &
             NormalizeAuroraToHP = .false.
-        end if
+        endif
 
       case ("#USEREGIONALAMIE")
         call read_in_logical(UseRegionalAMIE, iError)
@@ -851,7 +851,7 @@ subroutine set_inputs
           write(*, *) 'AMIELatEnd           (real)'
           write(*, *) 'AMIEBoundaryWidth    (real)'
           IsDone = .true.
-        end if
+        endif
 
       case ("#LIMITER")
         call read_in_string(TypeLimiter, iError)
@@ -864,7 +864,7 @@ subroutine set_inputs
           write(*, *) 'TypeLimiter  (string)'
           write(*, *) 'BetaLimiter  (real between 1.0-minmod and 2.0-mc)'
           IsDone = .true.
-        end if
+        endif
 
         call read_in_real(BetaLimiter, iError)
         if (iError /= 0) then
@@ -875,14 +875,14 @@ subroutine set_inputs
             write(*, *) '#LIMITER'
             write(*, *) 'TypeLimiter  (string)'
             write(*, *) 'BetaLimiter  (real between 1.0-minmod and 2.0-mc)'
-          end if
+          endif
           iError = 0
         else
           if (BetaLimiter < 1.0) BetaLimiter = 1.0
           if (BetaLimiter > 2.0) BetaLimiter = 2.0
           if (iDebugLevel > 2) &
             write(*, *) "===>Beta Limiter set to ", BetaLimiter
-        end if
+        endif
 
       case ("#NANCHECK")
         call read_in_logical(DoCheckForNans, iError)
@@ -892,7 +892,7 @@ subroutine set_inputs
           write(*, *) '#NANCHECK'
           write(*, *) 'DoCheckForNans (logical)'
           IsDone = .true.
-        end if
+        endif
 
       case ("#DEBUG")
         call read_in_int(iDebugLevel, iError)
@@ -916,7 +916,7 @@ subroutine set_inputs
           write(*, *) 'DtReport    (real)'
           write(*, *) 'UseBarriers (logical)'
           IsDone = .true.
-        end if
+        endif
 
       case ("#IONLIMITS")
         call read_in_real(MaxVParallel, iError)
@@ -930,7 +930,7 @@ subroutine set_inputs
           MaxVParallel = 100.0
           MaxEField = 0.1
           IsDone = .true.
-        end if
+        endif
 
       case ("#PHOTOELECTRON")
         if (RCMROutType /= 'PHOTOELECTRON') then
@@ -941,8 +941,8 @@ subroutine set_inputs
             write(*, *) '#PHOTOELECTRON'
             write(*, *) "PhotoElectronHeatingEfficiency   (real)"
             IsDone = .true.
-          end if
-        end if
+          endif
+        endif
 
       case ("#NEUTRALHEATING")
         call read_in_real(NeutralHeatingEfficiency, iError)
@@ -952,7 +952,7 @@ subroutine set_inputs
           write(*, *) '#NEUTRALHEATING'
           write(*, *) "NeutralHeatingEfficiency   (real)"
           IsDone = .true.
-        end if
+        endif
 
       case ("#THERMO")
         call read_in_logical(UseSolarHeating, iError)
@@ -976,7 +976,7 @@ subroutine set_inputs
           write(*, *) "UseTurbulentCond  (logical)"
           write(*, *) "UseIRHeating      (logical)"
           IsDone = .true.
-        end if
+        endif
 
       case ("#THERMALDIFFUSION")
         call read_in_real(KappaTemp0, iError)
@@ -985,7 +985,7 @@ subroutine set_inputs
           write(*, *) ''
           write(*, *) '#THERMALDIFFUSION'
           write(*, *) "KappaTemp0    (thermal conductivity, real)"
-        end if
+        endif
 
       case ("#THERMALCONDUCTION")
         call read_in_real(ThermalConduction_AO2, iError)
@@ -998,7 +998,7 @@ subroutine set_inputs
           write(*, *) "ThermalConduction_AO2 (Conduction A(O2): 3.6e-4, real)"
           write(*, *) "ThermalConduction_AO  (Conduction A(O): 5.6e-4, real)"
           write(*, *) "ThermalConduction_s   (Conduction s: 0.75, real)"
-        end if
+        endif
 
       case ("#VERTICALSOURCES")
         call read_in_real(MaximumVerticalVelocity, iError)
@@ -1007,7 +1007,7 @@ subroutine set_inputs
           write(*, *) ''
           write(*, *) '#VERTICALSOURCES'
           write(*, *) "MaximumVerticalVelocity      (real)"
-        end if
+        endif
 
       case ("#AUSMSOLVER")
         call read_in_logical(UseAUSMSolver, iError)
@@ -1016,7 +1016,7 @@ subroutine set_inputs
           write(*, *) ''
           write(*, *) '#AUSMSOLVER'
           write(*, *) "Use AUSM Solver      (logical)"
-        end if
+        endif
 
       case ("#DIFFUSION")
         call read_in_logical(UseDiffusion, iError)
@@ -1024,11 +1024,11 @@ subroutine set_inputs
           call read_in_real(EddyDiffusionCoef, iError)
           call read_in_real(EddyDiffusionPressure0, iError)
           call read_in_real(EddyDiffusionPressure1, iError)
-        end if
+        endif
 
         if (EddyDiffusionPressure0 < EddyDiffusionPressure1) then
           iError = 1
-        end if
+        endif
 
         if (iError /= 0) then
           write(*, *) 'Incorrect format for #DIFFUSION:'
@@ -1042,7 +1042,7 @@ subroutine set_inputs
           write(*, *) "EddyDiffusionCoef (real)"
           write(*, *) "EddyDiffusionPressure0 (real)"
           write(*, *) "EddyDiffusionPressure1 (real)"
-        end if
+        endif
 
       case ("#FORCING")
         call read_in_logical(UsePressureGradient, iError)
@@ -1062,7 +1062,7 @@ subroutine set_inputs
           write(*, *) "UseCoriolis         (logical)"
           write(*, *) "UseGravity          (logical)"
           IsDone = .true.
-        end if
+        endif
 
       case ("#MODIFIYPLANET")
         call read_in_real(RotationPeriodInput, iError)
@@ -1077,7 +1077,7 @@ subroutine set_inputs
           write(*, *) "RotationPeriodInput        (real)"
           write(*, *) "DaysPerYearInput           (real)"
           write(*, *) "DaysPerYearInput           (real)"
-        end if
+        endif
 
       case ("#USEIMPLICITIONMOMENTUM")
         call read_in_logical(UseImplicitFieldAlignedMomentum, iError)
@@ -1086,7 +1086,7 @@ subroutine set_inputs
           write(*, *) ''
           write(*, *) '#USEIMPLICITIONMOMENTUM'
           write(*, *) "UseImplicitFieldAlignedMomentum      (logical)"
-        end if
+        endif
 
       case ("#USEIMPROVEDIONADVECTION")
         call read_in_logical(UseImprovedIonAdvection, iError)
@@ -1098,7 +1098,7 @@ subroutine set_inputs
           write(*, *) '#USEIMPROVEDIONADVECTION'
           write(*, *) "UseImprovedIonAdvection      (logical)"
           write(*, *) "UseNighttimeIonBCs           (logical)"
-        end if
+        endif
 
       case ("#USETESTVISCOSITY")
         call read_in_real(TestViscosityFactor, iError)
@@ -1107,7 +1107,7 @@ subroutine set_inputs
           write(*, *) ''
           write(*, *) '#USETESTVISCOSITY'
           write(*, *) "TestViscosityFactor      (real)"
-        end if
+        endif
 
       case ("#DYNAMO")
         call read_in_logical(UseDynamo, iError)
@@ -1117,7 +1117,7 @@ subroutine set_inputs
           call read_in_real(MaxResidual, iError)
           call read_in_logical(IncludeCowling, iError)
           call read_in_real(DynamoLonAverage, iError)
-        end if
+        endif
         if (iError /= 0) then
           write(*, *) 'Incorrect format for #DYNAMO:'
           write(*, *) ''
@@ -1128,7 +1128,7 @@ subroutine set_inputs
           write(*, *) "MaxResidual            (V,real)"
           write(*, *) "IncludeCowling         (logical)"
           write(*, *) "DynamoLonAverage       (real)"
-        end if
+        endif
 
       case ("#IONFORCING")
         call read_in_logical(UseExB, iError)
@@ -1144,7 +1144,7 @@ subroutine set_inputs
           write(*, *) "UseIonGravity          (logical)"
           write(*, *) "UseNeutralDrag         (logical)"
           IsDone = .true.
-        end if
+        endif
 
       case ("#CHEMISTRY")
 
@@ -1162,7 +1162,7 @@ subroutine set_inputs
           write(*, *) '#FIXTILT'
           write(*, *) 'IsFixedTilt   (logical)'
           IsDone = .true.
-        end if
+        endif
 
       case ("#DIPOLE")
 
@@ -1191,7 +1191,7 @@ subroutine set_inputs
           yDipoleCenter = yDipoleCenter*1000.0
           zDipoleCenter = zDipoleCenter*1000.0
 
-        end if
+        endif
 
       case ("#APEX")
 
@@ -1202,7 +1202,7 @@ subroutine set_inputs
             write(*, *) "-   use APEX coordinates, sorry.      -"
             write(*, *) "-          Ignoring                   -"
             write(*, *) "---------------------------------------"
-          end if
+          endif
           UseApex = .false.
         else
 
@@ -1216,9 +1216,9 @@ subroutine set_inputs
             write(*, *) '        Sets whether to use a realistic magnetic'
             write(*, *) '        field (T) or a dipole (F)'
             IsDone = .true.
-          end if
+          endif
 
-        end if
+        endif
 
       case ("#ALTITUDE")
         call read_in_real(AltMin, iError)
@@ -1237,7 +1237,7 @@ subroutine set_inputs
         else
           AltMin = AltMin*1000.0
           AltMax = AltMax*1000.0
-        end if
+        endif
 
       case ("#GRID")
         if (nLats == 1 .and. nLons == 1) Is1D = .true.
@@ -1254,8 +1254,8 @@ subroutine set_inputs
             write(*, *) "variable in #GRID."
             LonEnd = LonStart
             iError = 0
-          end if
-        end if
+          endif
+        endif
 
         if (LonStart < 0) LonStart = LonStart + 360.0
         if (LonEnd < 0) LonEnd = LonEnd + 360.0
@@ -1290,12 +1290,12 @@ subroutine set_inputs
             IsFullSphere = .false.
             LatStart = LatStart*pi/180.0
             LatEnd = LatEnd*pi/180.0
-          end if
+          endif
 
           LonStart = LonStart*pi/180.0
           LonEnd = LonEnd*pi/180.0
 
-        end if
+        endif
 
       case ("#NEWSTRETCH")
         NewStretchedGrid = .true.
@@ -1315,7 +1315,7 @@ subroutine set_inputs
           write(*, *) '5.0         ! Width of stretched region'
           write(*, *) '0.6         ! Amount of stretch 0 (none) to 1 (lots)'
           IsDone = .true.
-        end if
+        endif
 
       case ("#STRETCH")
         call read_in_real(ConcentrationLatitude, iError)
@@ -1337,7 +1337,7 @@ subroutine set_inputs
             '! More control of stretch ( > 1 stretch less '// &
             '< 1 stretch more)'
           IsDone = .true.
-        end if
+        endif
 
       case ("#TOPOGRAPHY")
         call read_in_logical(UseTopography, iError)
@@ -1348,7 +1348,7 @@ subroutine set_inputs
           write(*, *) 'UseTopography (logical)'
           write(*, *) 'AltMinUniform (real)'
           IsDone = .true.
-        end if
+        endif
         AltMinUniform = AltMinUniform*1000.0
 
       case ("#RESTART")
@@ -1359,14 +1359,14 @@ subroutine set_inputs
           write(*, *) '#RESTART'
           write(*, *) 'DoRestart (logical)'
           IsDone = .true.
-        end if
+        endif
 
       case ("#PLOTTIMECHANGE")
         call read_in_time(PlotTimeChangeStart, iError)
         call read_in_time(PlotTimeChangeEnd, iError)
         do iOutputTypes = 1, nOutputTypes
           call read_in_real(PlotTimeChangeDt(iOutputTypes), iError)
-        end do
+        enddo
         if (iError /= 0) then
           write(*, *) 'Incorrect format for #PLOTTIMECHANGE:'
           write(*, *) 'This allows you to change the output cadence of the '
@@ -1377,9 +1377,9 @@ subroutine set_inputs
           write(*, *) 'yyyy mm dd hh mm ss ms (end)'
           do iOutputTypes = 1, nOutputTypes
             write(*, *) 'dt (real)'
-          end do
+          enddo
           IsDone = .true.
-        end if
+        endif
 
       case ("#APPENDFILES")
         call read_in_logical(DoAppendFiles, iError)
@@ -1391,7 +1391,7 @@ subroutine set_inputs
           write(*, *) 'It only works for satellite files now.'
           write(*, *) '#APPENDFILES'
           write(*, *) 'DoAppendFiles    (logical)'
-        end if
+        endif
 
       case ("#CCMCFILENAME")
         call read_in_logical(UseCCMCFileName, iError)
@@ -1402,7 +1402,7 @@ subroutine set_inputs
           write(*, *) '1DALL_GITM_yyyy-mm-ddThh-mm-ss.bin'
           write(*, *) '#CCMCFILENAME'
           write(*, *) 'UseCCMCFileName    (logical)'
-        end if
+        endif
 
       case ("#SAVEPLOTS", "#SAVEPLOT")
         call read_in_real(DtRestart, iError)
@@ -1414,14 +1414,14 @@ subroutine set_inputs
           do iOutputTypes = 1, nOutputTypes
             call read_in_string(OutputType(iOutputTypes), iError)
             call read_in_real(DtPlot(iOutputTypes), iError)
-          end do
+          enddo
           iError = bad_outputtype()
           if (iError /= 0) then
             write(*, *) "Error in #SAVEPLOTS"
             write(*, *) "Bad output type : ", OutputType(iError)
-          end if
+          endif
           DtPlotSave = DtPlot
-        end if
+        endif
         if (iError /= 0) then
           write(*, *) 'Incorrect format for #SAVEPLOT'
           write(*, *) 'The DtRestart variable sets the time in between '
@@ -1439,7 +1439,7 @@ subroutine set_inputs
           write(*, *) 'Outputtype (string, 3D, 2D, ION, NEUTRAL, ...)'
           write(*, *) 'DtPlot    (real, seconds)'
           IsDone = .true.
-        end if
+        endif
 
       case ("#SAVEHIMEPLOT")
         call read_in_real(HIMEPlotLonStart, iError)
@@ -1455,7 +1455,7 @@ subroutine set_inputs
           write(*, *) 'HIMEPlotLatStart (real)'
           write(*, *) 'HIMEPlotLatEnd (real)'
           IsDone = .true.
-        end if
+        endif
 
       case ("#SATELLITES")
         call read_in_int(nSats, iError)
@@ -1474,8 +1474,8 @@ subroutine set_inputs
             call read_in_string(SatOutputType(iSat), iError)
             call read_in_real(SatDtPlot(iSat), iError)
             iSatCurrentIndex(iSat) = 0
-          end do
-        end if
+          enddo
+        endif
         if (iError /= 0) then
           write(*, *) 'Incorrect format for #SATELLITES'
           write(*, *) ''
@@ -1489,7 +1489,7 @@ subroutine set_inputs
         else
           call read_satellites(iError)
           if (iError /= 0) IsDone = .true.
-        end if
+        endif
 
       case ("#RCMR")
         ! Read in the data assimilation type
@@ -1508,7 +1508,7 @@ subroutine set_inputs
               write(*, *) 'if the actual F10.7 is not close to 100'
               f107_est = 100
               iError = 0
-            end if
+            endif
 
             f107a_est = f107_est
             call IO_set_f107_single(f107_est)
@@ -1525,11 +1525,11 @@ subroutine set_inputs
               write(*, *) 'close to 0.1'
               PhotoElectronHeatingEfficiency_est = 0.1
               iError = 0
-            end if
+            endif
 
             if (RCMROutType == 'PHOTOELECTRON') then
               PhotoElectronHeatingEfficiency = PhotoElectronHeatingEfficiency_est
-            end if
+            endif
 
                  !!ANKIT: TEC read
           else if (RCMROutType == 'EDC') then
@@ -1545,18 +1545,18 @@ subroutine set_inputs
               write(*, *) 'close to 1750'
               EDC_est = 1750
               iError = 0
-            end if
+            endif
 
             if (RCMROutType == 'EDC') then
               EddyDiffusionCoef = EDC_est(1, 1)
-            end if
-          end if
+            endif
+          endif
           ! Quality check of the satellite indexes will occur when
           ! reading the satellite block.
           call read_in_int(nRCMRSat, iError)
           do iSat = 1, nRCMRSat
             call read_in_int(RCMRSat(iSat), iError)
-          end do
+          enddo
           call read_in_string(RCMRrun, iError)    !Ankit23May16: Truth or ID
           call read_in_int(Nc, iError)            !Ankit23May16: Controller Order.
           call read_in_int(RegZ, iError)          !Ankit23May16: Regressor Variable. 1=z, 0=y.
@@ -1566,7 +1566,7 @@ subroutine set_inputs
           call read_in_real(Measure_Dts, iError)  !Ankit23May16: Executes every Measure_Dts*Dts*steps steps.
           call read_in_int(C_on, iError)          !Ankit23May16: RCMR switches on after C_on steps.
           call read_in_int(uFiltLength, iError)   !Ankit23May16: Length of averaging filter.
-        end if
+        endif
 
         if (iError /= 0) then
           write(*, *) 'Incorrect format for #RCMR'
@@ -1586,11 +1586,11 @@ subroutine set_inputs
         else
           if (RCMROutType == 'EDC') then
             call read_tec_locations
-          end if
+          endif
           call alloc_rcmr
           call init_markov_matrix
           call init_rcmr
-        end if
+        endif
 
       case ("#DART") !alexey
         call read_in_int(useDART, iError)
@@ -1599,7 +1599,7 @@ subroutine set_inputs
           write(*, *) ''
           write(*, *) '#DART'
           write(*, *) "useDART (integer, {default 0=no}, 1=master ensemble member, 2=slave ens.)"
-        end if
+        endif
 
       case ("#ELECTRODYNAMICS")
         call read_in_real(dTPotential, iError)
@@ -1613,7 +1613,7 @@ subroutine set_inputs
           write(*, *) 'DtPotential (real, seconds)'
           write(*, *) 'DtAurora    (real, seconds)'
           IsDone = .true.
-        end if
+        endif
 
       case ("#INPUTTIMEDELAY")
         call read_in_real(TimeDelayHighLat, iError)
@@ -1626,7 +1626,7 @@ subroutine set_inputs
           write(*, *) 'TimeDelayHighLat (real, seconds)'
           write(*, *) 'TimeDelayEUV     (real, seconds)'
           IsDone = .true.
-        end if
+        endif
 
       case ("#LTERadiation")
         call read_in_real(DtLTERadiation, iError)
@@ -1636,7 +1636,7 @@ subroutine set_inputs
           write(*, *) '#LTERadiation'
           write(*, *) 'DtLTERadiation (real)'
           IsDone = .true.
-        end if
+        endif
 
       case ("#IONPRECIPITATION")
         call read_in_logical(UseIonPrecipitation, iError)
@@ -1647,7 +1647,7 @@ subroutine set_inputs
           write(*, *) '#IONPRECIPITATION'
           write(*, *) 'UseIonPrecipitation     (logical)'
           IsDone = .true.
-        end if
+        endif
 
       case ("#LOGFILE")
         call read_in_real(dTLogFile, iError)
@@ -1662,7 +1662,7 @@ subroutine set_inputs
           write(*, *) '#LOGFILE'
           write(*, *) 'DtLogFile   (real, seconds)'
           IsDone = .true.
-        end if
+        endif
 
       case ("#EUVMODEL")
         call read_in_logical(UseEUVAC, iError)
@@ -1685,7 +1685,7 @@ subroutine set_inputs
           write(*, *) '#EUV_DATA'
           write(*, *) 'UseEUVData            (logical)'
           write(*, *) 'cEUVFile              (string)'
-        end if
+        endif
 
       case ("#EUV_DATA")
         call read_in_logical(UseEUVData, iError)
@@ -1701,8 +1701,8 @@ subroutine set_inputs
           if (UseEUVData) call Set_Euv(iError, CurrentTime, EndTime)
           if (iError /= 0) then
             call stop_gitm("Stopping after set_euv in set_inputs. Error in EUV data. Check times!")
-          end if
-        end if
+          endif
+        endif
 
       case ("#ECLIPSE")
         IncludeEclipse = .true.
@@ -1737,7 +1737,7 @@ subroutine set_inputs
           write(*, *) 'Max Distance                 (real)'
           write(*, *) 'ExpAmp                       (real)'
           write(*, *) 'ExpWidth                     (real)'
-        end if
+        endif
 
       case ("#GLOW")
         call read_in_logical(UseGlow, iError)
@@ -1755,14 +1755,14 @@ subroutine set_inputs
           call read_NGDC_Indices(iError)
         else
           call read_NGDC_Indices_new(iError, CurrentTime, EndTime)
-        end if
+        endif
 
         if (iError /= 0) then
           write(*, *) "read indices was NOT successful (NGDC file)"
           IsDone = .true.
         else
           UseVariableInputs = .true.
-        end if
+        endif
 
       case ("#F107_FILE")
         cTempLines(1) = cLine
@@ -1779,7 +1779,7 @@ subroutine set_inputs
           IsDone = .true.
         else
           UseVariableInputs = .true.
-        end if
+        endif
 
       case ("#OMNIWEB_AP_INDICES")
         cTempLines(1) = cLine
@@ -1794,14 +1794,14 @@ subroutine set_inputs
           call stop_gitm("OMNIWEB AP cannot be read by GITM in component mode")
         else
           call read_OMNIWEB_Ap_Indices_new(iError, CurrentTime, EndTime)
-        end if
+        endif
 
         if (iError /= 0) then
           write(*, *) "read indices was NOT successful (OMNIWEB Ap file)"
           IsDone = .true.
         else
           UseVariableInputs = .true.
-        end if
+        endif
 
       case ("#SME_INDICES")
         cTempLines(1) = cLine
@@ -1820,7 +1820,7 @@ subroutine set_inputs
           write(*, *) "or put a F if you don't."
           write(*, *) "----------------------------------------------"
           iError = 0
-        end if
+        endif
         cTempLines(4) = " "
         cTempLines(5) = "#END"
 
@@ -1831,7 +1831,7 @@ subroutine set_inputs
           call read_sme(iError, &
                         CurrentTime + TimeDelayHighLat, &
                         EndTime + TimeDelayHighLat, doUseAeForHp)
-        end if
+        endif
 
         if (iError /= 0) then
           write(*, *) "read_sme was NOT successful (Check SME file!)"
@@ -1850,8 +1850,8 @@ subroutine set_inputs
             IsDone = .true.
           else
             UseVariableInputs = .true.
-          end if
-        end if
+          endif
+        endif
 
       case ("#ACE_DATA")
         cTempLines(1) = cLine
@@ -1869,7 +1869,7 @@ subroutine set_inputs
           IsDone = .true.
         else
           UseVariableInputs = .true.
-        end if
+        endif
 
       case ("#SWPC_INDICES")
         cTempLines(1) = cLine
@@ -1888,7 +1888,7 @@ subroutine set_inputs
           IsDone = .true.
         else
           UseVariableInputs = .true.
-        end if
+        endif
 
       case ("#NOAAHPI_INDICES")
         cTempLines(1) = cLine
@@ -1902,14 +1902,14 @@ subroutine set_inputs
           call read_NOAAHPI_Indices(iError)
         else
           call read_NOAAHPI_Indices_new(iError, StartTime, EndTime)
-        end if
+        endif
 
         if (iError /= 0) then
           write(*, *) "read indices was NOT successful (NOAA HPI file)"
           IsDone = .true.
         else
           UseVariableInputs = .true.
-        end if
+        endif
 
       case ("#END")
         IsDone = .true.
@@ -1918,21 +1918,21 @@ subroutine set_inputs
 
       if (iError /= 0) IsDone = .true.
 
-    end if
+    endif
 
     iLine = iLine + 1
 
     if (iLine >= nInputLines) IsDone = .true.
 
-  end do
+  enddo
 
   if (iDebugProc >= 0 .and. iProc /= iDebugProc) then
     iDebugLevel = -1
-  end if
+  endif
 
   if (iError /= 0) then
     call stop_gitm("Must Stop!!")
-  end if
+  endif
 
   ! We need to check to see if the current time and end time are
   ! larger than the last F107 time.  If that is the case, the code
@@ -1944,11 +1944,11 @@ subroutine set_inputs
     call check_all_indices(CurrentTime, iError)
     if (iError == 0) then
       call check_all_indices(EndTime, iError)
-    end if
+    endif
     if (iError /= 0) then
       call stop_gitm("Issue with Indices! Check the file(s) times!")
-    end if
-  end if
+    endif
+  endif
   RestartTime = CurrentTime
 
 !  KappaTemp0 = 3.6e-4
@@ -1961,7 +1961,7 @@ contains
     if (iError == 0) then
       iline = iline + 1
       read(cInputText(iline), *, iostat=iError) variable
-    end if
+    endif
   end subroutine read_in_int
 
   subroutine read_in_time(variable, iError)
@@ -1973,7 +1973,7 @@ contains
       read(cInputText(iline), *, iostat=iError) iTimeReadIn(1:6)
       iTimeReadIn(7) = 0
       call time_int_to_real(iTimeReadIn, variable)
-    end if
+    endif
   end subroutine read_in_time
 
   subroutine read_in_logical(variable, iError)
@@ -1982,7 +1982,7 @@ contains
     if (iError == 0) then
       iline = iline + 1
       read(cInputText(iline), *, iostat=iError) variable
-    end if
+    endif
   end subroutine read_in_logical
 
   subroutine read_in_string(variable, iError)
@@ -1994,7 +1994,7 @@ contains
       ! Remove anything after a space or TAB
       i = index(variable, ' '); if (i > 0) variable(i:len(cLine)) = ' '
       i = index(variable, char(9)); if (i > 0) variable(i:len(cLine)) = ' '
-    end if
+    endif
   end subroutine read_in_string
 
   subroutine read_in_real(variable, iError)
@@ -2003,7 +2003,7 @@ contains
     if (iError == 0) then
       iline = iline + 1
       read(cInputText(iline), *, iostat=iError) variable
-    end if
+    endif
   end subroutine read_in_real
 
 end subroutine set_inputs
@@ -2032,8 +2032,8 @@ subroutine fix_vernal_time
                      floor(n*(DaysPerYearInput - int(DaysPerYearInput)))* &
                      RotationPeriodInput
         n = 0
-      end if
-    end do
+      endif
+    enddo
     DTime = CurrentTime - VernalTime
   else
     n = 0
@@ -2045,10 +2045,10 @@ subroutine fix_vernal_time
                      floor(n*(DaysPerYearInput - int(DaysPerYearInput)))* &
                      RotationPeriodInput
         n = 0
-      end if
+      endif
       DTime = CurrentTime - VernalTime
-    end do
-  end if
+    enddo
+  endif
   iDay = DTime/RotationPeriodInput
   uTime = (DTime/RotationPeriodInput - iDay)*RotationPeriodInput
   iJulianDay = jday( &

--- a/src/set_vertical_bcs.Earth.f90
+++ b/src/set_vertical_bcs.Earth.f90
@@ -96,7 +96,7 @@ subroutine set_vertical_bcs(LogRho, LogNS, Vel_GD, Temp, LogINS, iVel, VertVel)
   do iAlt = -1, nAlts + 2
     EffectiveGravity(iAlt) = Gravity_G(iAlt) + &
                              Centrifugal/InvRadialDistance_C(iAlt)
-  end do
+  enddo
 
   !------------------------------------------------------------
   ! This is so we can have a fixed lower BC (MSIS specified):
@@ -108,7 +108,7 @@ subroutine set_vertical_bcs(LogRho, LogNS, Vel_GD, Temp, LogINS, iVel, VertVel)
     call meter6(.true.)
     sw = 1
     IsFirstTime = .true.
-  end if
+  endif
 
   if (UseMsisBCs) then
 
@@ -135,29 +135,29 @@ subroutine set_vertical_bcs(LogRho, LogNS, Vel_GD, Temp, LogINS, iVel, VertVel)
       vel_gd(iAlt, iEast_) = v(iEast_)
       vel_gd(iAlt, iNorth_) = v(iNorth_)
 
-    end do
+    enddo
   else
     ! Don't Let the winds blow
     Vel_GD(-1:0, iEast_) = 0.0
     Vel_GD(-1:0, iNorth_) = 0.0
     ! The rest of the BCs will just stay constant.
-  end if
+  endif
 
   if (.not. DuringPerturb) then
     Vel_GD(-1:0, iUp_) = 0.0
     VertVel(-1:0, :) = 0.0
-  end if
+  endif
 
   if (UseGSWMTides) then
     Vel_GD(-1:0, iEast_) = TidesEast(iLon1D, iLat1D, 1:2, iBlock1D)
     Vel_GD(-1:0, iNorth_) = TidesNorth(iLon1D, iLat1D, 1:2, iBlock1D)
     Temp(-1:0) = TidesTemp(iLon1D, iLat1D, 1:2, iBlock1D) + Temp(-1:0)
-  end if
+  endif
   if (UseWACCMTides) then
     Vel_GD(-1:0, iEast_) = TidesEast(iLon1D, iLat1D, 1:2, iBlock1D)
     Vel_GD(-1:0, iNorth_) = TidesNorth(iLon1D, iLat1D, 1:2, iBlock1D)
     Temp(-1:0) = TidesTemp(iLon1D, iLat1D, 1:2, iBlock1D)
-  end if
+  endif
   if (UseHmeTides) then
     Vel_GD(-1:0, iEast_) = TidesEast(iLon1D, iLat1D, 1:2, iBlock1D)
     Vel_GD(-1:0, iNorth_) = TidesNorth(iLon1D, iLat1D, 1:2, iBlock1D)
@@ -175,7 +175,7 @@ subroutine set_vertical_bcs(LogRho, LogNS, Vel_GD, Temp, LogINS, iVel, VertVel)
     ! MSIS density.  I am not 100% sure of this, but let's try it out:
     NS(0, 1:nSpecies) = NS(0, 1:nSpecies)*TidesRhoRat(iLon1D, iLat1D, 2, iBlock1D)
 
-  end if
+  endif
 
   ! In order to get a real hydrostatic solution at the bottom, we will
   ! overwrite the -1 cell with our own calculation of the hydrostatic
@@ -212,7 +212,7 @@ subroutine set_vertical_bcs(LogRho, LogNS, Vel_GD, Temp, LogINS, iVel, VertVel)
   Temp(iAlt) = Temp(iAlt + 1)
   do iDir = 1, 3
     Vel_GD(iAlt, iDir) = Vel_GD(iAlt + 1, iDir)
-  end do
+  enddo
 
   do iSpecies = 1, nSpecies
 
@@ -238,7 +238,7 @@ subroutine set_vertical_bcs(LogRho, LogNS, Vel_GD, Temp, LogINS, iVel, VertVel)
       if (iSpecies == iO_3P_) then
         ! Assume 0 gradient below boundary
         LogNS(iAlt, iSpecies) = LogNS(0, iSpecies)
-      end if
+      endif
 
     else
 
@@ -278,20 +278,20 @@ subroutine set_vertical_bcs(LogRho, LogNS, Vel_GD, Temp, LogINS, iVel, VertVel)
         ! Limit the Gradients through the lower boundary
         if (dLogNS .le. 0.0) then
           LogNS(iAlt, iSpecies) = LogNS(iAlt + 1, iSpecies)
-        end if
+        endif
 
         ! Only allow the NO density to decrease by roughly 1/3 scale
         ! height max
         if (iSpecies == iNO_) then
           if (LogNS(iAlt, iSpecies) < LogNS(iAlt + 1, iSpecies) - 0.333) then
             LogNS(iAlt, iSpecies) = LogNS(iAlt + 1, iSpecies) - 0.333
-          end if
-        end if
+          endif
+        endif
 
-      end do !iAlt = 0,-1,-1
+      enddo !iAlt = 0,-1,-1
 
-    end if ! PhotoChemical Check
-  end do  ! iSpecies loop
+    endif ! PhotoChemical Check
+  enddo  ! iSpecies loop
 
   do iAlt = 0, -1, -1
 
@@ -326,14 +326,14 @@ subroutine set_vertical_bcs(LogRho, LogNS, Vel_GD, Temp, LogINS, iVel, VertVel)
       ! chemitry is dominant.  It shouldn't matter, really:
       LogINS(iAlt, iSpecies) = LogINS(iAlt + 1, iSpecies)
 
-    end do ! Ions
+    enddo ! Ions
 
     ! Electon Density:
     if (UseImprovedIonAdvection) then
       LogINS(iAlt, nIons) = sum(LogINS(iAlt, 1:nIons - 1))
     else
       LogINS(iAlt, nIons) = alog(sum(exp(LogINS(iAlt, 1:nIons - 1))))
-    end if
+    endif
 
     ! Set the Ion Bulk Winds
     do iDir = 1, 3
@@ -344,7 +344,7 @@ subroutine set_vertical_bcs(LogRho, LogNS, Vel_GD, Temp, LogINS, iVel, VertVel)
                  IVel(iAlt + 5, iDir)*MeshCoef4
 
       IVel(iAlt, iDir) = IVel(iAlt + 1, iDir) - dAlt_F(iAlt + 1)*dVertVel
-    end do  ! iDir
+    enddo  ! iDir
 
     ! -------------------------------------------------
     ! Return to the neutrals, to deal with (vertical) winds now...
@@ -360,7 +360,7 @@ subroutine set_vertical_bcs(LogRho, LogNS, Vel_GD, Temp, LogINS, iVel, VertVel)
 
       VertVel(iAlt, iSpecies) = VertVel(iAlt + 1, iSpecies) - &
                                 dAlt_F(iAlt + 1)*dVertVel
-    end do ! nSpecies
+    enddo ! nSpecies
 
     ! Update NS & LogRho to use in the vertical wind calculation:
 
@@ -368,7 +368,7 @@ subroutine set_vertical_bcs(LogRho, LogNS, Vel_GD, Temp, LogINS, iVel, VertVel)
     SumRho = 0.0
     do iSpecies = 1, nSpecies
       SumRho = SumRho + Mass(iSpecies)*NS(iAlt, iSpecies)
-    end do
+    enddo
     LogRho(iAlt) = alog(SumRho)
 
     ! Calculate the bulk vertical winds:
@@ -378,7 +378,7 @@ subroutine set_vertical_bcs(LogRho, LogNS, Vel_GD, Temp, LogINS, iVel, VertVel)
       Vel_GD(iAlt, iUp_) = Vel_GD(iAlt, iUp_) + &
                            NS(iAlt, iSpecies)*Mass(iSpecies)*VertVel(iAlt, iSpecies)/ &
                            exp(LogRho(iAlt))
-    end do
+    enddo
 
     if ((iAlt == -1) .and. (UseMsisBcs)) then
 
@@ -390,11 +390,11 @@ subroutine set_vertical_bcs(LogRho, LogNS, Vel_GD, Temp, LogINS, iVel, VertVel)
                    Vel_GD(iAlt + 5, iDir)*MeshCoef4
 
         Vel_GD(iAlt, iDir) = Vel_GD(iAlt + 1, iDir) - dAlt_F(iAlt + 1)*dVertVel
-      end do
+      enddo
 
-    end if
+    endif
 
-  end do ! End Outer IAlt Loop (0, -1, -1)
+  enddo ! End Outer IAlt Loop (0, -1, -1)
 
   ! Special Case for PhotoChemical Species
   ! Allow O to flow upward
@@ -409,9 +409,9 @@ subroutine set_vertical_bcs(LogRho, LogNS, Vel_GD, Temp, LogINS, iVel, VertVel)
 
       VertVel(0, iSpecies) = -1.0*VertVel(1, iSpecies)
       VertVel(-1, iSpecies) = -1.0*VertVel(1, iSpecies)
-    end if
+    endif
 
-  end do
+  enddo
 
   ! For WP-GITM: add neutral atmospheric perturbations caused by
   ! tsunami or earthquake
@@ -426,7 +426,7 @@ subroutine set_vertical_bcs(LogRho, LogNS, Vel_GD, Temp, LogINS, iVel, VertVel)
                               Temp(-1:0))
     LogNS(-1:0, :) = LogNS_LBC
     Vel_GD(-1:0, iEast_:iUp_) = VelGD_LBC
-  end if
+  endif
 
   !------------------------------------------------------------------------
   !------------------------------------------------------------------------
@@ -454,9 +454,9 @@ subroutine set_vertical_bcs(LogRho, LogNS, Vel_GD, Temp, LogINS, iVel, VertVel)
         (VertVel(nAlts, iSpecies) .lt. 0.0)) then
       VertVel(nAlts + 1, iSpecies) = -VertVel(nAlts, iSpecies)
       VertVel(nAlts + 2, iSpecies) = -VertVel(nAlts - 1, iSpecies)
-    end if
+    endif
 
-  end do
+  enddo
 
   if (Vel_GD(nAlts, iUp_) < 0.0) then
     Vel_GD(nAlts + 1, iUp_) = -Vel_GD(nAlts, iUp_)
@@ -464,7 +464,7 @@ subroutine set_vertical_bcs(LogRho, LogNS, Vel_GD, Temp, LogINS, iVel, VertVel)
   else
     Vel_GD(nAlts + 1, iUp_) = Vel_GD(nAlts, iUp_)
     Vel_GD(nAlts + 2, iUp_) = Vel_GD(nAlts, iUp_)
-  end if
+  endif
 
   ! Vertical Ion Drifts:
   if (IVel(nAlts, iUp_) < 0.0) then
@@ -473,7 +473,7 @@ subroutine set_vertical_bcs(LogRho, LogNS, Vel_GD, Temp, LogINS, iVel, VertVel)
   else
     IVel(nAlts + 1, iUp_) = IVel(nAlts, iUp_)
     IVel(nAlts + 2, iUp_) = IVel(nAlts, iUp_)
-  end if
+  endif
 
   ! Constant temperature (zero gradient)
 
@@ -500,8 +500,8 @@ subroutine set_vertical_bcs(LogRho, LogNS, Vel_GD, Temp, LogINS, iVel, VertVel)
 
       LogNS(iAlt, iSpecies) = alog(NS(iAlt, iSpecies))
 
-    end do
-  end do
+    enddo
+  enddo
 
   UsePlasmasphereBC = .false.
   if (UseNighttimeIonBCs) then
@@ -509,14 +509,14 @@ subroutine set_vertical_bcs(LogRho, LogNS, Vel_GD, Temp, LogINS, iVel, VertVel)
         ((MLatVertical > 30.0 .and. MLatVertical < 70.0) .or. &
          (MLatVertical > -60.0 .and. MLatVertical < -30.0))) then
       UsePlasmasphereBC = .true.
-    end if
-  end if
+    endif
+  endif
 
   if (UseImprovedIonAdvection) then
     tec = sum(dAlt_f(1:nAlts)*LogINS(1:nAlts, 1))/1e16
   else
     tec = sum(dAlt_f(1:nAlts)*exp(LogINS(1:nAlts, 1)))/1e16
-  end if
+  endif
 
   do iAlt = nAlts + 1, nAlts + 2
 
@@ -561,7 +561,7 @@ subroutine set_vertical_bcs(LogRho, LogNS, Vel_GD, Temp, LogINS, iVel, VertVel)
           if (ieee_is_nan(n3)) write(*, *) 'n3 :', iAlt - 3, LogINS(iAlt - 3, iSpecies)
           if (ieee_is_nan(n4)) write(*, *) 'n4 :', iAlt - 4, LogINS(iAlt - 4, iSpecies)
           if (ieee_is_nan(n5)) write(*, *) 'n5 :', iAlt - 5, LogINS(iAlt - 5, iSpecies)
-        end if
+        endif
       else
         n0 = LogINS(iAlt, iSpecies)
         n1 = LogINS(iAlt - 1, iSpecies)
@@ -569,7 +569,7 @@ subroutine set_vertical_bcs(LogRho, LogNS, Vel_GD, Temp, LogINS, iVel, VertVel)
         n3 = LogINS(iAlt - 3, iSpecies)
         n4 = LogINS(iAlt - 4, iSpecies)
         n5 = LogINS(iAlt - 5, iSpecies)
-      end if
+      endif
 
       dn = MeshCoefm0*n1 + &
            MeshCoefm1*n2 + &
@@ -591,35 +591,35 @@ subroutine set_vertical_bcs(LogRho, LogNS, Vel_GD, Temp, LogINS, iVel, VertVel)
           LogINS(iAlt, iSpecies) = exp(n0)
         else
           LogINS(iAlt, iSpecies) = n0
-        end if
+        endif
 
-      end if
+      endif
 
       if (DoCheckForNans) then
         if (ieee_is_nan(LogINS(iAlt, 1))) &
           write(*, *) 'svbc ', iAlt, LogINS(iAlt, 1), n0, dn, &
           n1, n2, n3, n4, n5, tec, MinTEC, UsePlasmasphereBC, &
           dAlt_F(iAlt)
-      end if
+      endif
 
-    end do
+    enddo
 
     ! Electon Density:
     if (UseImprovedIonAdvection) then
       LogINS(iAlt, nIons) = sum(LogINS(iAlt, 1:nIons - 1))
     else
       LogINS(iAlt, nIons) = alog(sum(exp(LogINS(iAlt, 1:nIons - 1))))
-    end if
+    endif
 
-  end do
+  enddo
 
   do iAlt = nAlts + 1, nAlts + 2
     SumRho = 0.0
     do iSpecies = 1, nSpecies
       SumRho = SumRho + Mass(iSpecies)*exp(LogNS(iAlt, iSpecies))
-    end do
+    enddo
     LogRho(iAlt) = alog(SumRho)
-  end do
+  enddo
 
 contains
 
@@ -635,7 +635,7 @@ contains
       if (LogINS(iAlt - 6, iSpecies) < 0.0) then
         write(*, *) 'Negative Ion density too close to the upper boundary: ', iSpecies
         call stop_gitm('Stopping in set_vertical_bcs')
-      end if
+      endif
 
       do iAltSub = iAlt - 5, iAlt - 1
 
@@ -649,19 +649,19 @@ contains
           else
             ! Or take previous point and decrease it by 5 percent:
             LogINS(iAltSub, iSpecies) = LogINS(iAltSub - 1, iSpecies)*0.95
-          end if
+          endif
 
-        end if
+        endif
 
-      end do
+      enddo
 
       ! Top point:
       if (LogINS(iAlt, iSpecies) < 0.0) then
         ! Take previous point and decrease it by 5 percent:
         LogINS(iAlt, iSpecies) = LogINS(iAlt - 1, iSpecies)*0.95
-      end if
+      endif
 
-    end if
+    endif
 
   end subroutine check_for_negative_densities
 

--- a/src/set_vertical_bcs.LV-426.f90
+++ b/src/set_vertical_bcs.LV-426.f90
@@ -54,13 +54,13 @@ subroutine set_vertical_bcs(LogRho, LogNS, Vel_GD, Temp, LogINS, iVel, VertVel)
     dn = (LogNS(2, iSpecies) - LogNS(1, iSpecies))
     LogNS(0, iSpecies) = LogNS(1, iSpecies) - dn
     LogNS(-1, iSpecies) = LogNS(0, iSpecies) - dn
-  end do
+  enddo
 
   do iSpecies = 1, nIonsAdvect
     dn = (LogINS(2, iSpecies) - LogINS(1, iSpecies))
     LogINS(0, iSpecies) = LogINS(1, iSpecies) - dn
     LogINS(-1, iSpecies) = LogINS(0, iSpecies) - dn
-  end do
+  enddo
 
   !-----------------------------------------------------------
   ! Top
@@ -91,7 +91,7 @@ subroutine set_vertical_bcs(LogRho, LogNS, Vel_GD, Temp, LogINS, iVel, VertVel)
     Vel_GD(nAlts + 2, iUp_) = -Vel_GD(nAlts - 1, iUp_)
     VertVel(nAlts + 1, :) = -VertVel(nAlts, :)
     VertVel(nAlts + 2, :) = -VertVel(nAlts - 1, :)
-  end if
+  endif
 
   ! Constant temperature (zero gradient)
 
@@ -111,7 +111,7 @@ subroutine set_vertical_bcs(LogRho, LogNS, Vel_GD, Temp, LogINS, iVel, VertVel)
     if (dn > -0.25*LogINS(nAlts, iSpecies)) dn = -0.25*LogINS(nAlts, iSpecies)
     LogINS(nAlts + 1, iSpecies) = LogINS(nAlts, iSpecies) + dn
     LogINS(nAlts + 2, iSpecies) = LogINS(nAlts + 1, iSpecies) + dn
-  end do
+  enddo
 
   ! Hydrostatic pressure for the neutrals
 
@@ -127,9 +127,9 @@ subroutine set_vertical_bcs(LogRho, LogNS, Vel_GD, Temp, LogINS, iVel, VertVel)
           Gravity_G(nAlts), Mass(iSpecies), Temp(nAlts), &
           LogNS(nAlts, iSpecies), LogNS(nAlts + 1, iSpecies), &
           dAlt_F(nAlts), LogNS(nAlts + 2, iSpecies)
-      end if
-    end do
-  end do
+      endif
+    enddo
+  enddo
 
 end subroutine set_vertical_bcs
 

--- a/src/set_vertical_bcs.Mars.f90
+++ b/src/set_vertical_bcs.Mars.f90
@@ -52,7 +52,7 @@ subroutine set_vertical_bcs(LogRho, LogNS, Vel_GD, Temp, LogINS, iVel, VertVel)
     call meter6(.true.)
     sw = 1
     IsFirstTime = .true.
-  end if
+  endif
 
   if (UseMsisBCs) then
     call get_HPI(CurrentTime, HP, iError)
@@ -66,12 +66,12 @@ subroutine set_vertical_bcs(LogRho, LogNS, Vel_GD, Temp, LogINS, iVel, VertVel)
                     F107A, F107, AP, LogNS(iAlt, :), Temp(iAlt), &
                     LogRho(iAlt))
 
-    end do
+    enddo
   else
 
     ! do nothing - which means don't change the initial condition.
 
-  end if
+  endif
 
   ! Let the winds blow !!!!
   Vel_GD(-1:0, iEast_) = 0.0
@@ -86,7 +86,7 @@ subroutine set_vertical_bcs(LogRho, LogNS, Vel_GD, Temp, LogINS, iVel, VertVel)
 
     LogINS(0, iSpecies) = LogINS(1, iSpecies) - dn
     LogINS(-1, iSpecies) = LogINS(0, iSpecies) - dn
-  end do
+  enddo
 
   ! Lower boundary for NO on Earth
 
@@ -98,7 +98,7 @@ subroutine set_vertical_bcs(LogRho, LogNS, Vel_GD, Temp, LogINS, iVel, VertVel)
   else
     LogNS(0, iN4S_) = LogNS(1, iN4S_) + dn
     LogNS(-1, iN4S_) = LogNS(0, iN4S_) + dn
-  end if
+  endif
 !  endif
 !
   ! Lower boundary for O on Mars
@@ -111,7 +111,7 @@ subroutine set_vertical_bcs(LogRho, LogNS, Vel_GD, Temp, LogINS, iVel, VertVel)
   else
     LogNS(0, iO_) = LogNS(1, iO_) + dn
     LogNS(-1, iO_) = LogNS(0, iO_) + dn
-  end if
+  endif
 !  endif
 
   if (VertVel(1, iN4S_) .gt. 0.0) then
@@ -121,7 +121,7 @@ subroutine set_vertical_bcs(LogRho, LogNS, Vel_GD, Temp, LogINS, iVel, VertVel)
   else
     VertVel(0, iN4S_) = 1.0*VertVel(1, iN4S_)
     VertVel(-1, iN4S_) = 1.0*VertVel(1, iN4S_)
-  end if
+  endif
 
   if (VertVel(1, iO_) .gt. 0.0) then
     ! Don't allow upwelling of N4S
@@ -130,7 +130,7 @@ subroutine set_vertical_bcs(LogRho, LogNS, Vel_GD, Temp, LogINS, iVel, VertVel)
   else
     VertVel(0, iO_) = 1.0*VertVel(1, iO_)
     VertVel(-1, iO_) = 1.0*VertVel(1, iO_)
-  end if
+  endif
 !
 !  ! Lower boundary for NO on Earth
 !  if (nSpecies == iNO_) then
@@ -181,7 +181,7 @@ subroutine set_vertical_bcs(LogRho, LogNS, Vel_GD, Temp, LogINS, iVel, VertVel)
     Vel_GD(nAlts + 2, iUp_) = -Vel_GD(nAlts - 1, iUp_)
     VertVel(nAlts + 1, :) = -VertVel(nAlts, :)
     VertVel(nAlts + 2, :) = -VertVel(nAlts - 1, :)
-  end if
+  endif
 
   ! Constant temperature (zero gradient)
 
@@ -201,7 +201,7 @@ subroutine set_vertical_bcs(LogRho, LogNS, Vel_GD, Temp, LogINS, iVel, VertVel)
     if (dn > 0) dn = -0.1*LogINS(nAlts, iSpecies)
     LogINS(nAlts + 1, iSpecies) = LogINS(nAlts, iSpecies) + dn
     LogINS(nAlts + 2, iSpecies) = LogINS(nAlts + 1, iSpecies) + dn
-  end do
+  enddo
 
   ! Hydrostatic pressure for the neutrals
 
@@ -217,9 +217,9 @@ subroutine set_vertical_bcs(LogRho, LogNS, Vel_GD, Temp, LogINS, iVel, VertVel)
           Gravity_G(nAlts), Mass(iSpecies), Temp(nAlts), &
           LogNS(nAlts, iSpecies), LogNS(nAlts + 1, iSpecies), &
           dAlt_F(nAlts), LogNS(nAlts + 2, iSpecies)
-      end if
-    end do
-  end do
+      endif
+    enddo
+  enddo
 
 end subroutine set_vertical_bcs
 

--- a/src/set_vertical_bcs.Titan.f90
+++ b/src/set_vertical_bcs.Titan.f90
@@ -107,7 +107,7 @@ subroutine set_vertical_bcs(LogRho, LogNS, Vel_GD, Temp, LogINS, iVel, VertVel)
     EffectiveGravity(iAlt) = &
       Gravity_G(iAlt) + &
       Centrifugal/InvRadialDistance_C(iAlt)
-  end do
+  enddo
 
   ! Update the -1 Cell only for Temp, LogNS, and Vel_GD
   ! The 0 Cell is set by MSIS or User-supplied Settings
@@ -150,7 +150,7 @@ subroutine set_vertical_bcs(LogRho, LogNS, Vel_GD, Temp, LogINS, iVel, VertVel)
   Temp(iAlt) = Temp(iAlt + 1)
   do iDir = 1, 3
     Vel_GD(iAlt, iDir) = Vel_GD(iAlt + 1, iDir)
-  end do
+  enddo
 
 !    do iSpecies = 1, nSpecies
 !       dLogNS = MeshCoef0*LogNS(iAlt+1,iSpecies) + &
@@ -289,9 +289,9 @@ subroutine set_vertical_bcs(LogRho, LogNS, Vel_GD, Temp, LogINS, iVel, VertVel)
         LogNS(iAlt, iSpecies) = LogNS(iAlt + 1, iSpecies) - &
                                 dAlt_F(iAlt + 1)*dLogNS
 
-      end do !iAlt = 0,-1,-1
-    end if ! PhotoChemical Check
-  end do  ! iSpecies loop
+      enddo !iAlt = 0,-1,-1
+    endif ! PhotoChemical Check
+  enddo  ! iSpecies loop
 
   ! Ion Lower Boundaries
   do iAlt = 0, -1, -1
@@ -328,7 +328,7 @@ subroutine set_vertical_bcs(LogRho, LogNS, Vel_GD, Temp, LogINS, iVel, VertVel)
       dLogINS = max(0.0, dLogINS)
       LogINS(iAlt, iSpecies) = LogINS(iAlt + 1, iSpecies) &
                                - dAlt_F(iAlt + 1)*dLogINS
-    end do ! Ions Advect
+    enddo ! Ions Advect
 
     do iSpecies = 1, nSpecies
       ! For Photochemical Species
@@ -342,7 +342,7 @@ subroutine set_vertical_bcs(LogRho, LogNS, Vel_GD, Temp, LogINS, iVel, VertVel)
 
       VertVel(iAlt, iSpecies) = VertVel(iAlt + 1, iSpecies) - &
                                 dAlt_F(iAlt + 1)*dVertVel
-    end do ! nSpecies
+    enddo ! nSpecies
 
     ! Set the Bulk Winds
     Vel_GD(iAlt, iUp_) = 0.0
@@ -350,7 +350,7 @@ subroutine set_vertical_bcs(LogRho, LogNS, Vel_GD, Temp, LogINS, iVel, VertVel)
       Vel_GD(iAlt, iUp_) = Vel_GD(iAlt, iUp_) + &
                            NS(iAlt, iSpecies)*Mass(iSpecies)* &
                            VertVel(iAlt, iSpecies)/exp(LogRho(iAlt))
-    end do
+    enddo
 
     ! Set the Ion Bulk Winds
     do iDir = 1, 3
@@ -362,9 +362,9 @@ subroutine set_vertical_bcs(LogRho, LogNS, Vel_GD, Temp, LogINS, iVel, VertVel)
 
       IVel(iAlt, iDir) = IVel(iAlt + 1, iDir) - &
                          dAlt_F(iAlt + 1)*dVertVel
-    end do  ! iDir
+    enddo  ! iDir
 
-  end do ! End Outer IAlt Loop (0, -1, -1)
+  enddo ! End Outer IAlt Loop (0, -1, -1)
 
   ! Special Case for PhotoChemical Species
   ! Allow O to flow upward
@@ -377,9 +377,9 @@ subroutine set_vertical_bcs(LogRho, LogNS, Vel_GD, Temp, LogINS, iVel, VertVel)
       VertVel(-1, iSpecies) = -1.0*VertVel(1, iSpecies)
     else
       ! Do nothing (already taken care of)
-    end if
+    endif
 
-  end do
+  enddo
 
   ! Neutral Bulk Winds (East and West)
 
@@ -413,7 +413,7 @@ subroutine set_vertical_bcs(LogRho, LogNS, Vel_GD, Temp, LogINS, iVel, VertVel)
 
     Vel_GD(iAlt, iDir) = Vel_GD(iAlt + 1, iDir) - &
                          dAlt_F(iAlt + 1)*dVertVel
-  end do
+  enddo
 
   !-----------------------------------------------------------
   ! Top
@@ -445,7 +445,7 @@ subroutine set_vertical_bcs(LogRho, LogNS, Vel_GD, Temp, LogINS, iVel, VertVel)
 !             PI/Mass(iSpecies)))*&
 !             (1.0 + Lambda_Jeans)*exp( -1.0*Lambda_Jeans)
 !     endif
-  end do
+  enddo
 
   ! Slip flow at the top
   ! Assume zero gradients in the velocities & temps
@@ -477,7 +477,7 @@ subroutine set_vertical_bcs(LogRho, LogNS, Vel_GD, Temp, LogINS, iVel, VertVel)
 
       VertVel(nAlts + 1, iSpecies) = UpperBoundaryVelocity
       VertVel(nAlts + 2, iSpecies) = VertVel(nAlts + 1, iSpecies)
-    end if
+    endif
 !     else
 
     !    ! Can't have photochemical species flowing downward
@@ -488,7 +488,7 @@ subroutine set_vertical_bcs(LogRho, LogNS, Vel_GD, Temp, LogINS, iVel, VertVel)
 !       endif
 !    endif
 
-  end do
+  enddo
 !
   if (IVel(nAlts, iUp_) .lt. 0.0) then
     IVel(nAlts + 1, iUp_) = -1.0*IVel(nAlts, iUp_)
@@ -496,7 +496,7 @@ subroutine set_vertical_bcs(LogRho, LogNS, Vel_GD, Temp, LogINS, iVel, VertVel)
   else
     IVel(nAlts + 1, iUp_) = IVel(nAlts, iUp_)
     IVel(nAlts + 2, iUp_) = IVel(nAlts, iUp_)
-  end if
+  endif
 
 !  if(Vel_GD(nAlts,iUp_) .lt. 0.0) then
 !     Vel_GD(nAlts+1,iUp_) = -1.0*Vel_GD(nAlts,iUp_)
@@ -521,7 +521,7 @@ subroutine set_vertical_bcs(LogRho, LogNS, Vel_GD, Temp, LogINS, iVel, VertVel)
     if (dn > -0.25*LogINS(nAlts, iSpecies)) dn = -0.25*LogINS(nAlts, iSpecies)
     LogINS(nAlts + 1, iSpecies) = LogINS(nAlts, iSpecies) + dn
     LogINS(nAlts + 2, iSpecies) = LogINS(nAlts + 1, iSpecies) + dn
-  end do
+  enddo
 
   ! Hydrostatic pressure for the neutrals
 
@@ -546,9 +546,9 @@ subroutine set_vertical_bcs(LogRho, LogNS, Vel_GD, Temp, LogINS, iVel, VertVel)
           Gravity_G(nAlts), Mass(iSpecies), Temp(nAlts), &
           LogNS(nAlts, iSpecies), LogNS(nAlts + 1, iSpecies), &
           dAlt_F(nAlts), LogNS(nAlts + 2, iSpecies)
-      end if
-    end do
-  end do
+      endif
+    enddo
+  enddo
 
 !  do iAlt = nAlts + 1, nAlts + 2
 !
@@ -629,9 +629,9 @@ subroutine set_vertical_bcs(LogRho, LogNS, Vel_GD, Temp, LogINS, iVel, VertVel)
     do iSpecies = 1, nSpecies
       SumRho = SumRho + &
                Mass(iSpecies)*exp(LogNS(iAlt, iSpecies))
-    end do
+    enddo
     LogRho(iAlt) = alog(SumRho)
-  end do
+  enddo
 !
 
 end subroutine set_vertical_bcs

--- a/src/set_vertical_bcs.Venus.f90
+++ b/src/set_vertical_bcs.Venus.f90
@@ -61,7 +61,7 @@ subroutine set_vertical_bcs(LogRho, LogNS, Vel_GD, Temp, LogINS, iVel, VertVel)
     dn = 0.0
     LogINS(0, iSpecies) = LogINS(1, iSpecies) - dn
     LogINS(-1, iSpecies) = LogINS(0, iSpecies) - dn
-  end do
+  enddo
 
   LogINS(0, nIons) = alog(sum(exp(LogINS(0, 1:nIons - 1))))
   LogINS(1, nIons) = alog(sum(exp(LogINS(1, 1:nIons - 1))))
@@ -75,7 +75,7 @@ subroutine set_vertical_bcs(LogRho, LogNS, Vel_GD, Temp, LogINS, iVel, VertVel)
     else
       LogNS(0, iN4S_) = LogNS(1, iN4S_) + dn
       LogNS(-1, iN4S_) = LogNS(0, iN4S_) + dn
-    end if
+    endif
 
     if (VertVel(1, iN4S_) .gt. 0.0) then
       ! Don't allow upwelling of N4S
@@ -84,9 +84,9 @@ subroutine set_vertical_bcs(LogRho, LogNS, Vel_GD, Temp, LogINS, iVel, VertVel)
     else
       VertVel(0, iN4S_) = 1.0*VertVel(1, iN4S_)
       VertVel(-1, iN4S_) = 1.0*VertVel(1, iN4S_)
-    end if
+    endif
 
-  end if
+  endif
 
   ! Lower boundary for O on Mars
   if (nSpecies >= iO_) then
@@ -98,7 +98,7 @@ subroutine set_vertical_bcs(LogRho, LogNS, Vel_GD, Temp, LogINS, iVel, VertVel)
     else
       LogNS(0, iO_) = LogNS(1, iO_) + dn
       LogNS(-1, iO_) = LogNS(0, iO_) + dn
-    end if
+    endif
 
     if (VertVel(1, iO_) .gt. 0.0) then
       ! Don't allow upwelling of O
@@ -107,9 +107,9 @@ subroutine set_vertical_bcs(LogRho, LogNS, Vel_GD, Temp, LogINS, iVel, VertVel)
     else
       VertVel(0, iO_) = 1.0*VertVel(1, iO_)
       VertVel(-1, iO_) = 1.0*VertVel(1, iO_)
-    end if
+    endif
 
-  end if
+  endif
 
   !-----------------------------------------------------------
   ! Top
@@ -140,7 +140,7 @@ subroutine set_vertical_bcs(LogRho, LogNS, Vel_GD, Temp, LogINS, iVel, VertVel)
     Vel_GD(nAlts + 2, iUp_) = -Vel_GD(nAlts - 1, iUp_)
     VertVel(nAlts + 1, :) = -VertVel(nAlts, :)
     VertVel(nAlts + 2, :) = -VertVel(nAlts - 1, :)
-  end if
+  endif
 
   ! Constant temperature (zero gradient)
 
@@ -158,7 +158,7 @@ subroutine set_vertical_bcs(LogRho, LogNS, Vel_GD, Temp, LogINS, iVel, VertVel)
     if (dn > 0) dn = -0.01*exp(LogINS(nAlts, iSpecies))
     LogINS(nAlts + 1, iSpecies) = alog(exp(LogINS(nAlts, iSpecies)) + dn)
     LogINS(nAlts + 2, iSpecies) = alog(exp(LogINS(nAlts + 1, iSpecies)) + dn)
-  end do
+  enddo
 
   LogINS(nAlts + 1, nIons) = alog(sum(exp(LogINS(nAlts + 1, 1:nIons - 1))))
   LogINS(nAlts + 2, nIons) = alog(sum(exp(LogINS(nAlts + 2, 1:nIons - 1))))
@@ -177,9 +177,9 @@ subroutine set_vertical_bcs(LogRho, LogNS, Vel_GD, Temp, LogINS, iVel, VertVel)
           Gravity_G(nAlts), Mass(iSpecies), Temp(nAlts), &
           LogNS(nAlts, iSpecies), LogNS(nAlts + 1, iSpecies), &
           dAlt_F(nAlts), LogNS(nAlts + 2, iSpecies)
-      end if
-    end do
-  end do
+      endif
+    enddo
+  enddo
 
 end subroutine set_vertical_bcs
 

--- a/src/stop_file.f90
+++ b/src/stop_file.f90
@@ -35,16 +35,16 @@ subroutine check_stop
     if (IsThere) then
       write(*, *) "GITM.STOP file found. Exiting."
       EndTimeLocal = CurrentTime - 1.0
-    end if
+    endif
 
-  end if
+  endif
 
   if (get_timing("GITM") > CPUTimeMax) then
     if (iProc == 0) write(*, *) "CPUTimeMax Exceeded. Exiting."
     EndTimeLocal = CurrentTime - 1.0
     open(unit=iOutputUnit_, file="GITM.CPU", status="unknown")
     close(iOutputUnit_)
-  end if
+  endif
 
   call MPI_AllREDUCE(EndTimeLocal, EndTime, &
                      1, MPI_DOUBLE_PRECISION, MPI_MIN, iCommGITM, iError)
@@ -75,19 +75,19 @@ subroutine delete_stop
   if (IsThere .and. iProc == 0) then
     open(iOutputUnit_, file='GITM.STOP', status='OLD')
     close(iOutputUnit_, status='DELETE')
-  end if
+  endif
 
   inquire(file='GITM.DONE', EXIST=IsThere)
   if (IsThere .and. iProc == 0) then
     open(iOutputUnit_, file='GITM.DONE', status='OLD')
     close(iOutputUnit_, status='DELETE')
-  end if
+  endif
 
   inquire(file='GITM.CPU', EXIST=IsThere)
   if (IsThere .and. iProc == 0) then
     open(iOutputUnit_, file='GITM.CPU', status='OLD')
     close(iOutputUnit_, status='DELETE')
-  end if
+  endif
 
 end subroutine delete_stop
 
@@ -124,21 +124,21 @@ subroutine check_start
           write(*, *) "GITM.START file found. Continuing."
           open(iOutputUnit_, file='GITM.START', status='OLD')
           close(iOutputUnit_, status='DELETE')
-        end if
-      end if
+        endif
+      endif
 
       if (.not. IsThere) call sleep(2.0)
 
       call MPI_BARRIER(iCommGITM, iError)
 
-    end do
+    enddo
 
     ! Here is where to open and read the file that will set the new pause time
     ! and update the state of GITM.
 
     PauseTime = PauseTime + 300.0  ! delete this when you read the new file....
 
-  end if
+  endif
 
 end subroutine check_start
 

--- a/src/stretch_grid.f90
+++ b/src/stretch_grid.f90
@@ -84,7 +84,7 @@ subroutine stretch_grid(x, y)
         xdist = (1.0 - cos(xnorm2)**SF)*(1.0 - latoffnorm) + latoffnorm
         xdist = StretchingPercentage2*xdist + OneMSP2*xnorm
 
-      end if
+      endif
 
     else
 
@@ -103,15 +103,15 @@ subroutine stretch_grid(x, y)
         xdist = (1.0 - cos(xnorm2)**SF)*(1.0 - latoffnorm) + latoffnorm
         xdist = StretchingPercentage2*xdist - OneMSP2*xnorm
 
-      end if
+      endif
 
       xdist = -xdist
 
-    end if
+    endif
 
     y = xdist/2.0 + 0.5
 
-  end if
+  endif
 
   if (x > 1.0) y = 2.0 - y
   if (x < 0.0) y = -y
@@ -169,7 +169,7 @@ subroutine stretch_grid_old(x, y)
       xdist = (1.0 - cos(xnorm2)**SF)*(1.0 - latoffnorm) + latoffnorm
       xdist = StretchingPercentage2*xdist + OneMSP2*xnorm
 
-    end if
+    endif
 
   else
 
@@ -188,11 +188,11 @@ subroutine stretch_grid_old(x, y)
       xdist = (1.0 - cos(xnorm2)**SF)*(1.0 - latoffnorm) + latoffnorm
       xdist = StretchingPercentage2*xdist - OneMSP2*xnorm
 
-    end if
+    endif
 
     xdist = -xdist
 
-  end if
+  endif
 
   y = xdist/2.0 + 0.5
 

--- a/src/tides.f90
+++ b/src/tides.f90
@@ -26,9 +26,9 @@ subroutine modify_initial_after_tides
         NDensityS(:, :, iAlt, iSpecies, iBlock) = &
           NDensityS(:, :, iAlt, iSpecies, iBlock)* &
           TidesRhoRat(:, :, iAlt + 2, iBlock)
-      end do
-    end do
-  end do
+      enddo
+    enddo
+  enddo
 
 end subroutine modify_initial_after_tides
 
@@ -60,7 +60,7 @@ subroutine read_waccm_tides
   if (IsFirstTime) then
     WACCM_file_name = "UA/DataIn/waccm_tides_2000_03.bin"
     IsFirstTime = .false.
-  end if
+  endif
 
   iError = 0
 
@@ -77,7 +77,7 @@ subroutine read_waccm_tides
 
   do ivar = 1, nvars
     read(iInputUnit_) varname(ivar)
-  end do
+  enddo
 
   read(iInputUnit_) iTime
 
@@ -156,7 +156,7 @@ subroutine read_waccm_tides
 
     do ivar = 1, nvars
       read(iInputUnit_) param(:, :, :, ivar)
-    end do
+    enddo
 
     lon_waccm = param(:, 1, 1, 1)
     lat_waccm = param(1, :, 1, 2)
@@ -195,7 +195,7 @@ subroutine read_waccm_tides
     call convert_waccm_fields(v24c, v24s, v12c, v12s, &
                               omegaa1_waccm, omegaa2_waccm, omegap1_waccm, omegap2_waccm)
 
-  end if
+  endif
 
   do iBlock = 1, nBlocks
 
@@ -204,12 +204,12 @@ subroutine read_waccm_tides
       iLon_Waccm(iLon, iBlock) = 1
       do iLonW = 2, nLonsWaccm - 1
         if (lon_waccm(iLonW) <= lon) iLon_Waccm(iLon, iBlock) = iLonW
-      end do
+      enddo
       rLon_Waccm(iLon, iBlock) = &
         (lon - lon_waccm(iLon_Waccm(iLon, iBlock)))/ &
         (lon_waccm(iLon_Waccm(iLon, iBlock) + 1) - &
          lon_waccm(iLon_Waccm(iLon, iBlock)))
-    end do
+    enddo
 
     do iLat = -1, nLats + 2
       lat = Latitude(iLat, iBlock)
@@ -218,12 +218,12 @@ subroutine read_waccm_tides
       iLat_Waccm(iLat, iBlock) = 1
       do iLatW = 2, nLatsWaccm - 1
         if (lat_waccm(iLatW) <= lat) iLat_Waccm(iLat, iBlock) = iLatW
-      end do
+      enddo
       rLat_Waccm(iLat, iBlock) = &
         (lat - lat_waccm(iLat_Waccm(iLat, iBlock)))/ &
         (lat_waccm(iLat_Waccm(iLat, iBlock) + 1) - &
          lat_waccm(iLat_Waccm(iLat, iBlock)))
-    end do
+    enddo
 
 ! This is for testing the linear interpolation
 !     do iLon = 1, nLonsWaccm
@@ -247,9 +247,9 @@ subroutine read_waccm_tides
             (1 - rj)*(ri)*Alt_waccm(j, i + 1, iAlt) + &
             (rj)*(1 - ri)*Alt_waccm(j + 1, i, iAlt) + &
             (rj)*(ri)*Alt_waccm(j + 1, i + 1, iAlt)
-        end do
-      end do
-    end do
+        enddo
+      enddo
+    enddo
 
     do iLon = -1, nLons + 2
       do iLat = -1, nLats + 2
@@ -258,17 +258,17 @@ subroutine read_waccm_tides
           do iAltW = 2, nAltsWaccm - 1
             if (Alt_Waccm_GitmGrid(iLon, iLat, iAltW, iBlock) <= a) &
               iAlt_Waccm(iLon, iLat, iAlt + 2, iBlock) = iAltW
-          end do
+          enddo
           i = iAlt_Waccm(iLon, iLat, iAlt + 2, iBlock)
           rAlt_Waccm(iLon, iLat, iAlt + 2, iBlock) = &
             (a - Alt_waccm_GitmGrid(iLon, iLat, i, iBlock))/ &
             (Alt_waccm_GitmGrid(iLon, iLat, i + 1, iBlock) - &
              Alt_waccm_GitmGrid(iLon, iLat, i, iBlock))
-        end do
-      end do
-    end do
+        enddo
+      enddo
+    enddo
 
-  end do
+  enddo
 
   call end_timing("read_waccm_tides")
 
@@ -382,10 +382,10 @@ subroutine update_waccm_tides
             (1 - ri)*(rj)*(rk)*omega_waccm(i, j + 1, k + 1) + &
             (ri)*(rj)*(rk)*omega_waccm(i + 1, j + 1, k + 1)
 
-        end do
-      end do
-    end do
-  end do
+        enddo
+      enddo
+    enddo
+  enddo
 
 end subroutine update_waccm_tides
 
@@ -433,22 +433,22 @@ subroutine init_hme
     if (galt < hmeAlts(1)) then
       write(*, *) "Well, shoot.  One of the GITM Alts is below HME!!!"
       call stop_gitm("I am unsure of what to do now! Stopping!")
-    end if
+    endif
     if (galt > hmeAlts(3)) then
       write(*, *) "Well, shoot.  One of the GITM Alts is above HME!!!"
       call stop_gitm("I am unsure of what to do now! Stopping!")
-    end if
+    endif
 
     if ((galt >= hmeAlts(1)) .and. (galt < hmeAlts(2))) then
       iAlt_Hme(iAlt) = 1
     else
       iAlt_Hme(iAlt) = 2
-    end if
+    endif
     rAlt_Hme(iAlt) = &
       (gAlt - hmeAlts(iAlt_Hme(iAlt)))/ &
       (hmeAlts(iAlt_Hme(iAlt + 1)) - hmeAlts(iAlt_Hme(iAlt)))
 
-  end do
+  enddo
 
   ! We need to get the latitudes, which is in each of the HME files. So,
   ! let's just read in one of the files and store the latitudes:
@@ -475,13 +475,13 @@ subroutine init_hme
     else
       do iLatH = 1, nLatsHme - 1
         if (hmeLats(iLatH) <= glat) iLat_Hme(iLat) = iLatH
-      end do
+      enddo
       rLat_Hme(iLat) = &
         (glat - hmeLats(iLat_Hme(iLat)))/ &
         (hmeLats(iLat_Hme(iLat) + 1) - hmeLats(iLat_Hme(iLat)))
-    end if
+    endif
 
-  end do
+  enddo
 
 end subroutine init_hme
 
@@ -514,7 +514,7 @@ subroutine update_hme_tides
     ReadFiles = .true.
   else
     ReadFiles = .false.
-  end if
+  endif
 
   ut = utime/3600.0
 
@@ -527,7 +527,7 @@ subroutine update_hme_tides
     tmp1 = pack(daysTidi, daysTidi < iday)
     tmp2 = pack(daysTidi, daysTidi > iday)
     call calc_1tide(tmp1(size(tmp1)), tmp2(1))
-  end if
+  endif
 
   iBlock = 1
   do iLon = -1, nLons + 2
@@ -559,9 +559,9 @@ subroutine update_hme_tides
                                                     (rj)*(1 - rk)*dr_rho_3d(iLon, j + 1, k) + &
                                                     (1 - rj)*(rk)*dr_rho_3d(iLon, j, k + 1) + &
                                                     (rj)*(rk)*dr_rho_3d(iLon, j + 1, k + 1)
-      end do
-    end do
-  end do
+      enddo
+    enddo
+  enddo
 
 end subroutine update_hme_tides
 
@@ -598,7 +598,7 @@ subroutine read_tides
     GSWM_file_name(3) = "UA/DataIn/semidiur_mig_99km_"//cMonth//".bin"
     GSWM_file_name(4) = "UA/DataIn/semidiur_nonmig_99km_"//cMonth//".bin"
     IsFirstTime = .false.
-  end if
+  endif
 
   iError = 0
 
@@ -618,7 +618,7 @@ subroutine read_tides
 
       do ivar = 1, nvars
         read(iInputUnit_) varname(ivar)
-      end do
+      enddo
 
       read(iInputUnit_) time
 
@@ -627,17 +627,17 @@ subroutine read_tides
       if (.not. allocated(u_gswm)) then
         allocate(u_gswm(nLonsGswm, nLatsGswm, nAltsGswm, 24))
         u_gswm(:, :, :, :) = 0.
-      end if
+      endif
 
       if (.not. allocated(v_gswm)) then
         allocate(v_gswm(nLonsGswm, nLatsGswm, nAltsGswm, 24))
         v_gswm(:, :, :, :) = 0.
-      end if
+      endif
 
       if (.not. allocated(t_gswm)) then
         allocate(t_gswm(nLonsGswm, nLatsGswm, nAltsGswm, 24))
         t_gswm(:, :, :, :) = 0.
-      end if
+      endif
 
       if (.not. allocated(lon_gswm)) allocate(lon_gswm(nLonsGswm))
       if (.not. allocated(lat_gswm)) allocate(lat_gswm(nLatsGswm))
@@ -645,8 +645,8 @@ subroutine read_tides
       do ihour = 1, 24
         do ivar = 1, nvars
           read(iInputUnit_) param(:, :, :, ivar, ihour)
-        end do
-      end do
+        enddo
+      enddo
 
       lon_gswm(:) = param(:, 1, 1, 1, 1)
       lat_gswm(:) = param(1, :, 1, 2, 1)
@@ -662,9 +662,9 @@ subroutine read_tides
       deallocate(varname)
       deallocate(param)
 
-    end if
+    endif
 
-  end do
+  enddo
 
   call end_timing("read_tides")
 
@@ -708,7 +708,7 @@ subroutine update_tides
               Longitude(iLon, iBlock)*180/pi
             write(*, *) "gswm lat/lon : ", &
               lat_gswm(iLatGSWM)*180/pi, lon_gswm(iLonGSWM)*180/pi
-          end if
+          endif
 
           TidesTemp(iLon, iLat, iAlt, iBlock) = &
             (1 - rfac)*t_gswm(iLonGSWM, iLatGSWM, 1, iFac1) + &
@@ -720,9 +720,9 @@ subroutine update_tides
             (1 - rfac)*v_gswm(iLonGSWM, iLatGSWM, 1, iFac1) + &
             (rfac)*v_gswm(iLonGSWM, iLatGSWM, 1, iFac2)
 
-        end do
-      end do
-    end do
-  end do
+        enddo
+      enddo
+    enddo
+  enddo
 
 end subroutine update_tides

--- a/src/time_routines.f90
+++ b/src/time_routines.f90
@@ -25,7 +25,7 @@ subroutine update_time
   do while (DTime > DaysPerYearInput*RotationPeriodInput)
     VernalTime = VernalTime + int(DaysPerYearInput)*RotationPeriodInput
     DTime = CurrentTime - VernalTime
-  end do
+  enddo
   iDay = DTime/RotationPeriodInput
   uTime = (DTime/RotationPeriodInput - iDay)*RotationPeriodInput
 
@@ -62,7 +62,7 @@ integer function jday(year, mon, day) result(Julian_Day)
   Julian_Day = 0
   do i = 1, mon - 1
     Julian_Day = Julian_Day + dayofmon(i)
-  end do
+  enddo
   Julian_Day = Julian_Day + day
 
 end
@@ -101,8 +101,8 @@ subroutine time_int_to_real(itime, timereal)
       nyear = itime(1) - 65
     else
       nyear = itime(1) + 100 - 65
-    end if
-  end if
+    endif
+  endif
   nleap = nyear/4
 
   nmonth = itime(2) - 1
@@ -111,7 +111,7 @@ subroutine time_int_to_real(itime, timereal)
 
   do i = 1, nmonth
     nday = nday + dayofmon(i)
-  end do
+  enddo
 
   nday = nday + itime(3) - 1
   nhour = itime(4)
@@ -167,8 +167,8 @@ subroutine time_real_to_int(timereal, itime)
       nyear = int((timereal - (dble(nleap)*sperday))/speryear)
       nleap = nyear/4
       nday = int((timereal - (dble(nyear)*speryear))/sperday)
-    end if
-  end if
+    endif
+  endif
 
   if (mod((nyear + 65), 4) .eq. 0) dayofmon(2) = dayofmon(2) + 1
 
@@ -189,7 +189,7 @@ subroutine time_real_to_int(timereal, itime)
   do while (nday .ge. dayofmon(nmonth))
     nday = nday - dayofmon(nmonth)
     nmonth = nmonth + 1
-  end do
+  enddo
 
   itime(1) = nyear + 1965
   itime(2) = nmonth

--- a/src/timing.f90
+++ b/src/timing.f90
@@ -16,7 +16,7 @@ subroutine start_timing(cTimingNameIn)
     Timings = 0.0
     iTimingLevel = 0
     IsTiming = .false.
-  end if
+  endif
 
   iLevel = 0
   iTiming = -1
@@ -24,14 +24,14 @@ subroutine start_timing(cTimingNameIn)
     if (IsTiming(i)) iLevel = iLevel + 1
     if (index(cTimingNames(i), cTimingNameIn) > 0) then
       iTiming = i
-    end if
-  end do
+    endif
+  enddo
 
   if (iTiming < 0) then
     nTiming = nTiming + 1
     cTimingNames(nTiming) = cTimingNameIn
     iTiming = nTiming
-  end if
+  endif
 
   IsTiming(iTiming) = .true.
   if (iTimingLevel(iTiming) < iLevel) iTimingLevel(iTiming) = iLevel
@@ -56,13 +56,13 @@ subroutine end_timing(cTimingNameIn)
   do i = 1, nTiming
     if (index(cTimingNames(i), cTimingNameIn) > 0) then
       iTiming = i
-    end if
-  end do
+    endif
+  enddo
 
   if (iTiming < 0) then
     write(*, *) "Unknown timing : ", cTimingNameIn
     return
-  end if
+  endif
 
   IsTiming(iTiming) = .false.
   Timings(iTiming, 2) = Timings(iTiming, 2) + &
@@ -87,8 +87,8 @@ real function get_timing(cTimingNameIn)
   do i = 1, nTiming
     if (index(cTimingNames(i), cTimingNameIn) > 0) then
       iTiming = i
-    end if
-  end do
+    endif
+  enddo
 
   if (iTiming < 0) then
     write(*, *) "Error!!"
@@ -99,8 +99,8 @@ real function get_timing(cTimingNameIn)
       get_timing = mpi_wtime() - Timings(iTiming, 1)
     else
       get_timing = Timings(iTiming, 2)
-    end if
-  end if
+    endif
+  endif
 
 end function get_timing
 
@@ -129,21 +129,21 @@ subroutine report_timing(cTimingNameIn)
         clevelSpace(1:5 - iTimingLevel(iTiming)), &
         " took ", Timings(iTiming, 2), &
         " seconds to complete"
-    end do
+    enddo
     return
-  end if
+  endif
 
   iTiming = -1
   do i = 1, nTiming
     if (index(cTimingNames(i), cTimingNameIn) > 0) then
       iTiming = i
-    end if
-  end do
+    endif
+  enddo
 
   if (iTiming < 0) then
     write(*, *) "Unknown timing : ", cTimingNameIn
     return
-  end if
+  endif
 
   write(*, "(a,a,f7.1,a)") &
     cTimingNames(iTiming), " took ", Timings(iTiming, 2), &

--- a/src/user.aurora.f90
+++ b/src/user.aurora.f90
@@ -108,7 +108,7 @@ subroutine output_header_user(cType, iOutputUnit_)
     write(iOutputUnit_, "(I7,A1,a)") 3, " ", "Altitude"
     write(iOutputUnit_, "(I7,A1,a)") 4, " ", "Joule Heating"
 
-  end if
+  endif
 
   ! ------------------------------------------
   ! 2D Output Header
@@ -139,8 +139,8 @@ subroutine output_header_user(cType, iOutputUnit_)
     write(iOutputUnit_, "(I7,A1,a)") 10, " ", "Wave Total Energy (ergs)"
     do n = 1, ED_N_Energies
       write(iOutputUnit_, "(I7,A6,1P,E9.3,A11)") 10 + n, " Flux@", ED_energies(n), "eV (/cm2/s)"
-    end do
-  end if
+    enddo
+  endif
 
   write(iOutputUnit_, *) ""
 
@@ -168,9 +168,9 @@ subroutine output_3dUser(iBlock, iOutputUnit_)
           Latitude(iLat, iBlock), &
           Altitude_GB(iLon, iLat, iAlt, iBlock), &
           UserData3D(iLon, iLat, iAlt, 1:nVarsUser3d - 3, iBlock)
-      end do
-    end do
-  end do
+      enddo
+    enddo
+  enddo
 
 end subroutine output_3dUser
 
@@ -196,8 +196,8 @@ subroutine output_2dUser(iBlock, iOutputUnit_)
         Latitude(iLat, iBlock), &
         Altitude_GB(iLon, iLat, iAlt, iBlock), &
         UserData2D(iLon, iLat, iAlt, 1:nVarsUser2d - 3, iBlock)
-    end do
-  end do
+    enddo
+  enddo
 
 end subroutine output_2dUser
 
@@ -223,8 +223,8 @@ subroutine output_1dUser(iBlock, iOutputUnit_)
         Latitude(iLat, iBlock), &
         Altitude_GB(iLon, iLat, iAlt, iBlock), &
         UserData2D(iLon, iLat, iAlt, 1:nVarsUser2d - 3, iBlock)
-    end do
-  end do
+    enddo
+  enddo
 
 end subroutine output_1dUser
 

--- a/src/user.etemp.f90
+++ b/src/user.etemp.f90
@@ -50,7 +50,7 @@ subroutine user_perturbation
   if (CurrentTime < PerturbTimeStart) then
     tsave = sum(temperature(1:nLons, 1:nLats, 1, 1:nBlocks))/ &
             (nLons*nLats*nBlocks)
-  end if
+  endif
 
   DuringPerturb = .false.
 
@@ -75,7 +75,7 @@ subroutine user_perturbation
               exp(-((longitude(iLon, iBlock) - loncenter)/lonwidth)**2)
           else
             f(iLon, iLat) = 0.0
-          end if
+          endif
 
           iAlt = 1
           UserHeatingRate(iLon, iLat, iAlt, iBlock) = &
@@ -84,8 +84,8 @@ subroutine user_perturbation
             TempUnit(iLon, iLat, iAlt)/ &
             cp(iLon, iLat, iAlt, iBlock)/ &
             rho(iLon, iLat, iAlt, iBlock)
-        end do
-      end do
+        enddo
+      enddo
 
 !        temperature(:,:,-1,iBlock) = tsave + 5.0 * f * tsave
 !        temperature(:,:, 0,iBlock) = tsave + 5.0 * f * tsave
@@ -98,9 +98,9 @@ subroutine user_perturbation
 !        Velocity(:,:,-1, iUp_, iBlock) = 2*f
 !        Velocity(:,:, 0, iUp_, iBlock) = 2*f
 !        Velocity(:,:, 1, iUp_, iBlock) = 2*f
-    end do
+    enddo
 
-  end if
+  endif
 
 !  NDensityS(nLons/2,nLats/2,2,1:3,1) = NDensityS(nLons/2,nLats/2,2,1:3,1)*50.0
 !  temperature(nLons/2,nLats/2,2,1) = temperature(nLons/2,nLats/2,2,1)*100.0
@@ -214,7 +214,7 @@ subroutine output_header_user(cType, iOutputUnit_)
     write(iOutputUnit_, "(I7,A1,a)") 3, " ", "Altitude"
     write(iOutputUnit_, "(I7,A1,a)") 4, " ", "JouleHeating"
     write(iOutputUnit_, "(I7,A1,a)") 5, " ", "JPara"
-  end if
+  endif
 
   ! ------------------------------------------
   ! 2D Output Header
@@ -245,8 +245,8 @@ subroutine output_header_user(cType, iOutputUnit_)
     write(iOutputUnit_, "(I7,A1,a)") 10, " ", "Wave Total Energy (ergs)"
     do n = 1, ED_N_Energies
       write(iOutputUnit_, "(I7,A6,1P,E9.3,A11)") 10 + n, " Flux@", ED_energies(n), "eV (/cm2/s)"
-    end do
-  end if
+    enddo
+  endif
 
   write(iOutputUnit_, *) ""
 
@@ -274,9 +274,9 @@ subroutine output_3dUser(iBlock, iOutputUnit_)
           Latitude(iLat, iBlock), &
           Altitude_GB(iLon, iLat, iAlt, iBlock), &
           UserData3D(iLon, iLat, iAlt, 1:nVarsUser3d - 3, iBlock)
-      end do
-    end do
-  end do
+      enddo
+    enddo
+  enddo
 
 end subroutine output_3dUser
 
@@ -302,8 +302,8 @@ subroutine output_2dUser(iBlock, iOutputUnit_)
         Latitude(iLat, iBlock), &
         Altitude_GB(iLon, iLat, iAlt, iBlock), &
         UserData2D(iLon, iLat, iAlt, 1:nVarsUser2d - 3, iBlock)
-    end do
-  end do
+    enddo
+  enddo
 
 end subroutine output_2dUser
 
@@ -329,8 +329,8 @@ subroutine output_1dUser(iBlock, iOutputUnit_)
         Latitude(iLat, iBlock), &
         Altitude_GB(iLon, iLat, iAlt, iBlock), &
         UserData2D(iLon, iLat, iAlt, 1:nVarsUser2d - 3, iBlock)
-    end do
-  end do
+    enddo
+  enddo
 
 end subroutine output_1dUser
 

--- a/src/user.f90
+++ b/src/user.f90
@@ -37,7 +37,7 @@ subroutine get_mean_bcs
     LocalSumVolume = LocalSumVolume + &
                      sum(CellVolume(1:nLons, 1:nLats, -1:0, iBlock))
 
-  end do
+  enddo
 
   call MPI_ALLREDUCE(LocalMeanVelBc_D, MeanVelBc_D, 2, &
                      MPI_REAL, MPI_SUM, iCommGITM, iError)
@@ -111,7 +111,7 @@ subroutine user_perturbation
   if (CurrentTime < PerturbTimeStart) then
     tsave = sum(temperature(1:nLons, 1:nLats, 1, 1:nBlocks))/ &
             (nLons*nLats*nBlocks)
-  end if
+  endif
 
   DuringPerturb = .false.
 
@@ -136,7 +136,7 @@ subroutine user_perturbation
               exp(-((longitude(iLon, iBlock) - loncenter)/lonwidth)**2)
           else
             f(iLon, iLat) = 0.0
-          end if
+          endif
 
           iAlt = 1
           UserHeatingRate(iLon, iLat, iAlt, iBlock) = &
@@ -145,8 +145,8 @@ subroutine user_perturbation
             TempUnit(iLon, iLat, iAlt)/ &
             cp(iLon, iLat, iAlt, iBlock)/ &
             rho(iLon, iLat, iAlt, iBlock)
-        end do
-      end do
+        enddo
+      enddo
 
 !        temperature(:,:,-1,iBlock) = tsave + 5.0 * f * tsave
 !        temperature(:,:, 0,iBlock) = tsave + 5.0 * f * tsave
@@ -159,9 +159,9 @@ subroutine user_perturbation
 !        Velocity(:,:,-1, iUp_, iBlock) = 2*f
 !        Velocity(:,:, 0, iUp_, iBlock) = 2*f
 !        Velocity(:,:, 1, iUp_, iBlock) = 2*f
-    end do
+    enddo
 
-  end if
+  endif
 
 !  NDensityS(nLons/2,nLats/2,2,1:3,1) = NDensityS(nLons/2,nLats/2,2,1:3,1)*50.0
 !  temperature(nLons/2,nLats/2,2,1) = temperature(nLons/2,nLats/2,2,1)*100.0
@@ -243,7 +243,7 @@ subroutine user_bc_perturbation(LogRhoBc, LogNSBc, VelBc_GD, TempBc)
     Slope = tan(pi/2.+PerturbWaveDirection*pi/180.)
     WaveSpeedLat = PerturbWaveSpeed/sin(PerturbWaveDirection*pi/180.)
     IsFirstCall = .false.
-  end if
+  endif
 
   if (CurrentTime /= OldTime) then
     ! These are the same for all grid cells within each time step
@@ -251,7 +251,7 @@ subroutine user_bc_perturbation(LogRhoBc, LogNSBc, VelBc_GD, TempBc)
     BouyancyFreq2 = (Gamma_const - 1)/Gamma_const*AvgGravity/ScaleHeight
     SoundSpeed2 = Gamma_const*AvgGravity*ScaleHeight
     OldTime = CurrentTime
-  end if
+  endif
 
   ! longitude degree-meter conversion factor of the current Lat
   dLon = pi*Rbody*cos(Lat*pi/180.)/180.
@@ -282,7 +282,7 @@ subroutine user_bc_perturbation(LogRhoBc, LogNSBc, VelBc_GD, TempBc)
           write(*, *) 'No longer a upward-propagating waves at Time = ', &
           CurrentTime - StartTime, 'iFreq =', iFreq
         cycle
-      end if
+      endif
 
       Kz = sqrt(WaveFreqIntri2/SoundSpeed2 + &
                 (BouyancyFreq2 - WaveFreqIntri2)*Kh2/WaveFreqIntri2 - &
@@ -301,8 +301,8 @@ subroutine user_bc_perturbation(LogRhoBc, LogNSBc, VelBc_GD, TempBc)
           .and. (Lat - RefLat)*dLat - Slope*(Lon - RefLon)*dLon <= &
           WaveSpeedLat*(CurrentTime - StartTime - PerturbTimeDelay &
                         - PerturbDuration)
-      end if
-    end if
+      endif
+    endif
 
     do iAlt = -1, 0
 
@@ -321,7 +321,7 @@ subroutine user_bc_perturbation(LogRhoBc, LogNSBc, VelBc_GD, TempBc)
             write(*, *) 'No longer a upward-propagating AGW at Time = ', &
             CurrentTime - StartTime, 'iFreq =', iFreq
           cycle
-        end if
+        endif
 
         Kr = sqrt(WaveFreqIntri2*(WaveFreqIntri2 - SoundSpeed2/ &
                                   (4.*ScaleHeight**2))/SoundSpeed2 &
@@ -338,7 +338,7 @@ subroutine user_bc_perturbation(LogRhoBc, LogNSBc, VelBc_GD, TempBc)
                      (CurrentTime - StartTime - PerturbTimeDelay) &
                      .and. RadialD >= PerturbWaveFreq(iFreq)/Kr* &
                      (CurrentTime - StartTime - PerturbTimeDelay - PerturbDuration))
-      end if
+      endif
 
       if (DoPerturb) then
 
@@ -374,7 +374,7 @@ subroutine user_bc_perturbation(LogRhoBc, LogNSBc, VelBc_GD, TempBc)
                    FFTReal(iFreq)*exp(Altitude_G(iAlt)/(2.*ScaleHeight))
           WaveCombo1 = (CoeffS*SineWave + CoeffC*CosineWave)/RadialD
           WaveCombo2 = (CoeffS*CosineWave + CoeffC*SineWave)/RadialD
-        end if
+        endif
 
         dRho = exp(-Altitude_G(iAlt)/ScaleHeight)*Rho0*WaveFreqIntri/Coeff3* &
                ((Coeff2*WaveFreqIntri2 + Coeff1/ScaleHeight)*Kz*WaveCombo1 - &
@@ -407,9 +407,9 @@ subroutine user_bc_perturbation(LogRhoBc, LogNSBc, VelBc_GD, TempBc)
           'WaveForm = ', WaveForm, 'CoeffS =', CoeffS, 'CoeffC =', CoeffC, &
           'dRho = ', dRho, 'dVel = ', dVel
 
-      end if
-    end do
-  end do
+      endif
+    enddo
+  enddo
 
 end subroutine user_bc_perturbation
 
@@ -536,7 +536,7 @@ subroutine output_header_user(cType, iOutputUnit_)
     write(iOutputUnit_, "(I7,A1,a)") 4, " ", "Joule Heating"
     write(iOutputUnit_, "(I7,A1,a)") 5, " ", "JPara"
 
-  end if
+  endif
 
   ! ------------------------------------------
   ! 2D Output Header
@@ -567,8 +567,8 @@ subroutine output_header_user(cType, iOutputUnit_)
     write(iOutputUnit_, "(I7,A1,a)") 10, " ", "Wave Total Energy (ergs)"
     do n = 1, ED_N_Energies
       write(iOutputUnit_, "(I7,A6,1P,E9.3,A11)") 10 + n, " Flux@", ED_energies(n), "eV (/cm2/s)"
-    end do
-  end if
+    enddo
+  endif
 
   ! ------------------------------------------
   ! 1D Output Header
@@ -587,7 +587,7 @@ subroutine output_header_user(cType, iOutputUnit_)
     write(iOutputUnit_, "(I7,A1,a)") 2, " ", "Latitude"
     write(iOutputUnit_, "(I7,A1,a)") 3, " ", "Altitude"
     write(iOutputUnit_, "(I7,A1,a)") 4, " ", "Electron Density"
-  end if
+  endif
 
   ! ------------------------------------------
   ! 0D Output Header
@@ -608,7 +608,7 @@ subroutine output_header_user(cType, iOutputUnit_)
     write(iOutputUnit_, "(I7,A1,a)") 4, " ", "Electron Density"
     write(iOutputUnit_, "(I7,A1,a)") 5, " ", "Electron Temperature"
     write(iOutputUnit_, "(I7,A1,a)") 6, " ", "Ion Temperature"
-  end if
+  endif
 
   write(iOutputUnit_, *) ""
 
@@ -636,9 +636,9 @@ subroutine output_3dUser(iBlock, iOutputUnit_)
           Latitude(iLat, iBlock), &
           Altitude_GB(iLon, iLat, iAlt, iBlock), &
           UserData3D(iLon, iLat, iAlt, 1:nVarsUser3d - 3, iBlock)
-      end do
-    end do
-  end do
+      enddo
+    enddo
+  enddo
 
 end subroutine output_3dUser
 
@@ -664,8 +664,8 @@ subroutine output_2dUser(iBlock, iOutputUnit_)
         Latitude(iLat, iBlock), &
         Altitude_GB(iLon, iLat, iAlt, iBlock), &
         UserData2D(iLon, iLat, iAlt, 1:nVarsUser2d - 3, iBlock)
-    end do
-  end do
+    enddo
+  enddo
 
 end subroutine output_2dUser
 
@@ -692,7 +692,7 @@ subroutine output_1dUser(iiLon, iiLat, iBlock, rLon, rLat, iOutputUnit_)
       Altitude_GB(iiLon, iiLat, iAlt, iBlock), &
       inter(IDensityS(0:nLons + 1, 0:nLats + 1, iAlt, ie_, iBlock), &
             iiLon, iiLat, rLon, rLat)
-  end do
+  enddo
 
 contains
 

--- a/src/vertical_solver.f90
+++ b/src/vertical_solver.f90
@@ -487,7 +487,7 @@ subroutine advance_vertical_1stage_rusanov( &
                            GradVel_CD(:, iDim), DiffVel_CD(:, iDim))
     call calc_rusanov_alts(iVel(:, iDim), &
                            GradiVel_CD(:, iDim), DiffiVel_CD(:, iDim))
-  end do
+  enddo
 
   ! Add geometrical correction to gradient and obtain divergence
   DivVel = GradVel_CD(:, iUp_) + 2*Vel_GD(1:nAlts, iUp_)*InvRadialDistance_C(1:nAlts)
@@ -503,20 +503,20 @@ subroutine advance_vertical_1stage_rusanov( &
     DiffVertVel(:, iSpecies) = DiffTmp
     DivVertVel(:, iSpecies) = GradVertVel(:, iSpecies) + &
                               2*VertVel(1:nAlts, iSpecies)*InvRadialDistance_C(1:nAlts)
-  end do
+  enddo
 
   do iSpecies = 1, nIons - 1
     call calc_rusanov_alts(LogINS(:, iSpecies), GradTmp, DiffTmp)
     GradLogINS(:, iSpecies) = GradTmp
     DiffLogINS(:, iSpecies) = DiffTmp
-  end do
+  enddo
 
   ! Use Colegrove Method
   ! Step 1:  Calculate Ln(rho_{s}/Rho)
   do iSpecies = 1, nSpecies
     LogConS(-1:nAlts + 2, iSpecies) = &
       alog(Mass(iSpecies)*NS(-1:nAlts + 2, iSpecies)/Rho(-1:nAlts + 2))
-  end do
+  enddo
 
   do iAlt = 1, nAlts
 
@@ -549,8 +549,8 @@ subroutine advance_vertical_1stage_rusanov( &
         + MeshCoef2*LogConS(iAlt, iSpecies) &
         + MeshCoef3*LogConS(iAlt + 1, iSpecies) &
         + MeshCoef4*LogConS(iAlt + 2, iSpecies)
-    end do  ! iSpecies Loop
-  end do ! iAlt Loop
+    enddo  ! iSpecies Loop
+  enddo ! iAlt Loop
 
   AmpSP = (1.0/(10.0*Dt))
   kSP = nAltsSponge + 1
@@ -562,7 +562,7 @@ subroutine advance_vertical_1stage_rusanov( &
                                  (DivVertVel(iAlt, iSpecies) + &
                                   VertVel(iAlt, iSpecies)*GradLogNS(iAlt, iSpecies)) + &
                                  Dt*DiffLogNS(iAlt, iSpecies)
-    end do
+    enddo
 
     do iSpecies = 1, nIonsAdvect
       if (UseImprovedIonAdvection) then
@@ -574,8 +574,8 @@ subroutine advance_vertical_1stage_rusanov( &
         NewLogINS(iAlt, iSpecies) = NewLogINS(iAlt, iSpecies) - Dt* &
                                     (IVel(iAlt, iUp_)*GradLogINS(iAlt, iSpecies)) &
                                     + Dt*DiffLogINS(iAlt, iSpecies)
-      end if
-    end do
+      endif
+    enddo
 
     ! Bulk Velocity defined as the mass-weighted average of the
     ! species' velocities
@@ -585,12 +585,12 @@ subroutine advance_vertical_1stage_rusanov( &
       NuSP = AmpSP*(1.0 - cos(pi*(kSP - (nAlts - iAlt))/kSP))
     else
       NuSP = 0.0
-    end if
+    endif
 
     if (UseDamping) then
       VertTau(iAlt) = &
         15 - (1 - exp(-1.0*altitude_G(ialt)/1000.0/40.0))*5.0
-    end if
+    endif
 
     do iSpecies = 1, nSpecies
       !The tau term was added as a vertical wind damping term
@@ -610,7 +610,7 @@ subroutine advance_vertical_1stage_rusanov( &
         NewVertVel(iAlt, ispecies) = NewVertVel(iAlt, ispecies) + Dt*( &
                                      Centrifugal/InvRadialDistance_C(iAlt) + &
                                      Coriolis*Vel_GD(iAlt, iEast_))
-      end if
+      endif
 
       ! Thermal Diffusion Effects (For Light Species H2, H, and He)
       ! ThermalDiffCoefS is set in calc_rates
@@ -620,9 +620,9 @@ subroutine advance_vertical_1stage_rusanov( &
                                    Dt*(ThermalDiffCoefS(iSpecies)*Boltzmanns_Constant* &
                                        GradTemp(iAlt))/Mass(iSpecies)
 
-    end do
+    enddo
 
-  end do
+  enddo
 
   ! Add Neutral Friction Between Species
   ! Needed for each increment in the RK-4 Solver
@@ -634,7 +634,7 @@ subroutine advance_vertical_1stage_rusanov( &
                                GradLogConS(1:nAlts, 1:nSpecies), &
                                Temp(1:nAlts))
     NewVertVel(1:nAlts, 1:nSpecies) = nVel(1:nAlts, 1:nSpecies)
-  end if
+  endif
 
   do iAlt = 1, nAlts
 
@@ -649,9 +649,9 @@ subroutine advance_vertical_1stage_rusanov( &
                               NewVertVel(iAlt, iSpecies)* &
                               (Mass(iSpecies)*NS(iAlt, iSpecies)/Rho(iAlt))
 
-    end do
+    enddo
 
-  end do
+  enddo
 
   do iAlt = 1, nAlts
 
@@ -673,11 +673,11 @@ subroutine advance_vertical_1stage_rusanov( &
                      Temp(iAlt)*DivVel(iAlt))) &
                     + Dt*DiffTemp(iAlt)
 
-  end do
+  enddo
   do iAlt = 1, nAlts
     NewSumRho = sum(Mass(1:nSpecies)*exp(NewLogNS(iAlt, 1:nSpecies)))
     NewLogRho(iAlt) = alog(NewSumRho)
-  end do
+  enddo
 
 end subroutine advance_vertical_1stage_rusanov
 
@@ -703,7 +703,7 @@ subroutine nighttime_timeconstant(UpdatValue, OldBCs)
     UpdatValue(nAlts + 1, :) = OldBCs(1, :)
     UpdatValue(nAlts + 2, :) = OldBCs(2, :)
 
-  end if
+  endif
 
 end subroutine nighttime_timeconstant
 
@@ -781,7 +781,7 @@ subroutine calc_facevalues_alts(Var, VarLeft, VarRight)
 
 !     write(*,*) dVarUp, dVarDown, dVarLimited(i)
 
-  end do
+  enddo
 
   i = 0
   dVarUp = (Var(i + 1) - Var(i))*InvDAlt_F(i + 1)
@@ -796,7 +796,7 @@ subroutine calc_facevalues_alts(Var, VarLeft, VarRight)
   do i = 1, nAlts + 1
     VarLeft(i) = Var(i - 1) + 0.5*dVarLimited(i - 1)*dAlt_F(i)
     VarRight(i) = Var(i) - 0.5*dVarLimited(i)*dAlt_F(i)
-  end do
+  enddo
 
 end subroutine calc_facevalues_alts
 

--- a/src/vertical_solver_ausm.f90
+++ b/src/vertical_solver_ausm.f90
@@ -17,9 +17,9 @@ subroutine check_ion_densities(iDen)
     do iAlt = 1, nAlts + 2
       if (iDen(iAlt, iIon) < 0.0) then
         iDen(iAlt, iIon) = max(iDen(iAlt - 1, iIon)*0.99, 10.0)
-      end if
-    end do
-  end do
+      endif
+    enddo
+  enddo
 
 end subroutine check_ion_densities
 
@@ -585,7 +585,7 @@ subroutine advance_vertical_1stage_ausm(DtIn, &
     EffectiveGravity(iAlt) = &
       Gravity_G(iAlt) + &
       Centrifugal/InvRadialDistance_C(iAlt)
-  end do
+  enddo
 
   NS = exp(LogNS)
 
@@ -594,18 +594,18 @@ subroutine advance_vertical_1stage_ausm(DtIn, &
   nFilter = 10
   do iAlt = -1, nAlts + 2
     RadialDistance_C(iAlt) = 1.0/InvRadialDistance_C(iAlt)
-  end do
+  enddo
 
   NT(-1:nAlts + 2) = 0.0
   do iSpecies = 1, nSpecies
     NT(-1:nAlts + 2) = NT(-1:nAlts + 2) + &
                        NS(-1:nAlts + 2, iSpecies)
-  end do
+  enddo
 
   do iAlt = -1, nAlts + 2
     Press(iAlt) = NT(iAlt)*Boltzmanns_Constant*Temp(iAlt)
     LogPress(iAlt) = alog(Press(iAlt))
-  end do
+  enddo
 
   call calc_rusanov_alts_ausm(LogPress, GradLogPress, DiffLogPress)
   call calc_rusanov_alts_ausm(LogRho, GradLogRho, DiffLogRho)
@@ -617,7 +617,7 @@ subroutine advance_vertical_1stage_ausm(DtIn, &
     ! call calc_rusanov_alts_ausm(iVel(:,iDim), &
     call calc_rusanov_alts_rusanov(iVel(:, iDim), &
                                    GradiVel_CD(:, iDim), DiffiVel_CD(:, iDim))
-  end do
+  enddo
 
   ! Add geometrical correction to gradient and obtain divergence
   DivVel = GradVel_CD(:, iUp_) + 2*Vel_GD(1:nAlts, iUp_)*InvRadialDistance_C(1:nAlts)
@@ -635,14 +635,14 @@ subroutine advance_vertical_1stage_ausm(DtIn, &
     DivVertVel(:, iSpecies) = GradVertVel(:, iSpecies) + &
                               2*VertVel(1:nAlts, iSpecies)*InvRadialDistance_C(1:nAlts)
 
-  end do
+  enddo
 
   do iSpecies = 1, nIons - 1
     ! call calc_rusanov_alts_ausm(LogINS(:,iSpecies), GradTmp, DiffTmp)
     call calc_rusanov_alts_rusanov(LogINS(:, iSpecies), GradTmp, DiffTmp)
     GradLogINS(:, iSpecies) = GradTmp
     DiffLogINS(:, iSpecies) = DiffTmp
-  end do
+  enddo
 
   ! Step 1:  Calculate Ln(rho_{s}/Rho)
   do iSpecies = 1, nSpecies
@@ -650,7 +650,7 @@ subroutine advance_vertical_1stage_ausm(DtIn, &
       alog(Mass(iSpecies)*NS(-1:nAlts + 2, iSpecies)/Rho(-1:nAlts + 2))
     !LogConS(-1:nAlts+2,iSpecies) = &
     !     alog(NS(-1:nAlts+2,iSpecies)/NT(-1:nAlts+2))
-  end do
+  enddo
 
   do iAlt = 1, nAlts
 
@@ -683,8 +683,8 @@ subroutine advance_vertical_1stage_ausm(DtIn, &
         + MeshCoef2*LogConS(iAlt, iSpecies) &
         + MeshCoef3*LogConS(iAlt + 1, iSpecies) &
         + MeshCoef4*LogConS(iAlt + 2, iSpecies)
-    end do  ! iSpecies Loop
-  end do ! iAlt Loop
+    enddo  ! iSpecies Loop
+  enddo ! iAlt Loop
 
   !!!! JMB AUSM: BEGIN THE HYDROSTATIC BACKGROUND
   !!!! We define a hydrostatic background to subtract off
@@ -701,7 +701,7 @@ subroutine advance_vertical_1stage_ausm(DtIn, &
                      (Boltzmanns_Constant*MeanTemp)
     HydroNT(iAlt) = HydroNT(iAlt - 1)*(Temp(iAlt - 1)/Temp(iAlt))* &
                     exp(-1.0*dAlt_F(iAlt)*InvScaleHeight)
-  end do
+  enddo
   iAlt = -1
   MeanMass = 0.5*(MeanMajorMass_1d(-1) + MeanMajorMass_1d(0))
   MeanGravity = 0.5*(EffectiveGravity(iAlt + 1) + EffectiveGravity(iAlt))
@@ -725,8 +725,8 @@ subroutine advance_vertical_1stage_ausm(DtIn, &
       HydroNS(iAlt, iSpecies) = &
         HydroNS(iAlt - 1, iSpecies)*(Temp(iAlt - 1)/Temp(iAlt))* &
         exp(-1.0*dAlt_F(iAlt)*InvScaleHeight)
-    end do
-  end do
+    enddo
+  enddo
   ! Extend the densities downward with the mean mass of the atmosphere
   do iSpecies = 1, nSpecies
     iAlt = -1
@@ -738,16 +738,16 @@ subroutine advance_vertical_1stage_ausm(DtIn, &
     HydroNS(iAlt, iSpecies) = &
       HydroNS(iAlt + 1, iSpecies)*(Temp(iAlt + 1)/Temp(iAlt))* &
       exp(dAlt_F(iAlt)*InvScaleHeight)
-  end do
+  enddo
   do iAlt = -1, nAlts + 2
     do iSpecies = 1, nSpecies
       HydroPressureS(iAlt, iSpecies) = &
         HydroNS(iAlt, iSpecies)*Boltzmanns_Constant*Temp(iAlt)
       HydroRhoS(iAlt, iSpecies) = Mass(iSpecies)*HydroNS(iAlt, iSpecies)
-    end do
+    enddo
     HydroPressure(iAlt) = HydroNT(iAlt)*Boltzmanns_Constant*Temp(iAlt)
     HydroRho(iAlt) = HydroNT(iAlt)*MeanMajorMass_1d(iAlt)
-  end do
+  enddo
   do iSpecies = 1, nSpecies
     RhoS(-1:nAlts + 2, iSpecies) = &
       Mass(iSpecies)*NS(-1:nAlts + 2, iSpecies)
@@ -758,7 +758,7 @@ subroutine advance_vertical_1stage_ausm(DtIn, &
     PressureS(-1:nAlts + 2, iSpecies) = &
       NS(-1:nAlts + 2, iSpecies)*Temp(-1:nAlts + 2)* &
       Boltzmanns_Constant
-  end do
+  enddo
 
   do iAlt = -1, nAlts + 2
     TotalEnergy(iAlt) = &
@@ -766,10 +766,10 @@ subroutine advance_vertical_1stage_ausm(DtIn, &
       0.5*Rho(iAlt)*(Vel_GD(iAlt, iUp_)**2.0 + &
                      Vel_GD(iAlt, iNorth_)**2.0 + &
                      Vel_GD(iAlt, iEast_)**2.0)
-  end do
+  enddo
   do iDim = 1, 3
     Momentum(-1:nAlts + 2, iDim) = Rho(-1:nAlts + 2)*Vel_GD(-1:nAlts + 2, iDim)
-  end do
+  enddo
 
   DeviationRhoSRatio(-1:nAlts + 2, 1:nSpecies) = &
     abs(RhoS(-1:nAlts + 2, 1:nSpecies) - &
@@ -786,9 +786,9 @@ subroutine advance_vertical_1stage_ausm(DtIn, &
         SubtractHydrostatic(iAlt, iSpecies) = .false.
       else
         SubtractHydrostatic(iAlt, iSpecies) = .true.
-      end if
-    end do
-  end do
+      endif
+    enddo
+  enddo
 
   NewRho = Rho
   NewPress = Press
@@ -811,7 +811,7 @@ subroutine advance_vertical_1stage_ausm(DtIn, &
       NewRhoS(iAlt, iSpecies) = RhoS(iAlt, iSpecies) &
                                 - DtIn*(AUSMRhoSFluxes(iAlt, iSpecies))
       NewLogNS(iAlt, iSpecies) = alog(NewRhoS(iAlt, iSpecies)/Mass(iSpecies))
-    end do
+    enddo
 
     do iSpecies = 1, nIonsAdvect
 !        if (UseImprovedIonAdvection) then
@@ -825,9 +825,9 @@ subroutine advance_vertical_1stage_ausm(DtIn, &
                                   (IVel(iAlt, iUp_)*GradLogINS(iAlt, iSpecies)) &
                                   + DtIn*DiffLogINS(iAlt, iSpecies)
 !        endif
-    end do
+    enddo
 
-  end do !iAlt = 1,nAlts
+  enddo !iAlt = 1,nAlts
 
   NewNS = 0.0
   NewNT = 0.0
@@ -842,19 +842,19 @@ subroutine advance_vertical_1stage_ausm(DtIn, &
 
       NewNT(iAlt) = NewNT(iAlt) + &
                     NewNS(iAlt, iSpecies)
-    end do
-  end do
+    enddo
+  enddo
 
   if (iAlt >= (nAlts - nAltsSponge)) then
     NuSP = AmpSP*(1.0 - cos(pi*(kSP - (nAlts - iAlt))/kSP))
   else
     NuSP = 0.0
-  end if
+  endif
 
   if (UseDamping) then
     VertTau(iAlt) = &
       15 - (1 - exp(-1.0*altitude_G(ialt)/1000.0/40.0))*5.0
-  end if
+  endif
 
   do iAlt = 1, nAlts
     do iSpecies = 1, nSpecies
@@ -867,7 +867,7 @@ subroutine advance_vertical_1stage_ausm(DtIn, &
         NewMomentumS(iAlt, iSpecies) = MomentumS(iAlt, iSpecies) - &
                                        DtIn*(AUSMMomentumSFluxes(iAlt, iSpecies)) + &
                                        DtIn*DeviationRhoS(iAlt, iSpecies)*EffectiveGravity(iAlt)
-      end if
+      endif
 
 !        NewMomentumS(iAlt,iSpecies) = NewMomentumS(iAlt,iSpecies) + &
 !              DtIn*ChemSources_1d(iAlt,iSpecies)*&
@@ -884,7 +884,7 @@ subroutine advance_vertical_1stage_ausm(DtIn, &
       if (UseCoriolis) then
         NewVertVel(iAlt, ispecies) = NewVertVel(iAlt, ispecies) + DtIn*( &
                                      Coriolis*Vel_GD(iAlt, iEast_))
-      end if
+      endif
       ! Thermal Diffusion Effects (For Light Species H2, H, and He)
       ! ThermalDiffCoefS is set in calc_rates
       ! Note:  ThermalDiffCoefS is < 0.0 for light species
@@ -892,9 +892,9 @@ subroutine advance_vertical_1stage_ausm(DtIn, &
       NewVertVel(iAlt, iSpecies) = NewVertVel(iAlt, iSpecies) - &
                                    DtIn*(ThermalDiffCoefS(iSpecies)*Boltzmanns_Constant* &
                                          GradTemp(iAlt))/Mass(iSpecies)
-    end do ! iSpecies
+    enddo ! iSpecies
 
-  end do ! iAlt
+  enddo ! iAlt
 
   if (UseNeutralFriction) then
     nVel(1:nAlts, 1:nSpecies) = NewVertVel(1:nAlts, 1:nSpecies)
@@ -907,7 +907,7 @@ subroutine advance_vertical_1stage_ausm(DtIn, &
                                GradLogConS(1:nAlts, 1:nSpecies), &
                                Temp(1:nAlts))
     NewVertVel(1:nAlts, 1:nSpecies) = nVel(1:nAlts, 1:nSpecies)
-  end if
+  endif
 
   do iAlt = -1, nAlts + 2
     do iSpecies = 1, nSpecies
@@ -915,8 +915,8 @@ subroutine advance_vertical_1stage_ausm(DtIn, &
                                        NewVertVel(iAlt, iSpecies))
       NewVertVel(iAlt, iSpecies) = min(MaximumVerticalVelocity, &
                                        NewVertVel(iAlt, iSpecies))
-    end do
-  end do
+    enddo
+  enddo
 
   NewVel_GD(-1:nAlts + 2, iUp_) = 0.0
   do iAlt = -1, nAlts + 2
@@ -933,8 +933,8 @@ subroutine advance_vertical_1stage_ausm(DtIn, &
 !
       NewVel_GD(iAlt, iUp_) = NewVel_GD(iAlt, iUp_) + &
                               NewVertVel(iAlt, iSpecies)*NewRhoS(iAlt, iSpecies)/NewRho(iAlt)
-    end do
-  end do
+    enddo
+  enddo
 
   do iAlt = 1, nAlts
 
@@ -984,12 +984,12 @@ subroutine advance_vertical_1stage_ausm(DtIn, &
 !       0.25*exp(-1.0*(Altitude_G(iAlt) - Altitude_G(0))/&
 !       (45.0e+03)) * DtIn*DiffTemp(iAlt)
 
-  end do ! iAlt
+  enddo ! iAlt
 
   do iAlt = 1, nAlts
     NewSumRho = sum(Mass(1:nSpecies)*exp(NewLogNS(iAlt, 1:nSpecies)))
     NewLogRho(iAlt) = alog(NewSumRho)
-  end do
+  enddo
 
 end subroutine advance_vertical_1stage_ausm
 
@@ -1065,7 +1065,7 @@ subroutine calc_facevalues_alts_ausm(Var, VarLeft, VarRight)
 
     dVarLimited(i) = Limiter_mc(dVarUp, dVarDown)
 
-  end do
+  enddo
 
   i = 0
   dVarUp = (Var(i + 1) - Var(i))*InvDAlt_F(i + 1)
@@ -1080,7 +1080,7 @@ subroutine calc_facevalues_alts_ausm(Var, VarLeft, VarRight)
   do i = 1, nAlts + 1
     VarLeft(i) = Var(i - 1) + 0.5*dVarLimited(i - 1)*dAlt_F(i)
     VarRight(i) = Var(i) - 0.5*dVarLimited(i)*dAlt_F(i)
-  end do
+  enddo
 
 end subroutine calc_facevalues_alts_ausm
 
@@ -1340,8 +1340,8 @@ subroutine calc_all_fluxes_hydro(DtIn, RhoS, PressureS, HydroPressureS, HydroRho
 
       LiouKpS(iAlt, iSpecies) = exp(LogKpS(iAlt, iSpecies))
       Ku(iAlt, iSpecies) = exp(LogKuS(iAlt, iSpecies))
-    end do
-  end do
+    enddo
+  enddo
 
 !!!! Grab the left and right states of the Variables
 !!!!  on boh Interfaces (P12 = +1/2 and M12 = -1/2)
@@ -1359,7 +1359,7 @@ subroutine calc_all_fluxes_hydro(DtIn, RhoS, PressureS, HydroPressureS, HydroRho
     RhoSLeft_P12(:, iSpecies) = exp(LogRhoSLeft_P12(:, iSpecies))
     RhoSRight_P12(:, iSpecies) = exp(LogRhoSRight_P12(:, iSpecies))
 
-  end do
+  enddo
 
 !    write(*,*) '==================== CALC_HYDRO_FLUXES ================'
 !    write(*,*) '======= M12 FACEVALUES ========'
@@ -1402,7 +1402,7 @@ subroutine calc_all_fluxes_hydro(DtIn, RhoS, PressureS, HydroPressureS, HydroRho
     HydroPressureSRight_P12(:, iSpecies) = &
       exp(LogHydroPressureSRight_P12(:, iSpecies))
 
-  end do
+  enddo
 
   do iSpecies = 1, nSpecies
          !! Calculate the Left and Right Faces of the PressureS
@@ -1416,14 +1416,14 @@ subroutine calc_all_fluxes_hydro(DtIn, RhoS, PressureS, HydroPressureS, HydroRho
     PressureSLeft_P12(:, iSpecies) = exp(LogPressureSLeft_P12(:, iSpecies))
     PressureSRight_P12(:, iSpecies) = exp(LogPressureSRight_P12(:, iSpecies))
 
-  end do
+  enddo
 
   do iSpecies = 1, nSpecies
          !! Calculate the Left and Right Faces of the Var (Rho)
     call calc_kt_facevalues(VertVel(:, iSpecies), &
                             VelLeft_M12(:, iSpecies), VelRight_M12(:, iSpecies), &
                             VelLeft_P12(:, iSpecies), VelRight_P12(:, iSpecies))
-  end do
+  enddo
 
 !    write(*,*) '======= M12 VELOCITY FACEVALUES ========'
 !    do iSpecies = 1, nSpecies
@@ -1461,7 +1461,7 @@ subroutine calc_all_fluxes_hydro(DtIn, RhoS, PressureS, HydroPressureS, HydroRho
                            RhoSLeft_P12(1:nAlts, iSpecies)
     RhoRight_P12(1:nAlts) = RhoRight_P12(1:nAlts) + &
                             RhoSRight_P12(1:nAlts, iSpecies)
-  end do
+  enddo
 
   PLeft_M12(:) = 0.0
   PRight_M12(:) = 0.0
@@ -1479,7 +1479,7 @@ subroutine calc_all_fluxes_hydro(DtIn, RhoS, PressureS, HydroPressureS, HydroRho
                          PressureSLeft_P12(1:nAlts, iSpecies)
     PRight_P12(1:nAlts) = PRight_P12(1:nAlts) + &
                           PressureSRight_P12(1:nAlts, iSpecies)
-  end do
+  enddo
 
   do iDim = 1, 3
       !! Calculate the Left and Right Faces of the Var (Rho)
@@ -1488,7 +1488,7 @@ subroutine calc_all_fluxes_hydro(DtIn, RhoS, PressureS, HydroPressureS, HydroRho
                             VelGDRight_M12(:, iDim), &
                             VelGDLeft_P12(:, iDim), &
                             VelGDRight_P12(:, iDim))
-  end do
+  enddo
 
   VelGDLeft_M12(:, iUp_) = 0.0
   VelGDRight_M12(:, iUp_) = 0.0
@@ -1517,7 +1517,7 @@ subroutine calc_all_fluxes_hydro(DtIn, RhoS, PressureS, HydroPressureS, HydroRho
       VelGDRight_P12(1:nAlts, iUp_) + &
       RhoSRight_P12(1:nAlts, iSpecies)* &
       VelRight_P12(1:nAlts, iSpecies)/RhoRight_P12(1:nAlts)
-  end do
+  enddo
 
         !! Calculate the Left and Right Faces of the Pressure
   call calc_kt_facevalues(Gamma_1d(:), GammaLeft_M12(:), GammaRight_M12(:), &
@@ -1549,7 +1549,7 @@ subroutine calc_all_fluxes_hydro(DtIn, RhoS, PressureS, HydroPressureS, HydroRho
       (VelGDRight_P12(iAlt, iUp_)**2.0 + VelGDRight_P12(iAlt, iEast_)**2.0 + &
        VelGDRight_P12(iAlt, iNorth_)**2.0)
 
-  end do
+  enddo
 
 !!!! Liou et al. [2006] suggest using the Enthalpy for the
 !!!! numerical speed of sound.
@@ -1596,7 +1596,7 @@ subroutine calc_all_fluxes_hydro(DtIn, RhoS, PressureS, HydroPressureS, HydroRho
 !      write(*,*) ' PLeft_M12(iAlt), PRight_M12, PLeft_P12, PRight_P12 =', &
 !            PLeft_M12(iAlt), PRight_M12(iAlt), PLeft_P12(iAlt), &
 !            PRight_P12(iAlt)
-  end do
+  enddo
 
 !!! Liou Methodology
 
@@ -1635,7 +1635,7 @@ subroutine calc_all_fluxes_hydro(DtIn, RhoS, PressureS, HydroPressureS, HydroRho
 
 !      write(*,*) 'iAlt, InterfaceCS_M12(iAlt), InterfaceCS_P12(iAlt) =',&
 !                  iAlt, InterfaceCS_M12(iAlt), InterfaceCS_P12(iAlt)
-  end do
+  enddo
 
 !stop
 
@@ -1664,7 +1664,7 @@ subroutine calc_all_fluxes_hydro(DtIn, RhoS, PressureS, HydroPressureS, HydroRho
   do iAlt = 1, nAlts
     MeanCS_P12(iAlt) = InterfaceCS_P12(iAlt)
     MeanCS_M12(iAlt) = InterfaceCS_M12(iAlt)
-  end do
+  enddo
 
 !!! Next, define local mach numbers at the interfaces
 
@@ -1683,8 +1683,8 @@ subroutine calc_all_fluxes_hydro(DtIn, RhoS, PressureS, HydroPressureS, HydroRho
       MRight_P12(iAlt, iSpecies) = &
         VelRight_P12(iAlt, iSpecies)/MeanCS_P12(iAlt)
 
-    end do
-  end do
+    enddo
+  enddo
 
   do iSpecies = 1, nSpecies
     M2Bar_M12(1:nAlts, iSpecies) = &
@@ -1694,7 +1694,7 @@ subroutine calc_all_fluxes_hydro(DtIn, RhoS, PressureS, HydroPressureS, HydroRho
     M2Bar_P12(1:nAlts, iSpecies) = &
       0.5*(MLeft_P12(1:nAlts, iSpecies)**2.0 + &
            MRight_P12(1:nAlts, iSpecies)**2.0)
-  end do
+  enddo
 
   do iSpecies = 1, nSpecies
     do iAlt = 1, nAlts
@@ -1707,8 +1707,8 @@ subroutine calc_all_fluxes_hydro(DtIn, RhoS, PressureS, HydroPressureS, HydroRho
       MZero_M12(iAlt, iSpecies) = sqrt(M2Zero_M12(iAlt, iSpecies))
       MZero_P12(iAlt, iSpecies) = sqrt(M2Zero_P12(iAlt, iSpecies))
 
-    end do
-  end do
+    enddo
+  enddo
 
   do iSpecies = 1, nSpecies
     do iAlt = 1, nAlts
@@ -1718,8 +1718,8 @@ subroutine calc_all_fluxes_hydro(DtIn, RhoS, PressureS, HydroPressureS, HydroRho
       FA_P12(iAlt, iSpecies) = &
         MZero_P12(iAlt, iSpecies)*(2.0 - MZero_P12(iAlt, iSpecies))
 
-    end do
-  end do
+    enddo
+  enddo
 
   do iSpecies = 1, nSpecies
     do iAlt = 1, nAlts
@@ -1743,8 +1743,8 @@ subroutine calc_all_fluxes_hydro(DtIn, RhoS, PressureS, HydroPressureS, HydroRho
         0.5*(MRight_P12(iAlt, iSpecies) + abs(MRight_P12(iAlt, iSpecies)))
       MF1N_Right_P12(iAlt, iSpecies) = &
         0.5*(MRight_P12(iAlt, iSpecies) - abs(MRight_P12(iAlt, iSpecies)))
-    end do
-  end do
+    enddo
+  enddo
 
   do iSpecies = 1, nSpecies
     do iAlt = 1, nAlts
@@ -1761,8 +1761,8 @@ subroutine calc_all_fluxes_hydro(DtIn, RhoS, PressureS, HydroPressureS, HydroRho
       MF2P_Right_P12(iAlt, iSpecies) = 0.25*(MRight_P12(iAlt, iSpecies) + 1.0)**2.0
       MF2N_Right_P12(iAlt, iSpecies) = -0.25*(MRight_P12(iAlt, iSpecies) - 1.0)**2.0
 
-    end do
-  end do
+    enddo
+  enddo
 
 !!! Begin 4th Order Mach Number Polynomials
   do iSpecies = 1, nSpecies
@@ -1772,31 +1772,31 @@ subroutine calc_all_fluxes_hydro(DtIn, RhoS, PressureS, HydroPressureS, HydroRho
       else
         MF4P_Left_M12(iAlt, iSpecies) = MF2P_Left_M12(iAlt, iSpecies)* &
                                         (1.0 - 16.0*LiouBeta*MF2N_Left_M12(iAlt, iSpecies))
-      end if
+      endif
 
       if (abs(MRight_M12(iAlt, iSpecies)) .ge. 1.0) then
         MF4N_Right_M12(iAlt, iSpecies) = MF1N_Right_M12(iAlt, iSpecies)
       else
         MF4N_Right_M12(iAlt, iSpecies) = MF2N_Right_M12(iAlt, iSpecies)* &
                                          (1.0 + 16.0*LiouBeta*MF2P_Right_M12(iAlt, iSpecies))
-      end if
+      endif
 
       if (abs(MLeft_P12(iAlt, iSpecies)) .ge. 1.0) then
         MF4P_Left_P12(iAlt, iSpecies) = MF1P_Left_P12(iAlt, iSpecies)
       else
         MF4P_Left_P12(iAlt, iSpecies) = MF2P_Left_P12(iAlt, iSpecies)* &
                                         (1.0 - 16.0*LiouBeta*MF2N_Left_P12(iAlt, iSpecies))
-      end if
+      endif
 
       if (abs(MRight_P12(iAlt, iSpecies)) .ge. 1.0) then
         MF4N_Right_P12(iAlt, iSpecies) = MF1N_Right_P12(iAlt, iSpecies)
       else
         MF4N_Right_P12(iAlt, iSpecies) = MF2N_Right_P12(iAlt, iSpecies)* &
                                          (1.0 + 16.0*LiouBeta*MF2P_Right_P12(iAlt, iSpecies))
-      end if
+      endif
 
-    end do
-  end do
+    enddo
+  enddo
 
 !!! Begin 2nd Order Mach Number Polynomials
   do iSpecies = 1, nSpecies
@@ -1843,9 +1843,9 @@ subroutine calc_all_fluxes_hydro(DtIn, RhoS, PressureS, HydroPressureS, HydroRho
            (FA_M12(iAlt, iSpecies)*MeanCS_M12(iAlt) + &
             ModifiedZeta(iAlt, iSpecies)*dAlt_C(iAlt)/DtIn))
 
-      end if
-    end do ! iSpecies
-  end do ! iAlt
+      endif
+    enddo ! iSpecies
+  enddo ! iAlt
 
   do iAlt = 1, nAlts
     do iSpecies = 1, nSpecies
@@ -1863,8 +1863,8 @@ subroutine calc_all_fluxes_hydro(DtIn, RhoS, PressureS, HydroPressureS, HydroRho
 
       LiouNumericalVelocity_P12(iAlt, iSpecies) = &
         MeanCS_P12(iAlt)*InterfaceMach_P12(iAlt, iSpecies)
-    end do ! iSpecies
-  end do  ! iAlt
+    enddo ! iSpecies
+  enddo  ! iAlt
 
   NumericalVelocity_M12(1:nAlts, 1:nSpecies) = &
     LiouNumericalVelocity_M12(1:nAlts, 1:nSpecies)
@@ -1904,10 +1904,10 @@ subroutine calc_all_fluxes_hydro(DtIn, RhoS, PressureS, HydroPressureS, HydroRho
           ((RhoSRight_M12(iAlt, iSpecies))*VelRight_M12(iAlt, iSpecies) - &
            (RhoSLeft_M12(iAlt, iSpecies))*VelLeft_M12(iAlt, iSpecies))
 
-      end if
+      endif
 
-    end do !!iAlt = 1, nAlts
-  end do !!! nSpecies
+    enddo !!iAlt = 1, nAlts
+  enddo !!! nSpecies
 
   do iSpecies = 1, nSpecies
     do iAlt = 1, nAlts
@@ -1925,7 +1925,7 @@ subroutine calc_all_fluxes_hydro(DtIn, RhoS, PressureS, HydroPressureS, HydroRho
         MomentumSFlux_P12(iAlt, iSpecies) = &
           (RhoSRight_P12(iAlt, iSpecies)*VelRight_P12(iAlt, iSpecies)* &
            NumericalVelocity_P12(iAlt, iSpecies))
-      end if
+      endif
       if (NumericalVelocity_M12(iAlt, iSpecies) .ge. 0.0) then
         RhoSFlux_M12(iAlt, iSpecies) = &
           (RhoSLeft_M12(iAlt, iSpecies)*NumericalVelocity_M12(iAlt, iSpecies))
@@ -1940,9 +1940,9 @@ subroutine calc_all_fluxes_hydro(DtIn, RhoS, PressureS, HydroPressureS, HydroRho
         MomentumSFlux_M12(iAlt, iSpecies) = &
           (RhoSRight_M12(iAlt, iSpecies)*VelRight_M12(iAlt, iSpecies)* &
            NumericalVelocity_M12(iAlt, iSpecies))
-      end if
-    end do
-  end do
+      endif
+    enddo
+  enddo
 
   BulkNumericalVelocity_P12(1:nAlts) = 0.0
   BulkNumericalVelocity_M12(1:nAlts) = 0.0
@@ -1959,7 +1959,7 @@ subroutine calc_all_fluxes_hydro(DtIn, RhoS, PressureS, HydroPressureS, HydroRho
       (RhoSLeft_M12(1:nAlts, iSpecies) + RhoSRight_M12(1:nAlts, iSpecies))* &
       NumericalVelocity_M12(1:nAlts, iSpecies)/ &
       (RhoLeft_M12(1:nAlts) + RhoRight_M12(1:nAlts))
-  end do
+  enddo
 
   do iAlt = 1, nAlts
     if (BulkNumericalVelocity_P12(iAlt) .ge. 0.0) then
@@ -1978,7 +1978,7 @@ subroutine calc_all_fluxes_hydro(DtIn, RhoS, PressureS, HydroPressureS, HydroRho
       Momentum_P12(iAlt, 1:3) = &
         RhoRight_P12(iAlt)*VelGDRight_P12(iAlt, 1:3)* &
         BulkNumericalVelocity_P12(iAlt)
-    end if
+    endif
     if (BulkNumericalVelocity_M12(iAlt) .ge. 0.0) then
       EnergyFlux_M12(iAlt) = &
         (ELeft_M12(iAlt) + PLeft_M12(iAlt)) &
@@ -1995,20 +1995,20 @@ subroutine calc_all_fluxes_hydro(DtIn, RhoS, PressureS, HydroPressureS, HydroRho
       Momentum_M12(iAlt, 1:3) = &
         RhoRight_M12(iAlt)*VelGDRight_M12(iAlt, 1:3)* &
         BulkNumericalVelocity_M12(iAlt)
-    end if
-  end do !! End iAlt Loop
+    endif
+  enddo !! End iAlt Loop
 
   do iAlt = 1, nAlts
     LeftRadius(iAlt) = 0.5*(RadDist(iAlt) + RadDist(iAlt - 1))
     RightRadius(iAlt) = 0.5*(RadDist(iAlt) + RadDist(iAlt + 1))
-  end do
+  enddo
 
   do iAlt = 1, nAlts
     AreaFunction_P12(iAlt) = RightRadius(iAlt)**2.0
     AreaFunction_M12(iAlt) = LeftRadius(iAlt)**2.0
     LocalCellVolume(iAlt) = &
       (1.0/3.0)*(RightRadius(iAlt)**3.0 - LeftRadius(iAlt)**3.0)
-  end do
+  enddo
 
   do iSpecies = 1, nSpecies
     RhoSFlux(1:nAlts, iSpecies) = &
@@ -2025,7 +2025,7 @@ subroutine calc_all_fluxes_hydro(DtIn, RhoS, PressureS, HydroPressureS, HydroRho
       MomentumSFlux(1:nAlts, iSpecies) + &
       (NumericalPressure_P12(1:nAlts, iSpecies) - &
        NumericalPressure_M12(1:nAlts, iSpecies))/dAlt_C(1:nAlts)
-  end do
+  enddo
 
   EnergyFlux(1:nAlts) = &
     ((AreaFunction_P12(1:nAlts))*EnergyFlux_P12(1:nAlts) - &
@@ -2037,7 +2037,7 @@ subroutine calc_all_fluxes_hydro(DtIn, RhoS, PressureS, HydroPressureS, HydroRho
       (AreaFunction_P12(1:nAlts)*Momentum_P12(1:nAlts, iDim) - &
        AreaFunction_M12(1:nAlts)*Momentum_M12(1:nAlts, iDim))/ &
       LocalCellVolume(1:nAlts)
-  end do
+  enddo
 
 end subroutine calc_all_fluxes_hydro
 
@@ -2065,7 +2065,7 @@ subroutine calc_kt_facevalues(Var, VarLeft_M12, VarRight_M12, &
     dVarUp = (Var(i + 1) - Var(i))*InvDAlt_F(i + 1)
     dVarDown = (Var(i) - Var(i - 1))*InvDAlt_F(i)
     dVarLimited(i) = Limiter_mc(dVarUp, dVarDown)
-  end do
+  enddo
 
   do i = 1, nAlts
     VarLeft_M12(i) = Var(i - 1) + 0.5*dVarLimited(i - 1)*dAlt_F(i - 1)
@@ -2073,7 +2073,7 @@ subroutine calc_kt_facevalues(Var, VarLeft_M12, VarRight_M12, &
 
     VarLeft_P12(i) = Var(i) + 0.5*dVarLimited(i)*dAlt_F(i)
     VarRight_P12(i) = Var(i + 1) - 0.5*dVarLimited(i + 1)*dAlt_F(i + 1)
-  end do
+  enddo
 
 !        do i=1,nAlts
 !            VarLeft_M12(i) = Var(i-1) + 0.5*dVarLimited(i-1) * dAlt_F(i  )

--- a/src/vertical_solver_rusanov.f90
+++ b/src/vertical_solver_rusanov.f90
@@ -474,7 +474,7 @@ subroutine advance_vertical_1stage( &
                                    GradVel_CD(:, iDim), DiffVel_CD(:, iDim))
     call calc_rusanov_alts_rusanov(iVel(:, iDim), &
                                    GradiVel_CD(:, iDim), DiffiVel_CD(:, iDim))
-  end do
+  enddo
 
   ! Add geometrical correction to gradient and obtain divergence
   DivVel = GradVel_CD(:, iUp_) + 2*Vel_GD(1:nAlts, iUp_)*InvRadialDistance_C(1:nAlts)
@@ -490,20 +490,20 @@ subroutine advance_vertical_1stage( &
     DiffVertVel(:, iSpecies) = DiffTmp
     DivVertVel(:, iSpecies) = GradVertVel(:, iSpecies) + &
                               2*VertVel(1:nAlts, iSpecies)*InvRadialDistance_C(1:nAlts)
-  end do
+  enddo
 
   do iSpecies = 1, nIons - 1
     call calc_rusanov_alts_rusanov(LogINS(:, iSpecies), GradTmp, DiffTmp)
     GradLogINS(:, iSpecies) = GradTmp
     DiffLogINS(:, iSpecies) = DiffTmp
-  end do
+  enddo
 
   ! Use Colegrove Method
   ! Step 1:  Calculate Ln(rho_{s}/Rho)
   do iSpecies = 1, nSpecies
     LogConS(-1:nAlts + 2, iSpecies) = &
       alog(Mass(iSpecies)*NS(-1:nAlts + 2, iSpecies)/Rho(-1:nAlts + 2))
-  end do
+  enddo
 
   do iAlt = 1, nAlts
 
@@ -536,8 +536,8 @@ subroutine advance_vertical_1stage( &
         + MeshCoef2*LogConS(iAlt, iSpecies) &
         + MeshCoef3*LogConS(iAlt + 1, iSpecies) &
         + MeshCoef4*LogConS(iAlt + 2, iSpecies)
-    end do  ! iSpecies Loop
-  end do ! iAlt Loop
+    enddo  ! iSpecies Loop
+  enddo ! iAlt Loop
 
   AmpSP = (1.0/(10.0*Dt))
   kSP = nAltsSponge + 1
@@ -549,7 +549,7 @@ subroutine advance_vertical_1stage( &
                                  (DivVertVel(iAlt, iSpecies) + &
                                   VertVel(iAlt, iSpecies)*GradLogNS(iAlt, iSpecies)) + &
                                  Dt*DiffLogNS(iAlt, iSpecies)
-    end do
+    enddo
 
     do iSpecies = 1, nIonsAdvect
 !        if (UseImprovedIonAdvection) then
@@ -562,7 +562,7 @@ subroutine advance_vertical_1stage( &
                                   (IVel(iAlt, iUp_)*GradLogINS(iAlt, iSpecies)) &
                                   + Dt*DiffLogINS(iAlt, iSpecies)
 !        endif
-    end do
+    enddo
 
     ! Bulk Velocity defined as the mass-weighted average of the
     ! species' velocities
@@ -572,12 +572,12 @@ subroutine advance_vertical_1stage( &
       NuSP = AmpSP*(1.0 - cos(pi*(kSP - (nAlts - iAlt))/kSP))
     else
       NuSP = 0.0
-    end if
+    endif
 
     if (UseDamping) then
       VertTau(iAlt) = &
         15 - (1 - exp(-1.0*altitude_G(ialt)/1000.0/40.0))*5.0
-    end if
+    endif
 
     do iSpecies = 1, nSpecies
       !The tau term was added as a vertical wind damping term
@@ -597,7 +597,7 @@ subroutine advance_vertical_1stage( &
         NewVertVel(iAlt, ispecies) = NewVertVel(iAlt, ispecies) + Dt*( &
                                      Centrifugal/InvRadialDistance_C(iAlt) + &
                                      Coriolis*Vel_GD(iAlt, iEast_))
-      end if
+      endif
 
       ! Thermal Diffusion Effects (For Light Species H2, H, and He)
       ! ThermalDiffCoefS is set in calc_rates
@@ -607,9 +607,9 @@ subroutine advance_vertical_1stage( &
                                    Dt*(ThermalDiffCoefS(iSpecies)*Boltzmanns_Constant* &
                                        GradTemp(iAlt))/Mass(iSpecies)
 
-    end do
+    enddo
 
-  end do
+  enddo
 
   ! Add Neutral Friction Between Species
   ! Needed for each increment in the RK-4 Solver
@@ -633,7 +633,7 @@ subroutine advance_vertical_1stage( &
                                GradLogConS(1:nAlts, 1:nSpecies), &
                                Temp(1:nAlts))
     NewVertVel(1:nAlts, 1:nSpecies) = nVel(1:nAlts, 1:nSpecies)
-  end if
+  endif
 
   do iAlt = 1, nAlts
 
@@ -648,9 +648,9 @@ subroutine advance_vertical_1stage( &
                               NewVertVel(iAlt, iSpecies)* &
                               (Mass(iSpecies)*NS(iAlt, iSpecies)/Rho(iAlt))
 
-    end do
+    enddo
 
-  end do
+  enddo
 
   do iAlt = 1, nAlts
 
@@ -672,11 +672,11 @@ subroutine advance_vertical_1stage( &
                      Temp(iAlt)*DivVel(iAlt))) &
                     + Dt*DiffTemp(iAlt)
 
-  end do
+  enddo
   do iAlt = 1, nAlts
     NewSumRho = sum(Mass(1:nSpecies)*exp(NewLogNS(iAlt, 1:nSpecies)))
     NewLogRho(iAlt) = alog(NewSumRho)
-  end do
+  enddo
 
 end subroutine advance_vertical_1stage
 
@@ -754,7 +754,7 @@ subroutine calc_facevalues_alts_rusanov(Var, VarLeft, VarRight)
 
 !     write(*,*) dVarUp, dVarDown, dVarLimited(i)
 
-  end do
+  enddo
 
   i = 0
   dVarUp = (Var(i + 1) - Var(i))*InvDAlt_F(i + 1)
@@ -769,7 +769,7 @@ subroutine calc_facevalues_alts_rusanov(Var, VarLeft, VarRight)
   do i = 1, nAlts + 1
     VarLeft(i) = Var(i - 1) + 0.5*dVarLimited(i - 1)*dAlt_F(i)
     VarRight(i) = Var(i) - 0.5*dVarLimited(i)*dAlt_F(i)
-  end do
+  enddo
 
 end subroutine calc_facevalues_alts_rusanov
 

--- a/src/write_output.f90
+++ b/src/write_output.f90
@@ -36,14 +36,14 @@ subroutine write_output
         ", Time: ", iTimeArray(1:3), ' ', iTimeArray(4:6), &
         ", WallTime: ", RealTime/60.0, " min, Proj : ", &
         ProjectedTime/60.0
-    end if
-  end if
+    endif
+  endif
 
   DtPlot = DtPlotSave
   if (CurrentTime >= PlotTimeChangeStart .and. &
       CurrentTime <= PlotTimeChangeEnd) then
     DtPlot = PlotTimeChangeDt
-  end if
+  endif
 
   IsDone = .false.
   do i = 1, nOutputTypes
@@ -51,21 +51,21 @@ subroutine write_output
         floor((tsimulation)/DtPlot(i)) .or. tSimulation == 0.0) then
       do iBlock = 1, nBlocks
         call output(outputDir, iBlock, i)
-      end do
-    end if
-  end do
+      enddo
+    endif
+  enddo
 
   call move_satellites
 
   if (floor((tSimulation - dt)/DtRestart) /= &
       floor((tsimulation)/DtRestart)) then
     call write_restart(restartOutDir)
-  end if
+  endif
 
   if (floor((tSimulation - dt)/DtLogfile) /= &
       floor((tsimulation)/DtLogfile)) then
     call logfile(logDir)
-  end if
+  endif
 
 end subroutine write_output
 

--- a/srcGlow/GL_library.f90
+++ b/srcGlow/GL_library.f90
@@ -39,7 +39,7 @@ subroutine GL_setloc(alt, n, lat, lon, npb, ierror)
     iError = 1
   else
     iError = 0
-  end if
+  endif
 end subroutine GL_setloc
 
 !-----------------------------------------------------
@@ -82,7 +82,7 @@ subroutine GL_interp_flux(GITM_wave_l, GITM_wave_s, GITM_flux, nGitmWaves)
   do l = 1, lmax
     wave1(l) = waveS(lmax - (l - 1))
     wave2(l) = waveL(lmax - (l - 1))
-  end do
+  enddo
 
   SFLUX = 0.0
 
@@ -90,13 +90,13 @@ subroutine GL_interp_flux(GITM_wave_l, GITM_wave_s, GITM_flux, nGitmWaves)
 
     if (wave2(i) .ge. GITM_wave_l(1)) then
       istart = i
-    end if
+    endif
 
     if (WAVE1(i) .ge. GITM_wave_s(nGitmWaves)) then
       ifinish = i - 1
-    end if
+    endif
 
-  end do
+  enddo
 
   do i = istart, ifinish
 
@@ -109,13 +109,13 @@ subroutine GL_interp_flux(GITM_wave_l, GITM_wave_s, GITM_flux, nGitmWaves)
     countS = 1
     do j = 1, nGitmWaves
       if (dwaveL(j) .lt. dwaveL(countL)) countL = j
-    end do
+    enddo
     do j = 1, nGitmWaves
       if (dwaveS(j) .gt. -900) then
         countS = j
         goto 300
-      end if
-    end do
+      endif
+    enddo
 
 300 incL = 0
     incS = 0
@@ -130,9 +130,9 @@ subroutine GL_interp_flux(GITM_wave_l, GITM_wave_s, GITM_flux, nGitmWaves)
       else
         incU = incU + 1
         incL = incU
-      end if
+      endif
       goto 100
-    end if
+    endif
 
     incU = 0
     incD = 0
@@ -145,9 +145,9 @@ subroutine GL_interp_flux(GITM_wave_l, GITM_wave_s, GITM_flux, nGitmWaves)
       else
         incU = incU + 1
         incS = incU
-      end if
+      endif
       goto 200
-    end if
+    endif
 
     countS = countS + incS
     countL = countL + incL
@@ -172,10 +172,10 @@ subroutine GL_interp_flux(GITM_wave_l, GITM_wave_s, GITM_flux, nGitmWaves)
         if (GITM_wave_l(countL + icount) .ne. &
             GITM_wave_s(countL + icount)) then
           SFLUX(i) = SFLUX(i) + GITM_flux(countL + icount)
-        end if
-      end do
-    end if
-  end do
+        endif
+      enddo
+    endif
+  enddo
 
   !Deal with beginning and end of GLOW spectrum if not already
   if (istart .ne. 1) then
@@ -184,7 +184,7 @@ subroutine GL_interp_flux(GITM_wave_l, GITM_wave_s, GITM_flux, nGitmWaves)
     S_factor = (GITM_wave_s(1) - WAVE1(1))/ &
                (GITM_wave_s(1) - 0)
     SFLUX(i) = GITM_flux(1)*(S_Factor + L_factor)
-  end if
+  endif
 
   if (ifinish .ne. LMAX) then
     L_factor = (wave2(LMAX) - GITM_wave_l(nGitmWaves))/ &
@@ -192,7 +192,7 @@ subroutine GL_interp_flux(GITM_wave_l, GITM_wave_s, GITM_flux, nGitmWaves)
     S_factor = (GITM_wave_l(nGitmWaves) - WAVE1(LMAX))/ &
                (GITM_wave_l(nGitmWaves) - GITM_wave_s(nGitmWaves))
     SFLUX(i) = GITM_flux(nGitmWaves)*(S_Factor + L_factor)
-  end if
+  endif
   !Now take care of individual lines in GITM
   do j = 1, nGitmWaves
     if (GITM_wave_l(j) .eq. GITM_wave_s(j)) then
@@ -201,9 +201,9 @@ subroutine GL_interp_flux(GITM_wave_l, GITM_wave_s, GITM_flux, nGitmWaves)
             wave2(i) .ge. GITM_wave_l(j)) &
           SFLUX(i) = SFLUX(i) + GITM_flux(j)
 
-      end do
-    end if
-  end do
+      enddo
+    endif
+  enddo
 
   !Convert to cm
   SFLUX = SFLUX/(10000.0)
@@ -314,7 +314,7 @@ subroutine GL_getvals(ipin, emisrate, upeflx, downeflx, photoErate, ebins)
 !Downward flux at conjugate point = upward flux at location
   do N = 1, NBINS
     PHITOP(N) = UFLX(N, JMAX)
-  end do
+  enddo
 
 !Call Glow for conjugate point (same neutral atmosphere)
 
@@ -323,7 +323,7 @@ subroutine GL_getvals(ipin, emisrate, upeflx, downeflx, photoErate, ebins)
 !Upward flux at conjugate point = downward flux at location
   do N = 1, NBINS
     PHITOP(N) = UFLX(N, JMAX)
-  end do
+  enddo
 
 !Call Glow again at location
   SZAC = SZA
@@ -468,7 +468,7 @@ subroutine GL_getvals(ipin, emisrate, upeflx, downeflx, photoErate, ebins)
           doy = 0
           do imonth = 1, month - 1
             doy = doy + dayofmon(imonth)
-          end do
+          enddo
 
           doy = doy + day
 

--- a/srcGlow/Makefile
+++ b/srcGlow/Makefile
@@ -25,16 +25,21 @@ OBJECTS = \
 	vquart.o\
 	GL_library.o
 
+DEPEND:
+	@perl ${SCRIPTDIR}/depend.pl ./ ${SEARCH} ${LIBDIR} ${OBJECTS} ${MODULES}
+
 EXE = ${BINDIR}/GLOW.exe
-# SEARCH_EXTRA = -I../src 
 
 MYLIB = libGLOW.a
 
-LIB:	libGLOW.a
+LIB:	DEPEND
+	${MAKE} ${MYLIB}
+	@echo
 	@echo ${MYLIB} has been brought up to date.
+	@echo
 
-libGLOW.a: ${MF} ${MODULES} ${OBJECTS}
-	@echo 'Creating GLOW library' ; \
+${MYLIB}: ${MODULES} ${OBJECTS}
+	@echo 'Creating GLOW library'
 	${AR} ${MYLIB} ${MODULES} ${OBJECTS}
 
 MY_LIB=libUPTOGL.a
@@ -45,20 +50,16 @@ LIBADD: DEPEND
 	@echo ${MY_LIB} has been brought up to date.
 	@echo
 
-${MY_LIB}: ${MF} ${MODULES} ${OBJECTS}
-	cp -f ${LIBPREV} ${MY_LIB}
+${MY_LIB}: ${MODULES} ${OBJECTS}
+	${MAKE} ${MYLIB}
+	# cp -f ${LIBPREV} ${MY_LIB}
 	${AR} ${MY_LIB} ${OBJECTS} ${MODULES}
 
-$OBJECTS: $MODULES
 
-
-DEPEND:
-	@perl ${SCRIPTDIR}/depend.pl  ./ ../src/ ../share/Library/src/ ${OBJECTS} ${MODULES}
 
 GLOW: DEPEND
 	 @make ${EXE}
-#
-#
+
 glow: 	${OBJECTS} ${MODULES} 
 	${COMPILE.f77} ${Cflag3} -o ${EXE} main.o ${OBJECTS} ${MODULES}
 

--- a/srcInterface/UA_wrapper.f90
+++ b/srcInterface/UA_wrapper.f90
@@ -97,7 +97,7 @@ contains
         call check_dir("UA/DataIn")
         call check_dir("UA/data")
         call check_dir("UA/restartOUT")
-      end if
+      endif
 
       IsFramework = .true.
 
@@ -198,7 +198,7 @@ contains
         write(*, *) NameSub, " Error in allocating variables"
         write(*, *) " Lat_I, Lon_I, iProc_A, LatPE_I, LonPE_I, iProcPE_A"
         call CON_stop(NameSub//' UA_ERROR')
-      end if
+      endif
 
       LatPE_I = -1.0e32
       LonPE_I = -1.0e32
@@ -215,7 +215,7 @@ contains
         ! write(*,*) 'iProc: ',iProc
         iProcPE_A(iBlock) = iProc
 
-      end do
+      enddo
 
       ! call MPI_allreduce( LatPE_I, CoLat_I, nBlocksLon*nBlocksLat*nLats, &
       !          MPI_REAL, MPI_MAX, iComm, iError)
@@ -231,7 +231,7 @@ contains
     else
       allocate(CoLat_I(1), Lon_I(1), iProc_A(1), Alt_I(1), stat=iError)
       call check_allocate(iError, NameSub)
-    end if
+    endif
 
     if (DoTest) write(*, *) NameSub//': nCell: ', nLats, nLons, nAlts
 
@@ -297,7 +297,7 @@ contains
         write(*, '(a, 7i5)') NameSub//' End time     = ', iTimeDebug
         call time_real_to_int(CurrentTime, iTimeDebug)
         write(*, '(a, 7i5)') NameSub//' Current time = ', iTimeDebug
-      end if
+      endif
 
       call fix_vernal_time
 
@@ -306,7 +306,7 @@ contains
 
       IsFirstTime = .false.
 
-    end if
+    endif
 
   end subroutine UA_init_session
 
@@ -337,7 +337,7 @@ contains
     if (iDebugLevel > 1) then
       call time_real_to_int(CurrentTime, time_array)
       write(*, "(a,i5,5i3,i3)") "> Running UA from time : ", time_array(1:7)
-    end if
+    endif
 
     call calc_pressure
 
@@ -421,7 +421,7 @@ contains
     if (DoTestMe) then
       write(*, *) NameSub//': nVar=', nVar
       if (present(NameVar_V)) write(*, *) NameSub//': NameVar_V=', NameVar_V
-    end if
+    endif
 
   end subroutine UA_get_info_for_ie
 
@@ -476,7 +476,7 @@ contains
       EIEr3_HavePotential = 0.0
       EIEr3_HaveAveE = 0.0
       EIEr3_HaveEFlux = 0.0
-    end if
+    endif
 
     ! Debug: print basic coupling info:
     if (DoTest .and. (iProcGITM == 0)) then
@@ -489,7 +489,7 @@ contains
       write(*, *) 'Shape of Buffer_IIV = ', shape(Buffer_IIV)
       write(*, *) 'ncell_id(IE_) = ', ncell_id(IE_)
       write(*, *) 'iSizeIeHemi, jSizeIeHemi = ', iSizeIeHemi, jSizeIeHemi
-    end if
+    endif
 
     ! Debug statement: print max/mins of transferred variables.
     if (DoTest .and. (iProcGITM == 0)) write(*, *) &
@@ -507,8 +507,8 @@ contains
           if (iBlock == 2) ii = EIEi_HavenLats - i + 1
           do j = 1, EIEi_HavenMlts
             EIEr3_HavePotential(j, i, iBlock) = Buffer_IIV(ii, j, iVar)
-          end do
-        end do
+          enddo
+        enddo
         if (DoTest .and. (iProcGITM == 0)) write(*, '(a, 2(e12.5,1x))') 'UA pot: ', &
           maxval(EIEr3_HavePotential(:, :, iBlock)), &
           minval(EIEr3_HavePotential(:, :, iBlock))
@@ -521,8 +521,8 @@ contains
           if (iBlock == 2) ii = EIEi_HavenLats - i + 1
           do j = 1, EIEi_HavenMlts
             EIEr3_HaveAveE(j, i, iBlock) = Buffer_IIV(ii, j, iVar)
-          end do
-        end do
+          enddo
+        enddo
         if (DoTest .and. (iProcGITM == 0)) write(*, '(a, 2(e12.5,1x))') 'UA ave: ', &
           maxval(EIEr3_HaveAveE(:, :, iBlock)), &
           minval(EIEr3_HaveAveE(:, :, iBlock))
@@ -536,8 +536,8 @@ contains
           do j = 1, EIEi_HavenMlts
             EIEr3_HaveEFlux(j, i, iBlock) = &
               Buffer_IIV(ii, j, iVar)/(1.0e-7*100.0*100.0)
-          end do
-        end do
+          enddo
+        enddo
         if (DoTest .and. (iProcGITM == 0)) write(*, '(a, 2(e12.5,1x))') 'UA tot: ', &
           maxval(EIEr3_HaveEFlux(:, :, iBlock)), &
           minval(EIEr3_HaveEFlux(:, :, iBlock))
@@ -546,7 +546,7 @@ contains
         call CON_stop(NameSub//' invalid NameVarIn='//NameVarIn_V(iVar))
 
       end select
-    end do
+    enddo
 
     ! This bypasses some internal GITM issues.
     UAl_UseGridBasedEIE = .true.
@@ -594,7 +594,7 @@ contains
       write(*, *) NameSub//' UA E&M grid nLon, nLats = ', UAi_nMlts, UAi_nLats
       write(*, *) NameSub//' UA-IE coupling buffer nLon, nLats = ', nMltIn, nLatIn
       call CON_stop(NameSub//' Array size mismatch.')
-    end if
+    endif
 
     ! Collect relevant values using native GITM functions:
     allocate(UAr2_Fac(UAi_nMlts, UAi_nLats), &
@@ -641,7 +641,7 @@ contains
                       NameVarIn_V(iVar))
       end select
 
-    end do
+    enddo
 
     ! Dump contents to file in debug mode:
     if (DoTestMe) then
@@ -654,7 +654,7 @@ contains
       ! Fill output array to match required ordering
       do iVar = 1, nVarIn
         BufferPlot_VII(iVar, :, :) = BufferOut_IIBV(:, :, 1, iVar)
-      end do
+      enddo
 
       ! Create list of var names that includes dimensions:
       NameVarSave_V(1:2) = (/'mlt', 'lat'/)
@@ -671,7 +671,7 @@ contains
                           Coord1In_I=BufferPlot_VII(1, :, 1), &
                           Coord2In_I=BufferPlot_VII(2, 1, :), &
                           VarIn_VII=BufferPlot_VII(3:nVarIn, :, :))
-    end if
+    endif
 
     ! Deallocate intermediate variables:
     deallocate(UAr2_Fac, UAr2_Ped, UAr2_Hal, UAr2_Lats, UAr2_Mlts)

--- a/srcSphereAB/AB_COMM_module.f90
+++ b/srcSphereAB/AB_COMM_module.f90
@@ -85,7 +85,7 @@ contains
       ok = .false.
       call AB_ERROR_set("AB_COMM_XCHNG_create", "allocate error ", ierror)
       return
-    end if
+    endif
 
     ! allocate global receive request array used in transfer procedures
     allocate(xchng%rcv_req(0:max_pn), stat=ierror)
@@ -93,7 +93,7 @@ contains
       ok = .false.
       call AB_ERROR_set("AB_COMM_XCHNG_create", "allocate error ", ierror)
       return
-    end if
+    endif
     xchng%rcv_req = MPI_REQUEST_NULL
 
     ! allocate global send request array used in transfer procedures
@@ -102,7 +102,7 @@ contains
       ok = .false.
       call AB_ERROR_set("AB_COMM_XCHNG_create", "allocate error ", ierror)
       return
-    end if
+    endif
     xchng%snd_req = MPI_REQUEST_NULL
 
   end subroutine AB_COMM_XCHNG_create
@@ -134,7 +134,7 @@ contains
       ok = .false.
       call AB_ERROR_set("AB_COMM_XCHNG_REAL_start", "MPI error ", ierror)
       return
-    end if
+    endif
 
     ! initialize receive requests to null
     xchng%rcv_req = MPI_REQUEST_NULL
@@ -151,10 +151,10 @@ contains
             ok = .false.
             call AB_ERROR_set("AB_COMM_XCHNG_REAL_start", "MPI error ", ierror)
             return
-          end if
-        end if
-      end if
-    end do
+          endif
+        endif
+      endif
+    enddo
 
     ! make sure there are no outstanding send requests
     call MPI_waitall(np, xchng%snd_req, xchng%status, ierror)
@@ -162,7 +162,7 @@ contains
       ok = .false.
       call AB_ERROR_set("AB_COMM_XCHNG_REAL_start", "MPI error ", ierror)
       return
-    end if
+    endif
 
     ! initialize send requests to null
     xchng%snd_req = MPI_REQUEST_NULL
@@ -179,10 +179,10 @@ contains
             ok = .false.
             call AB_ERROR_set("AB_COMM_XCHNG_REAL_start", "MPI error ", ierror)
             return
-          end if
-        end if
-      end if
-    end do
+          endif
+        endif
+      endif
+    enddo
 
   end subroutine AB_COMM_XCHNG_REAL_start
 
@@ -214,7 +214,7 @@ contains
       ok = .false.
       call AB_ERROR_set("AB_COMM_XCHNG_INT_2D_start", "MPI error ", ierror)
       return
-    end if
+    endif
 
     ! initialize receive requests to null
     xchng%rcv_req = MPI_REQUEST_NULL
@@ -231,10 +231,10 @@ contains
             ok = .false.
             call AB_ERROR_set("AB_COMM_XCHNG_INT_2D_start", "MPI error ", ierror)
             return
-          end if
-        end if
-      end if
-    end do
+          endif
+        endif
+      endif
+    enddo
 
     ! make sure there are no outstanding send requests
     call MPI_waitall(np, xchng%snd_req, xchng%status, ierror)
@@ -242,7 +242,7 @@ contains
       ok = .false.
       call AB_ERROR_set("AB_COMM_XCHNG_INT_2D_start", "MPI error ", ierror)
       return
-    end if
+    endif
 
     ! initialize send requests to null
     xchng%snd_req = MPI_REQUEST_NULL
@@ -259,10 +259,10 @@ contains
             ok = .false.
             call AB_ERROR_set("AB_COMM_XCHNG_INT_2D_start", "MPI error ", ierror)
             return
-          end if
-        end if
-      end if
-    end do
+          endif
+        endif
+      endif
+    enddo
 
   end subroutine AB_COMM_XCHNG_INT_2D_start
 
@@ -281,7 +281,7 @@ contains
       ok = .false.
       call AB_ERROR_set("AB_COMM_XCHNG_finish_rcv", "MPI error ", ierror)
       return
-    end if
+    endif
 
   end subroutine AB_COMM_XCHNG_finish_rcv
 
@@ -300,7 +300,7 @@ contains
       ok = .false.
       call AB_ERROR_set("AB_COMM_XCHNG_finish_snd", "MPI error ", ierror)
       return
-    end if
+    endif
 
   end subroutine AB_COMM_XCHNG_finish_snd
 
@@ -322,7 +322,7 @@ contains
       ok = .false.
       call AB_ERROR_set("AB_COMM_XCHNG_destroy", "MPI error ", ierror)
       return
-    end if
+    endif
 
     ! deallocate send request array
     deallocate(xchng%snd_req)
@@ -333,7 +333,7 @@ contains
       ok = .false.
       call AB_ERROR_set("AB_COMM_XCHNG_destroy", "MPI error ", ierror)
       return
-    end if
+    endif
 
     ! deallocate receive request array
     deallocate(xchng%rcv_req)

--- a/srcSphereAB/AB_MSG_module.f90
+++ b/srcSphereAB/AB_MSG_module.f90
@@ -58,7 +58,7 @@ module AB_MSG_module
     if (.not. tmp_ok) then
       ok = .false.
       return
-    end if
+    endif
 
     ! allocate and initialize current message position
     allocate(msg%curr_out(0:max_pn), stat=ierror)
@@ -66,7 +66,7 @@ module AB_MSG_module
       ok = .false.
       call AB_ERROR_set("AB_MSG_create", "allocate error ", ierror)
       return
-    end if
+    endif
     msg%curr_out = 0
 
     ! allocate outgoing message buffers
@@ -75,7 +75,7 @@ module AB_MSG_module
       ok = .false.
       call AB_ERROR_set("AB_MSG_create", "allocate error ", ierror)
       return
-    end if
+    endif
 
     do p = 0, max_pn
       allocate(msg%out(p)%array(max_len(p)), stat=ierror)
@@ -83,8 +83,8 @@ module AB_MSG_module
         ok = .false.
         call AB_ERROR_set("AB_MSG_create", "allocate error ", ierror)
         return
-      end if
-    end do
+      endif
+    enddo
 
   end subroutine AB_MSG_create
 
@@ -122,12 +122,12 @@ module AB_MSG_module
     if (.not. tmp_ok) then
       ok = .false.
       return
-    end if
+    endif
 
     ! deallocate buffers
     do p = 0, msg%max_pn
       deallocate(msg%out(p)%array)
-    end do
+    enddo
 
     ! deallocate other memory
     deallocate(msg%curr_out)

--- a/srcSphereAB/AB_SPH_module.f90
+++ b/srcSphereAB/AB_SPH_module.f90
@@ -117,19 +117,19 @@ contains
       ok = .false.
       call AB_ERROR_set("AB_SPH_create", "not enough blocks")
       return
-    end if
+    endif
 
     if ((num_lat*num_long) < np) then
       ok = .false.
       call AB_ERROR_set("AB_SPH_create", "too many processors")
       return
-    end if
+    endif
 
     if ((num_long .ne. 1) .and. (mod(num_long, 2) .ne. 0)) then
       ok = .false.
       call AB_ERROR_set("AB_SPH_create", "num_long not even")
       return
-    end if
+    endif
 
     ! Initialize sph variables
     sph%cpb_long = cpb_long
@@ -168,7 +168,7 @@ contains
       lat = i/num_long
       long = i - (lat*num_long)
       call AB_create(grp, i - min_blk + 1, long + 1, lat + 1)
-    end do
+    enddo
 
     ! Connect blks into a spherical shell
     do i = min_blk, max_blk
@@ -199,13 +199,13 @@ contains
           else
             nbrs_p(ab_north) = me
             nbrs_b(ab_north) = arr_pos
-          end if
+          endif
         else
           nbrs_p(ab_north) = -1
           nbrs_b(ab_north) = -1
-        end if
+        endif
         next_to_north = .true.
-      end if
+      endif
 
        !! do south neighbor connection
       if (lat > 0) then
@@ -223,13 +223,13 @@ contains
           else
             nbrs_p(ab_south) = me
             nbrs_b(ab_south) = arr_pos
-          end if
+          endif
         else
           nbrs_p(ab_south) = -1
           nbrs_b(ab_south) = -1
-        end if
+        endif
         next_to_south = .true.
-      end if
+      endif
 
        !! do east neighbor connection
       if (long < num_long - 1) then
@@ -240,7 +240,7 @@ contains
         call coord_to_pb(proc, blk, lat, 0, num_long, num_per_proc, max_pn)
         nbrs_p(ab_east) = proc
         nbrs_b(ab_east) = blk + 1
-      end if
+      endif
 
        !! do west neighbor connection
       if (long > 0) then
@@ -251,7 +251,7 @@ contains
         call coord_to_pb(proc, blk, lat, num_long - 1, num_long, num_per_proc, max_pn)
         nbrs_p(ab_west) = proc
         nbrs_b(ab_west) = blk + 1
-      end if
+      endif
 
        !! do northeast corner connection
       if (lat < num_lat - 1) then
@@ -264,7 +264,7 @@ contains
           call coord_to_pb(proc, blk, lat + 1, 0, num_long, num_per_proc, max_pn)
           nbrs_p(ab_northeast) = proc
           nbrs_b(ab_northeast) = blk + 1
-        end if
+        endif
       else
         if (n_pole_conn) then
           if (num_long .ne. 1) then
@@ -276,12 +276,12 @@ contains
           else
             nbrs_p(ab_northeast) = me
             nbrs_b(ab_northeast) = arr_pos
-          end if
+          endif
         else
           nbrs_p(ab_northeast) = -1
           nbrs_b(ab_northeast) = -1
-        end if
-      end if
+        endif
+      endif
 
        !! do northwest corner connection
       if (lat < num_lat - 1) then
@@ -295,7 +295,7 @@ contains
                            num_per_proc, max_pn)
           nbrs_p(ab_northwest) = proc
           nbrs_b(ab_northwest) = blk + 1
-        end if
+        endif
       else
         if (n_pole_conn) then
           if (num_long .ne. 1) then
@@ -308,12 +308,12 @@ contains
           else
             nbrs_p(ab_northwest) = me
             nbrs_b(ab_northwest) = arr_pos
-          end if
+          endif
         else
           nbrs_p(ab_northwest) = -1
           nbrs_b(ab_northwest) = -1
-        end if
-      end if
+        endif
+      endif
 
        !! do southeast corner connection
       if (lat > 0) then
@@ -326,7 +326,7 @@ contains
           call coord_to_pb(proc, blk, lat - 1, 0, num_long, num_per_proc, max_pn)
           nbrs_p(ab_southeast) = proc
           nbrs_b(ab_southeast) = blk + 1
-        end if
+        endif
       else
         if (s_pole_conn) then
           if (num_long .ne. 1) then
@@ -338,12 +338,12 @@ contains
           else
             nbrs_p(ab_southeast) = me
             nbrs_b(ab_southeast) = arr_pos
-          end if
+          endif
         else
           nbrs_p(ab_southeast) = -1
           nbrs_b(ab_southeast) = -1
-        end if
-      end if
+        endif
+      endif
 
        !! do southwest corner connection
       if (lat > 0) then
@@ -357,7 +357,7 @@ contains
                            num_per_proc, max_pn)
           nbrs_p(ab_southwest) = proc
           nbrs_b(ab_southwest) = blk + 1
-        end if
+        endif
       else
         if (s_pole_conn) then
           if (num_long .ne. 1) then
@@ -370,17 +370,17 @@ contains
           else
             nbrs_p(ab_southwest) = me
             nbrs_b(ab_southwest) = arr_pos
-          end if
+          endif
         else
           nbrs_p(ab_southwest) = -1
           nbrs_b(ab_southwest) = -1
-        end if
-      end if
+        endif
+      endif
 
       ! set the current block to use these neighbor connections
       call AB_set_all_nbrs(grp, arr_pos, nbrs_p, nbrs_b, &
                            next_to_north, next_to_south)
-    end do
+    enddo
 
   contains
     ! Note: this function assumes ranges start at 0
@@ -398,7 +398,7 @@ contains
       else
         min_blk = num_per_proc*me
         max_blk = (num_per_proc*(me + 1)) - 1
-      end if
+      endif
 
     end subroutine calc_block_range
 
@@ -418,7 +418,7 @@ contains
       proc = blk_pos/num_per_proc
       if (proc > max_pn) then
         proc = max_pn
-      end if
+      endif
       blk = blk_pos - (proc*num_per_proc)
     end subroutine coord_to_pb
 
@@ -488,11 +488,11 @@ contains
           z(j, i, a) = alt*sin(th) + cz
 
           ph = ph + phi_cell_width
-        end do
+        enddo
         lgp = lgp + lat_cell_width
-      end do
+      enddo
       alt = alt + alt_cell_width
-    end do
+    enddo
 
   end subroutine AB_SPH_get_xyztp
 

--- a/srcSphereAB/AB_XFER_1blk_util.f90
+++ b/srcSphereAB/AB_XFER_1blk_util.f90
@@ -52,19 +52,19 @@ contains
               shifted_j = mod(j - 1 + half_long, long) + 1
               out_array(p) = v_in(shifted_j, i, a)
               p = p + 1
-            end do
-          end do
-        end do
+            enddo
+          enddo
+        enddo
       else
         do a = 1, alt
           do i = lat - gcn + 1, lat
             do j = 1, long
               out_array(p) = v_in(j, i, a)
               p = p + 1
-            end do
-          end do
-        end do
-      end if
+            enddo
+          enddo
+        enddo
+      endif
 
     case (ab_south)
       if (pole) then
@@ -74,19 +74,19 @@ contains
               shifted_j = mod(j - 1 + half_long, long) + 1
               out_array(p) = v_in(shifted_j, i, a)
               p = p + 1
-            end do
-          end do
-        end do
+            enddo
+          enddo
+        enddo
       else
         do a = 1, alt
           do i = 1, gcn
             do j = 1, long
               out_array(p) = v_in(j, i, a)
               p = p + 1
-            end do
-          end do
-        end do
-      end if
+            enddo
+          enddo
+        enddo
+      endif
 
     case (ab_east)
       do a = 1, alt
@@ -94,9 +94,9 @@ contains
           do j = long - gcn + 1, long
             out_array(p) = v_in(j, i, a)
             p = p + 1
-          end do
-        end do
-      end do
+          enddo
+        enddo
+      enddo
 
     case (ab_west)
       do a = 1, alt
@@ -104,9 +104,9 @@ contains
           do j = 1, gcn
             out_array(p) = v_in(j, i, a)
             p = p + 1
-          end do
-        end do
-      end do
+          enddo
+        enddo
+      enddo
 
     case (ab_northeast)
       if (pole) then
@@ -116,19 +116,19 @@ contains
               shifted_j = mod(j - 1 + half_long, long) + 1
               out_array(p) = v_in(shifted_j, i, a)
               p = p + 1
-            end do
-          end do
-        end do
+            enddo
+          enddo
+        enddo
       else
         do a = 1, alt
           do i = lat - gcn + 1, lat
             do j = long - gcn + 1, long
               out_array(p) = v_in(j, i, a)
               p = p + 1
-            end do
-          end do
-        end do
-      end if
+            enddo
+          enddo
+        enddo
+      endif
 
     case (ab_northwest)
       if (pole) then
@@ -138,19 +138,19 @@ contains
               shifted_j = mod(j - 1 + half_long, long) + 1
               out_array(p) = v_in(shifted_j, i, a)
               p = p + 1
-            end do
-          end do
-        end do
+            enddo
+          enddo
+        enddo
       else
         do a = 1, alt
           do i = lat - gcn + 1, lat
             do j = 1, gcn
               out_array(p) = v_in(j, i, a)
               p = p + 1
-            end do
-          end do
-        end do
-      end if
+            enddo
+          enddo
+        enddo
+      endif
 
     case (ab_southeast)
       if (pole) then
@@ -160,19 +160,19 @@ contains
               shifted_j = mod(j - 1 + half_long, long) + 1
               out_array(p) = v_in(shifted_j, i, a)
               p = p + 1
-            end do
-          end do
-        end do
+            enddo
+          enddo
+        enddo
       else
         do a = 1, alt
           do i = 1, gcn
             do j = long - gcn + 1, long
               out_array(p) = v_in(j, i, a)
               p = p + 1
-            end do
-          end do
-        end do
-      end if
+            enddo
+          enddo
+        enddo
+      endif
 
     case (ab_southwest)
       if (pole) then
@@ -182,19 +182,19 @@ contains
               shifted_j = mod(j - 1 + half_long, long) + 1
               out_array(p) = v_in(shifted_j, i, a)
               p = p + 1
-            end do
-          end do
-        end do
+            enddo
+          enddo
+        enddo
       else
         do a = 1, alt
           do i = 1, gcn
             do j = 1, gcn
               out_array(p) = v_in(j, i, a)
               p = p + 1
-            end do
-          end do
-        end do
-      end if
+            enddo
+          enddo
+        enddo
+      endif
 
     end select
   end subroutine AB_1blk3_gc_pack
@@ -216,9 +216,9 @@ contains
           do j = 1, long
             v_out(j, i, a) = in_array(p)
             p = p + 1
-          end do
-        end do
-      end do
+          enddo
+        enddo
+      enddo
 
     case (ab_south)
       do a = 1, alt
@@ -226,9 +226,9 @@ contains
           do j = 1, long
             v_out(j, i, a) = in_array(p)
             p = p + 1
-          end do
-        end do
-      end do
+          enddo
+        enddo
+      enddo
 
     case (ab_east)
       do a = 1, alt
@@ -236,9 +236,9 @@ contains
           do j = long + 1, long + gcn
             v_out(j, i, a) = in_array(p)
             p = p + 1
-          end do
-        end do
-      end do
+          enddo
+        enddo
+      enddo
 
     case (ab_west)
       do a = 1, alt
@@ -246,9 +246,9 @@ contains
           do j = 1 - gcn, 0
             v_out(j, i, a) = in_array(p)
             p = p + 1
-          end do
-        end do
-      end do
+          enddo
+        enddo
+      enddo
 
     case (ab_northeast)
       do a = 1, alt
@@ -256,9 +256,9 @@ contains
           do j = long + 1, long + gcn
             v_out(j, i, a) = in_array(p)
             p = p + 1
-          end do
-        end do
-      end do
+          enddo
+        enddo
+      enddo
 
     case (ab_northwest)
       do a = 1, alt
@@ -266,9 +266,9 @@ contains
           do j = 1 - gcn, 0
             v_out(j, i, a) = in_array(p)
             p = p + 1
-          end do
-        end do
-      end do
+          enddo
+        enddo
+      enddo
 
     case (ab_southeast)
       do a = 1, alt
@@ -276,9 +276,9 @@ contains
           do j = long + 1, long + gcn
             v_out(j, i, a) = in_array(p)
             p = p + 1
-          end do
-        end do
-      end do
+          enddo
+        enddo
+      enddo
 
     case (ab_southwest)
       do a = 1, alt
@@ -286,9 +286,9 @@ contains
           do j = 1 - gcn, 0
             v_out(j, i, a) = in_array(p)
             p = p + 1
-          end do
-        end do
-      end do
+          enddo
+        enddo
+      enddo
 
     end select
 
@@ -332,10 +332,10 @@ contains
               shifted_j = mod(j - 1 + half_long, long) + 1
               out_array(p) = v_in(shifted_j, i, a, e)
               p = p + 1
-            end do
-          end do
-        end do
-        end do
+            enddo
+          enddo
+        enddo
+        enddo
       else
         do e = 1, eta
         do a = 1, alt
@@ -343,11 +343,11 @@ contains
             do j = 1, long
               out_array(p) = v_in(j, i, a, e)
               p = p + 1
-            end do
-          end do
-        end do
-        end do
-      end if
+            enddo
+          enddo
+        enddo
+        enddo
+      endif
 
     case (ab_south)
       if (pole) then
@@ -358,10 +358,10 @@ contains
               shifted_j = mod(j - 1 + half_long, long) + 1
               out_array(p) = v_in(shifted_j, i, a, e)
               p = p + 1
-            end do
-          end do
-        end do
-        end do
+            enddo
+          enddo
+        enddo
+        enddo
       else
         do e = 1, eta
         do a = 1, alt
@@ -369,11 +369,11 @@ contains
             do j = 1, long
               out_array(p) = v_in(j, i, a, e)
               p = p + 1
-            end do
-          end do
-        end do
-        end do
-      end if
+            enddo
+          enddo
+        enddo
+        enddo
+      endif
 
     case (ab_east)
       do e = 1, eta
@@ -382,10 +382,10 @@ contains
           do j = long - gcn + 1, long
             out_array(p) = v_in(j, i, a, e)
             p = p + 1
-          end do
-        end do
-      end do
-      end do
+          enddo
+        enddo
+      enddo
+      enddo
 
     case (ab_west)
       do e = 1, eta
@@ -394,10 +394,10 @@ contains
           do j = 1, gcn
             out_array(p) = v_in(j, i, a, e)
             p = p + 1
-          end do
-        end do
-      end do
-      end do
+          enddo
+        enddo
+      enddo
+      enddo
 
     case (ab_northeast)
       if (pole) then
@@ -408,10 +408,10 @@ contains
               shifted_j = mod(j - 1 + half_long, long) + 1
               out_array(p) = v_in(shifted_j, i, a, e)
               p = p + 1
-            end do
-          end do
-        end do
-        end do
+            enddo
+          enddo
+        enddo
+        enddo
       else
         do e = 1, eta
         do a = 1, alt
@@ -419,11 +419,11 @@ contains
             do j = long - gcn + 1, long
               out_array(p) = v_in(j, i, a, e)
               p = p + 1
-            end do
-          end do
-        end do
-        end do
-      end if
+            enddo
+          enddo
+        enddo
+        enddo
+      endif
 
     case (ab_northwest)
       if (pole) then
@@ -434,10 +434,10 @@ contains
               shifted_j = mod(j - 1 + half_long, long) + 1
               out_array(p) = v_in(shifted_j, i, a, e)
               p = p + 1
-            end do
-          end do
-        end do
-        end do
+            enddo
+          enddo
+        enddo
+        enddo
       else
         do e = 1, eta
         do a = 1, alt
@@ -445,11 +445,11 @@ contains
             do j = 1, gcn
               out_array(p) = v_in(j, i, a, e)
               p = p + 1
-            end do
-          end do
-        end do
-        end do
-      end if
+            enddo
+          enddo
+        enddo
+        enddo
+      endif
 
     case (ab_southeast)
       if (pole) then
@@ -460,10 +460,10 @@ contains
               shifted_j = mod(j - 1 + half_long, long) + 1
               out_array(p) = v_in(shifted_j, i, a, e)
               p = p + 1
-            end do
-          end do
-        end do
-        end do
+            enddo
+          enddo
+        enddo
+        enddo
       else
         do e = 1, eta
         do a = 1, alt
@@ -471,11 +471,11 @@ contains
             do j = long - gcn + 1, long
               out_array(p) = v_in(j, i, a, e)
               p = p + 1
-            end do
-          end do
-        end do
-        end do
-      end if
+            enddo
+          enddo
+        enddo
+        enddo
+      endif
 
     case (ab_southwest)
       if (pole) then
@@ -486,10 +486,10 @@ contains
               shifted_j = mod(j - 1 + half_long, long) + 1
               out_array(p) = v_in(shifted_j, i, a, e)
               p = p + 1
-            end do
-          end do
-        end do
-        end do
+            enddo
+          enddo
+        enddo
+        enddo
       else
         do e = 1, eta
         do a = 1, alt
@@ -497,11 +497,11 @@ contains
             do j = 1, gcn
               out_array(p) = v_in(j, i, a, e)
               p = p + 1
-            end do
-          end do
-        end do
-        end do
-      end if
+            enddo
+          enddo
+        enddo
+        enddo
+      endif
 
     end select
 
@@ -524,10 +524,10 @@ contains
           do j = 1, long
             v_out(j, i, a, e) = in_array(p)
             p = p + 1
-          end do
-        end do
-      end do
-      end do
+          enddo
+        enddo
+      enddo
+      enddo
 
     case (ab_south)
       do e = 1, eta
@@ -536,10 +536,10 @@ contains
           do j = 1, long
             v_out(j, i, a, e) = in_array(p)
             p = p + 1
-          end do
-        end do
-      end do
-      end do
+          enddo
+        enddo
+      enddo
+      enddo
 
     case (ab_east)
       do e = 1, eta
@@ -548,10 +548,10 @@ contains
           do j = long + 1, long + gcn
             v_out(j, i, a, e) = in_array(p)
             p = p + 1
-          end do
-        end do
-      end do
-      end do
+          enddo
+        enddo
+      enddo
+      enddo
 
     case (ab_west)
       do e = 1, eta
@@ -560,10 +560,10 @@ contains
           do j = 1 - gcn, 0
             v_out(j, i, a, e) = in_array(p)
             p = p + 1
-          end do
-        end do
-      end do
-      end do
+          enddo
+        enddo
+      enddo
+      enddo
 
     case (ab_northeast)
       do e = 1, eta
@@ -572,10 +572,10 @@ contains
           do j = long + 1, long + gcn
             v_out(j, i, a, e) = in_array(p)
             p = p + 1
-          end do
-        end do
-      end do
-      end do
+          enddo
+        enddo
+      enddo
+      enddo
 
     case (ab_northwest)
       do e = 1, eta
@@ -584,10 +584,10 @@ contains
           do j = 1 - gcn, 0
             v_out(j, i, a, e) = in_array(p)
             p = p + 1
-          end do
-        end do
-      end do
-      end do
+          enddo
+        enddo
+      enddo
+      enddo
 
     case (ab_southeast)
       do e = 1, eta
@@ -596,10 +596,10 @@ contains
           do j = long + 1, long + gcn
             v_out(j, i, a, e) = in_array(p)
             p = p + 1
-          end do
-        end do
-      end do
-      end do
+          enddo
+        enddo
+      enddo
+      enddo
 
     case (ab_southwest)
       do e = 1, eta
@@ -608,10 +608,10 @@ contains
           do j = 1 - gcn, 0
             v_out(j, i, a, e) = in_array(p)
             p = p + 1
-          end do
-        end do
-      end do
-      end do
+          enddo
+        enddo
+      enddo
+      enddo
 
     end select
 

--- a/srcSphereAB/AB_XFER_array_util.f90
+++ b/srcSphereAB/AB_XFER_array_util.f90
@@ -50,19 +50,19 @@ contains
             do j = 1, long
               out_array(p) = v_in(j, i, a)
               p = p + 1
-            end do
-          end do
-        end do
+            enddo
+          enddo
+        enddo
       else
         do a = 1, alt
           do i = lat - gcn + 1, lat
             do j = 1, long
               out_array(p) = v_in(j, i, a)
               p = p + 1
-            end do
-          end do
-        end do
-      end if
+            enddo
+          enddo
+        enddo
+      endif
 
     case (ab_south)
       if (pole) then
@@ -71,19 +71,19 @@ contains
             do j = 1, long
               out_array(p) = v_in(j, i, a)
               p = p + 1
-            end do
-          end do
-        end do
+            enddo
+          enddo
+        enddo
       else
         do a = 1, alt
           do i = 1, gcn
             do j = 1, long
               out_array(p) = v_in(j, i, a)
               p = p + 1
-            end do
-          end do
-        end do
-      end if
+            enddo
+          enddo
+        enddo
+      endif
 
     case (ab_east)
       do a = 1, alt
@@ -91,9 +91,9 @@ contains
           do j = long - gcn + 1, long
             out_array(p) = v_in(j, i, a)
             p = p + 1
-          end do
-        end do
-      end do
+          enddo
+        enddo
+      enddo
 
     case (ab_west)
       do a = 1, alt
@@ -101,9 +101,9 @@ contains
           do j = 1, gcn
             out_array(p) = v_in(j, i, a)
             p = p + 1
-          end do
-        end do
-      end do
+          enddo
+        enddo
+      enddo
 
     case (ab_northeast)
       if (pole) then
@@ -112,19 +112,19 @@ contains
             do j = long - gcn + 1, long
               out_array(p) = v_in(j, i, a)
               p = p + 1
-            end do
-          end do
-        end do
+            enddo
+          enddo
+        enddo
       else
         do a = 1, alt
           do i = lat - gcn + 1, lat
             do j = long - gcn + 1, long
               out_array(p) = v_in(j, i, a)
               p = p + 1
-            end do
-          end do
-        end do
-      end if
+            enddo
+          enddo
+        enddo
+      endif
 
     case (ab_northwest)
       if (pole) then
@@ -133,19 +133,19 @@ contains
             do j = 1, gcn
               out_array(p) = v_in(j, i, a)
               p = p + 1
-            end do
-          end do
-        end do
+            enddo
+          enddo
+        enddo
       else
         do a = 1, alt
           do i = lat - gcn + 1, lat
             do j = 1, gcn
               out_array(p) = v_in(j, i, a)
               p = p + 1
-            end do
-          end do
-        end do
-      end if
+            enddo
+          enddo
+        enddo
+      endif
 
     case (ab_southeast)
       if (pole) then
@@ -154,19 +154,19 @@ contains
             do j = long - gcn + 1, long
               out_array(p) = v_in(j, i, a)
               p = p + 1
-            end do
-          end do
-        end do
+            enddo
+          enddo
+        enddo
       else
         do a = 1, alt
           do i = 1, gcn
             do j = long - gcn + 1, long
               out_array(p) = v_in(j, i, a)
               p = p + 1
-            end do
-          end do
-        end do
-      end if
+            enddo
+          enddo
+        enddo
+      endif
 
     case (ab_southwest)
       if (pole) then
@@ -175,19 +175,19 @@ contains
             do j = 1, gcn
               out_array(p) = v_in(j, i, a)
               p = p + 1
-            end do
-          end do
-        end do
+            enddo
+          enddo
+        enddo
       else
         do a = 1, alt
           do i = 1, gcn
             do j = 1, gcn
               out_array(p) = v_in(j, i, a)
               p = p + 1
-            end do
-          end do
-        end do
-      end if
+            enddo
+          enddo
+        enddo
+      endif
 
     end select
 
@@ -210,9 +210,9 @@ contains
           do j = 1, long
             v_out(j, i, a) = in_array(p)
             p = p + 1
-          end do
-        end do
-      end do
+          enddo
+        enddo
+      enddo
 
     case (ab_south)
       do a = 1, alt
@@ -220,9 +220,9 @@ contains
           do j = 1, long
             v_out(j, i, a) = in_array(p)
             p = p + 1
-          end do
-        end do
-      end do
+          enddo
+        enddo
+      enddo
 
     case (ab_east)
       do a = 1, alt
@@ -230,9 +230,9 @@ contains
           do j = long + 1, long + gcn
             v_out(j, i, a) = in_array(p)
             p = p + 1
-          end do
-        end do
-      end do
+          enddo
+        enddo
+      enddo
 
     case (ab_west)
       do a = 1, alt
@@ -240,9 +240,9 @@ contains
           do j = 1 - gcn, 0
             v_out(j, i, a) = in_array(p)
             p = p + 1
-          end do
-        end do
-      end do
+          enddo
+        enddo
+      enddo
 
     case (ab_northeast)
       do a = 1, alt
@@ -250,9 +250,9 @@ contains
           do j = long + 1, long + gcn
             v_out(j, i, a) = in_array(p)
             p = p + 1
-          end do
-        end do
-      end do
+          enddo
+        enddo
+      enddo
 
     case (ab_northwest)
       do a = 1, alt
@@ -260,9 +260,9 @@ contains
           do j = 1 - gcn, 0
             v_out(j, i, a) = in_array(p)
             p = p + 1
-          end do
-        end do
-      end do
+          enddo
+        enddo
+      enddo
 
     case (ab_southeast)
       do a = 1, alt
@@ -270,9 +270,9 @@ contains
           do j = long + 1, long + gcn
             v_out(j, i, a) = in_array(p)
             p = p + 1
-          end do
-        end do
-      end do
+          enddo
+        enddo
+      enddo
 
     case (ab_southwest)
       do a = 1, alt
@@ -280,9 +280,9 @@ contains
           do j = 1 - gcn, 0
             v_out(j, i, a) = in_array(p)
             p = p + 1
-          end do
-        end do
-      end do
+          enddo
+        enddo
+      enddo
 
     end select
 
@@ -322,10 +322,10 @@ contains
               do j = 1, long
                 out_array(p) = v_in(j, i, a, e)
                 p = p + 1
-              end do
-            end do
-          end do
-        end do
+              enddo
+            enddo
+          enddo
+        enddo
       else
         do e = 1, eta
           do a = 1, alt
@@ -333,11 +333,11 @@ contains
               do j = 1, long
                 out_array(p) = v_in(j, i, a, e)
                 p = p + 1
-              end do
-            end do
-          end do
-        end do
-      end if
+              enddo
+            enddo
+          enddo
+        enddo
+      endif
 
     case (ab_south)
       if (pole) then
@@ -347,10 +347,10 @@ contains
             do j = 1, long
               out_array(p) = v_in(j, i, a, e)
               p = p + 1
-            end do
-          end do
-        end do
-        end do
+            enddo
+          enddo
+        enddo
+        enddo
       else
         do e = 1, eta
         do a = 1, alt
@@ -358,11 +358,11 @@ contains
             do j = 1, long
               out_array(p) = v_in(j, i, a, e)
               p = p + 1
-            end do
-          end do
-        end do
-        end do
-      end if
+            enddo
+          enddo
+        enddo
+        enddo
+      endif
 
     case (ab_east)
       do e = 1, eta
@@ -371,10 +371,10 @@ contains
           do j = long - gcn + 1, long
             out_array(p) = v_in(j, i, a, e)
             p = p + 1
-          end do
-        end do
-      end do
-      end do
+          enddo
+        enddo
+      enddo
+      enddo
 
     case (ab_west)
       do e = 1, eta
@@ -383,10 +383,10 @@ contains
           do j = 1, gcn
             out_array(p) = v_in(j, i, a, e)
             p = p + 1
-          end do
-        end do
-      end do
-      end do
+          enddo
+        enddo
+      enddo
+      enddo
 
     case (ab_northeast)
       if (pole) then
@@ -396,10 +396,10 @@ contains
             do j = long - gcn + 1, long
               out_array(p) = v_in(j, i, a, e)
               p = p + 1
-            end do
-          end do
-        end do
-        end do
+            enddo
+          enddo
+        enddo
+        enddo
       else
         do e = 1, eta
         do a = 1, alt
@@ -407,11 +407,11 @@ contains
             do j = long - gcn + 1, long
               out_array(p) = v_in(j, i, a, e)
               p = p + 1
-            end do
-          end do
-        end do
-        end do
-      end if
+            enddo
+          enddo
+        enddo
+        enddo
+      endif
 
     case (ab_northwest)
       if (pole) then
@@ -421,10 +421,10 @@ contains
             do j = 1, gcn
               out_array(p) = v_in(j, i, a, e)
               p = p + 1
-            end do
-          end do
-        end do
-        end do
+            enddo
+          enddo
+        enddo
+        enddo
       else
         do e = 1, eta
         do a = 1, alt
@@ -432,11 +432,11 @@ contains
             do j = 1, gcn
               out_array(p) = v_in(j, i, a, e)
               p = p + 1
-            end do
-          end do
-        end do
-        end do
-      end if
+            enddo
+          enddo
+        enddo
+        enddo
+      endif
 
     case (ab_southeast)
       if (pole) then
@@ -446,10 +446,10 @@ contains
             do j = long - gcn + 1, long
               out_array(p) = v_in(j, i, a, e)
               p = p + 1
-            end do
-          end do
-        end do
-        end do
+            enddo
+          enddo
+        enddo
+        enddo
       else
         do e = 1, eta
         do a = 1, alt
@@ -457,11 +457,11 @@ contains
             do j = long - gcn + 1, long
               out_array(p) = v_in(j, i, a, e)
               p = p + 1
-            end do
-          end do
-        end do
-        end do
-      end if
+            enddo
+          enddo
+        enddo
+        enddo
+      endif
 
     case (ab_southwest)
       if (pole) then
@@ -471,10 +471,10 @@ contains
             do j = 1, gcn
               out_array(p) = v_in(j, i, a, e)
               p = p + 1
-            end do
-          end do
-        end do
-        end do
+            enddo
+          enddo
+        enddo
+        enddo
       else
         do e = 1, eta
         do a = 1, alt
@@ -482,11 +482,11 @@ contains
             do j = 1, gcn
               out_array(p) = v_in(j, i, a, e)
               p = p + 1
-            end do
-          end do
-        end do
-        end do
-      end if
+            enddo
+          enddo
+        enddo
+        enddo
+      endif
 
     end select
 
@@ -510,10 +510,10 @@ contains
           do j = 1, long
             v_out(j, i, a, e) = in_array(p)
             p = p + 1
-          end do
-        end do
-      end do
-      end do
+          enddo
+        enddo
+      enddo
+      enddo
 
     case (ab_south)
       do e = 1, eta
@@ -522,10 +522,10 @@ contains
           do j = 1, long
             v_out(j, i, a, e) = in_array(p)
             p = p + 1
-          end do
-        end do
-      end do
-      end do
+          enddo
+        enddo
+      enddo
+      enddo
 
     case (ab_east)
       do e = 1, eta
@@ -534,10 +534,10 @@ contains
           do j = long + 1, long + gcn
             v_out(j, i, a, e) = in_array(p)
             p = p + 1
-          end do
-        end do
-      end do
-      end do
+          enddo
+        enddo
+      enddo
+      enddo
 
     case (ab_west)
       do e = 1, eta
@@ -546,10 +546,10 @@ contains
           do j = 1 - gcn, 0
             v_out(j, i, a, e) = in_array(p)
             p = p + 1
-          end do
-        end do
-      end do
-      end do
+          enddo
+        enddo
+      enddo
+      enddo
 
     case (ab_northeast)
       do e = 1, eta
@@ -558,10 +558,10 @@ contains
           do j = long + 1, long + gcn
             v_out(j, i, a, e) = in_array(p)
             p = p + 1
-          end do
-        end do
-      end do
-      end do
+          enddo
+        enddo
+      enddo
+      enddo
 
     case (ab_northwest)
       do e = 1, eta
@@ -570,10 +570,10 @@ contains
           do j = 1 - gcn, 0
             v_out(j, i, a, e) = in_array(p)
             p = p + 1
-          end do
-        end do
-      end do
-      end do
+          enddo
+        enddo
+      enddo
+      enddo
 
     case (ab_southeast)
       do e = 1, eta
@@ -582,10 +582,10 @@ contains
           do j = long + 1, long + gcn
             v_out(j, i, a, e) = in_array(p)
             p = p + 1
-          end do
-        end do
-      end do
-      end do
+          enddo
+        enddo
+      enddo
+      enddo
 
     case (ab_southwest)
       do e = 1, eta
@@ -594,10 +594,10 @@ contains
           do j = 1 - gcn, 0
             v_out(j, i, a, e) = in_array(p)
             p = p + 1
-          end do
-        end do
-      end do
-      end do
+          enddo
+        enddo
+      enddo
+      enddo
 
     end select
 

--- a/srcSphereAB/AB_XFER_module.f90
+++ b/srcSphereAB/AB_XFER_module.f90
@@ -67,7 +67,7 @@ contains
       ok = .false.
       call AB_ERROR_set("setup_for_xfers", "allocate error ", ierror)
       return
-    end if
+    endif
 
     ! Calculate the number of neighbors belonging to each processor
     xfer%num_nbrs = 0
@@ -75,10 +75,10 @@ contains
     do while (.not. done)
       if (nbr_p .ne. -1) then
         xfer%num_nbrs(nbr_p) = xfer%num_nbrs(nbr_p) + 1
-      end if
+      endif
 
       call AB_NBR_ITER_next(iter, ind, dir, nbr_p, nbr_i, done)
-    end do
+    enddo
 
     ! Allocate space for nbr order info
     allocate(xfer%nbr_order(0:xfer%max_pn), stat=ierror)
@@ -86,7 +86,7 @@ contains
       ok = .false.
       call AB_ERROR_set("setup_for_xfers", "allocate error ", ierror)
       return
-    end if
+    endif
 
     ! Allocate space for nbr order snd buffers
     allocate(snd_bufs(0:xfer%max_pn), stat=ierror)
@@ -94,7 +94,7 @@ contains
       ok = .false.
       call AB_ERROR_set("setup_for_xfers", "allocate error ", ierror)
       return
-    end if
+    endif
 
     ! allocate order info space and snd buffers
     do i = 0, xfer%max_pn
@@ -104,7 +104,7 @@ contains
         ok = .false.
         call AB_ERROR_set("setup_for_xfers", "allocate error ", ierror)
         return
-      end if
+      endif
 
       allocate(snd_bufs(i)%array(3, xfer%num_nbrs(i)), &
                stat=ierror)
@@ -112,8 +112,8 @@ contains
         ok = .false.
         call AB_ERROR_set("setup_for_xfers", "allocate error ", ierror)
         return
-      end if
-    end do
+      endif
+    enddo
 
     ! fill snd bufs with order info
     xfer%pos = 1 ! intialize all entries in xfer%pos to 1
@@ -126,10 +126,10 @@ contains
         snd_bufs(nbr_p)%array(3, pos) = dir
         pos = pos + 1
         xfer%pos(nbr_p) = pos
-      end if
+      endif
 
       call AB_NBR_ITER_next(iter, ind, dir, nbr_p, nbr_i, pole, nbr_dir, done)
-    end do
+    enddo
 
     ! start exchange of data
     call AB_COMM_XCHNG_INT_2D_start(xfer%xchng, xfer%num_nbrs, 3, snd_bufs, &
@@ -138,24 +138,24 @@ contains
     if (.not. tmp_ok) then
       ok = .false.
       return
-    end if
+    endif
 
     ! copy same proc info
     if (xfer%num_nbrs(xfer%me) .ne. 0) then
       xfer%nbr_order(xfer%me)%array = snd_bufs(xfer%me)%array
-    end if
+    endif
 
     ! wait until we've sent everything before deallocating the send bufs
     call AB_COMM_XCHNG_finish_snd(xfer%xchng, tmp_ok)
     if (.not. tmp_ok) then
       ok = .false.
       return
-    end if
+    endif
 
     ! Deallocate send buffers
     do i = 0, xfer%max_pn
       deallocate(snd_bufs(i)%array)
-    end do
+    enddo
     deallocate(snd_bufs)
 
     ! wait until we've received everything before exiting
@@ -163,7 +163,7 @@ contains
     if (.not. tmp_ok) then
       ok = .false.
       return
-    end if
+    endif
 
   end subroutine setup_for_xfers
 
@@ -231,7 +231,7 @@ contains
     if (.not. tmp_ok) then
       ok = .false.
       return
-    end if
+    endif
 
     ! allocate pos array used in transfer procedures
     allocate(xfer%pos(0:xfer%max_pn), stat=ierror)
@@ -239,14 +239,14 @@ contains
       ok = .false.
       call AB_ERROR_set("AB_XFER_create", "allocate error ", ierror)
       return
-    end if
+    endif
 
     ! Setup for transfers
     call setup_for_xfers(xfer, tmp_ok)
     if (.not. tmp_ok) then
       ok = .false.
       return
-    end if
+    endif
 
     ! setup snd buffers
     !! allocate snd buffer storage
@@ -255,7 +255,7 @@ contains
       ok = .false.
       call AB_ERROR_set("AB_XFER_create", "allocate error ", ierror)
       return
-    end if
+    endif
 
     !! allocate array to hold size of snd buffers
     allocate(xfer%snd_buf_size(0:xfer%max_pn), stat=ierror)
@@ -263,7 +263,7 @@ contains
       ok = .false.
       call AB_ERROR_set("AB_XFER_create", "allocate error ", ierror)
       return
-    end if
+    endif
 
     !! calculate size of snd buffers
     xfer%snd_buf_size = 0
@@ -271,10 +271,10 @@ contains
     do while (.not. done)
       if (nbr_p .ne. -1) then
         xfer%snd_buf_size(nbr_p) = xfer%snd_buf_size(nbr_p) + xfer%size(dir)
-      end if
+      endif
 
       call AB_NBR_ITER_next(iter, ind, dir, nbr_p, nbr_i, done)
-    end do
+    enddo
 
     !! allocate snd buffers
     do p = 0, xfer%max_pn
@@ -288,11 +288,11 @@ contains
           ok = .false.
           call AB_ERROR_set("AB_XFER_create", "allocate error ", ierror)
           return
-        end if
+        endif
       else
         nullify (xfer%snd_buf(p)%array)
-      end if
-    end do
+      endif
+    enddo
 
     ! setup rcv buffers
     !! allocate rcv buffer storage
@@ -301,7 +301,7 @@ contains
       ok = .false.
       call AB_ERROR_set("AB_XFER_create", "allocate error ", ierror)
       return
-    end if
+    endif
 
     !! allocate array to hold size of buffers
     allocate(xfer%rcv_buf_size(0:xfer%max_pn), stat=ierror)
@@ -309,7 +309,7 @@ contains
       ok = .false.
       call AB_ERROR_set("AB_XFER_create", "allocate error ", ierror)
       return
-    end if
+    endif
 
     !! loop through blocks totalling the size coming into each proc
     xfer%rcv_buf_size = 0
@@ -319,9 +319,9 @@ contains
       rcv_buf_size = 0
       do i = 1, num_rcv
         rcv_buf_size = rcv_buf_size + xfer%size(rcv_order(3, i))
-      end do
+      enddo
       xfer%rcv_buf_size(p) = rcv_buf_size
-    end do
+    enddo
 
     !! allocate buffers
     do p = 0, xfer%max_pn
@@ -335,11 +335,11 @@ contains
           ok = .false.
           call AB_ERROR_set("AB_XFER_create", "allocate error ", ierror)
           return
-        end if
+        endif
       else
         nullify (xfer%rcv_buf(p)%array)
-      end if
-    end do
+      endif
+    enddo
 
   end subroutine AB_XFER_create
 
@@ -406,10 +406,10 @@ contains
         max_buf = min_buf + xfer%size(dir) - 1
         call get(ind, dir, pole, xfer%snd_buf(nbr_p)%array(min_buf:max_buf))
         xfer%pos(nbr_p) = max_buf + 1
-      end if
+      endif
 
       call AB_NBR_ITER_next(iter, ind, dir, nbr_p, nbr_i, pole, nbr_dir, done)
-    end do
+    enddo
 
     ! start the exchange of data
     call AB_COMM_XCHNG_REAL_start(xfer%xchng, &
@@ -419,7 +419,7 @@ contains
     if (.not. tmp_ok) then
       ok = .false.
       return
-    end if
+    endif
 
   end subroutine AB_XFER_start
 
@@ -477,14 +477,14 @@ contains
     ! copy this processors data from snd to rcv buffer
     if (xfer%snd_buf_size(xfer%me) .ne. 0) then
       xfer%rcv_buf(xfer%me)%array = xfer%snd_buf(xfer%me)%array
-    end if
+    endif
 
     ! wait for all our data to arrive
     call AB_COMM_XCHNG_finish_rcv(xfer%xchng, tmp_ok)
     if (.not. tmp_ok) then
       ok = .false.
       return
-    end if
+    endif
 
     ! give received data back to user
     do p = 0, xfer%max_pn
@@ -497,8 +497,8 @@ contains
         call put(rcv_order(1, i), rcv_order(2, i), &
                  xfer%rcv_buf(p)%array(min_buf:max_buf))
         pos = max_buf + 1
-      end do
-    end do
+      enddo
+    enddo
   end subroutine AB_XFER_finish
 
  !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
@@ -536,18 +536,18 @@ contains
     if (.not. tmp_ok) then
       ok = .false.
       return
-    end if
+    endif
 
     ! deallocate buffers
     do p = 0, xfer%max_pn
       if (xfer%snd_buf_size(p) .ne. 0) then
         deallocate(xfer%snd_buf(p)%array)
-      end if
+      endif
 
       if (xfer%rcv_buf_size(p) .ne. 0) then
         deallocate(xfer%rcv_buf(p)%array)
-      end if
-    end do
+      endif
+    enddo
 
     ! deallocate buffer storage
     deallocate(xfer%snd_buf)
@@ -563,7 +563,7 @@ contains
     ! Deallocate nbr order info
     do p = 0, xfer%max_pn
       deallocate(xfer%nbr_order(p)%array)
-    end do
+    enddo
 
     ! Deallocate nbr order info array
     deallocate(xfer%nbr_order)

--- a/srcSphereAB/AB_XFER_util.f90
+++ b/srcSphereAB/AB_XFER_util.f90
@@ -46,19 +46,19 @@
              do j = 1, long
                out_array(p) = v_in(j, i, a)
                p = p + 1
-             end do
-           end do
-         end do
+             enddo
+           enddo
+         enddo
        else
          do a = 1, alt
            do i = lat - gcn + 1, lat
              do j = 1, long
                out_array(p) = v_in(j, i, a)
                p = p + 1
-             end do
-           end do
-         end do
-       end if
+             enddo
+           enddo
+         enddo
+       endif
 
      case (ab_south)
        if (pole) then
@@ -67,19 +67,19 @@
              do j = 1, long
                out_array(p) = v_in(j, i, a)
                p = p + 1
-             end do
-           end do
-         end do
+             enddo
+           enddo
+         enddo
        else
          do a = 1, alt
            do i = 1, gcn
              do j = 1, long
                out_array(p) = v_in(j, i, a)
                p = p + 1
-             end do
-           end do
-         end do
-       end if
+             enddo
+           enddo
+         enddo
+       endif
 
      case (ab_east)
        do a = 1, alt
@@ -87,9 +87,9 @@
            do j = long - gcn + 1, long
              out_array(p) = v_in(j, i, a)
              p = p + 1
-           end do
-         end do
-       end do
+           enddo
+         enddo
+       enddo
 
      case (ab_west)
        do a = 1, alt
@@ -97,9 +97,9 @@
            do j = 1, gcn
              out_array(p) = v_in(j, i, a)
              p = p + 1
-           end do
-         end do
-       end do
+           enddo
+         enddo
+       enddo
 
      case (ab_northeast)
        if (pole) then
@@ -108,19 +108,19 @@
              do j = long - gcn + 1, long
                out_array(p) = v_in(j, i, a)
                p = p + 1
-             end do
-           end do
-         end do
+             enddo
+           enddo
+         enddo
        else
          do a = 1, alt
            do i = lat - gcn + 1, lat
              do j = long - gcn + 1, long
                out_array(p) = v_in(j, i, a)
                p = p + 1
-             end do
-           end do
-         end do
-       end if
+             enddo
+           enddo
+         enddo
+       endif
 
      case (ab_northwest)
        if (pole) then
@@ -129,19 +129,19 @@
              do j = 1, gcn
                out_array(p) = v_in(j, i, a)
                p = p + 1
-             end do
-           end do
-         end do
+             enddo
+           enddo
+         enddo
        else
          do a = 1, alt
            do i = lat - gcn + 1, lat
              do j = 1, gcn
                out_array(p) = v_in(j, i, a)
                p = p + 1
-             end do
-           end do
-         end do
-       end if
+             enddo
+           enddo
+         enddo
+       endif
 
      case (ab_southeast)
        if (pole) then
@@ -150,19 +150,19 @@
              do j = long - gcn + 1, long
                out_array(p) = v_in(j, i, a)
                p = p + 1
-             end do
-           end do
-         end do
+             enddo
+           enddo
+         enddo
        else
          do a = 1, alt
            do i = 1, gcn
              do j = long - gcn + 1, long
                out_array(p) = v_in(j, i, a)
                p = p + 1
-             end do
-           end do
-         end do
-       end if
+             enddo
+           enddo
+         enddo
+       endif
 
      case (ab_southwest)
        if (pole) then
@@ -171,19 +171,19 @@
              do j = 1, gcn
                out_array(p) = v_in(j, i, a)
                p = p + 1
-             end do
-           end do
-         end do
+             enddo
+           enddo
+         enddo
        else
          do a = 1, alt
            do i = 1, gcn
              do j = 1, gcn
                out_array(p) = v_in(j, i, a)
                p = p + 1
-             end do
-           end do
-         end do
-       end if
+             enddo
+           enddo
+         enddo
+       endif
 
      end select
 
@@ -206,9 +206,9 @@
            do j = 1, long
              v_out(j, i, a) = in_array(p)
              p = p + 1
-           end do
-         end do
-       end do
+           enddo
+         enddo
+       enddo
 
      case (ab_south)
        do a = 1, alt
@@ -216,9 +216,9 @@
            do j = 1, long
              v_out(j, i, a) = in_array(p)
              p = p + 1
-           end do
-         end do
-       end do
+           enddo
+         enddo
+       enddo
 
      case (ab_east)
        do a = 1, alt
@@ -226,9 +226,9 @@
            do j = long + 1, long + gcn
              v_out(j, i, a) = in_array(p)
              p = p + 1
-           end do
-         end do
-       end do
+           enddo
+         enddo
+       enddo
 
      case (ab_west)
        do a = 1, alt
@@ -236,9 +236,9 @@
            do j = 1 - gcn, 0
              v_out(j, i, a) = in_array(p)
              p = p + 1
-           end do
-         end do
-       end do
+           enddo
+         enddo
+       enddo
 
      case (ab_northeast)
        do a = 1, alt
@@ -246,9 +246,9 @@
            do j = long + 1, long + gcn
              v_out(j, i, a) = in_array(p)
              p = p + 1
-           end do
-         end do
-       end do
+           enddo
+         enddo
+       enddo
 
      case (ab_northwest)
        do a = 1, alt
@@ -256,9 +256,9 @@
            do j = 1 - gcn, 0
              v_out(j, i, a) = in_array(p)
              p = p + 1
-           end do
-         end do
-       end do
+           enddo
+         enddo
+       enddo
 
      case (ab_southeast)
        do a = 1, alt
@@ -266,9 +266,9 @@
            do j = long + 1, long + gcn
              v_out(j, i, a) = in_array(p)
              p = p + 1
-           end do
-         end do
-       end do
+           enddo
+         enddo
+       enddo
 
      case (ab_southwest)
        do a = 1, alt
@@ -276,9 +276,9 @@
            do j = 1 - gcn, 0
              v_out(j, i, a) = in_array(p)
              p = p + 1
-           end do
-         end do
-       end do
+           enddo
+         enddo
+       enddo
 
      end select
 
@@ -320,19 +320,19 @@
                shifted_j = mod(j - 1 + half_long, long) + 1
                out_array(p) = v_in(shifted_j, i, a)
                p = p + 1
-             end do
-           end do
-         end do
+             enddo
+           enddo
+         enddo
        else
          do a = 1, alt
            do i = lat - gcn + 1, lat
              do j = 1, long
                out_array(p) = v_in(j, i, a)
                p = p + 1
-             end do
-           end do
-         end do
-       end if
+             enddo
+           enddo
+         enddo
+       endif
 
      case (ab_south)
        if (pole) then
@@ -342,19 +342,19 @@
                shifted_j = mod(j - 1 + half_long, long) + 1
                out_array(p) = v_in(shifted_j, i, a)
                p = p + 1
-             end do
-           end do
-         end do
+             enddo
+           enddo
+         enddo
        else
          do a = 1, alt
            do i = 1, gcn
              do j = 1, long
                out_array(p) = v_in(j, i, a)
                p = p + 1
-             end do
-           end do
-         end do
-       end if
+             enddo
+           enddo
+         enddo
+       endif
 
      case (ab_east)
        do a = 1, alt
@@ -362,9 +362,9 @@
            do j = long - gcn + 1, long
              out_array(p) = v_in(j, i, a)
              p = p + 1
-           end do
-         end do
-       end do
+           enddo
+         enddo
+       enddo
 
      case (ab_west)
        do a = 1, alt
@@ -372,9 +372,9 @@
            do j = 1, gcn
              out_array(p) = v_in(j, i, a)
              p = p + 1
-           end do
-         end do
-       end do
+           enddo
+         enddo
+       enddo
 
      case (ab_northeast)
        if (pole) then
@@ -384,19 +384,19 @@
                shifted_j = mod(j - 1 + half_long, long) + 1
                out_array(p) = v_in(shifted_j, i, a)
                p = p + 1
-             end do
-           end do
-         end do
+             enddo
+           enddo
+         enddo
        else
          do a = 1, alt
            do i = lat - gcn + 1, lat
              do j = long - gcn + 1, long
                out_array(p) = v_in(j, i, a)
                p = p + 1
-             end do
-           end do
-         end do
-       end if
+             enddo
+           enddo
+         enddo
+       endif
 
      case (ab_northwest)
        if (pole) then
@@ -406,19 +406,19 @@
                shifted_j = mod(j - 1 + half_long, long) + 1
                out_array(p) = v_in(shifted_j, i, a)
                p = p + 1
-             end do
-           end do
-         end do
+             enddo
+           enddo
+         enddo
        else
          do a = 1, alt
            do i = lat - gcn + 1, lat
              do j = 1, gcn
                out_array(p) = v_in(j, i, a)
                p = p + 1
-             end do
-           end do
-         end do
-       end if
+             enddo
+           enddo
+         enddo
+       endif
 
      case (ab_southeast)
        if (pole) then
@@ -428,19 +428,19 @@
                shifted_j = mod(j - 1 + half_long, long) + 1
                out_array(p) = v_in(shifted_j, i, a)
                p = p + 1
-             end do
-           end do
-         end do
+             enddo
+           enddo
+         enddo
        else
          do a = 1, alt
            do i = 1, gcn
              do j = long - gcn + 1, long
                out_array(p) = v_in(j, i, a)
                p = p + 1
-             end do
-           end do
-         end do
-       end if
+             enddo
+           enddo
+         enddo
+       endif
 
      case (ab_southwest)
        if (pole) then
@@ -450,19 +450,19 @@
                shifted_j = mod(j - 1 + half_long, long) + 1
                out_array(p) = v_in(shifted_j, i, a)
                p = p + 1
-             end do
-           end do
-         end do
+             enddo
+           enddo
+         enddo
        else
          do a = 1, alt
            do i = 1, gcn
              do j = 1, gcn
                out_array(p) = v_in(j, i, a)
                p = p + 1
-             end do
-           end do
-         end do
-       end if
+             enddo
+           enddo
+         enddo
+       endif
 
      end select
    end subroutine AB_1blk3_gc_pack
@@ -484,9 +484,9 @@
            do j = 1, long
              v_out(j, i, a) = in_array(p)
              p = p + 1
-           end do
-         end do
-       end do
+           enddo
+         enddo
+       enddo
 
      case (ab_south)
        do a = 1, alt
@@ -494,9 +494,9 @@
            do j = 1, long
              v_out(j, i, a) = in_array(p)
              p = p + 1
-           end do
-         end do
-       end do
+           enddo
+         enddo
+       enddo
 
      case (ab_east)
        do a = 1, alt
@@ -504,9 +504,9 @@
            do j = long + 1, long + gcn
              v_out(j, i, a) = in_array(p)
              p = p + 1
-           end do
-         end do
-       end do
+           enddo
+         enddo
+       enddo
 
      case (ab_west)
        do a = 1, alt
@@ -514,9 +514,9 @@
            do j = 1 - gcn, 0
              v_out(j, i, a) = in_array(p)
              p = p + 1
-           end do
-         end do
-       end do
+           enddo
+         enddo
+       enddo
 
      case (ab_northeast)
        do a = 1, alt
@@ -524,9 +524,9 @@
            do j = long + 1, long + gcn
              v_out(j, i, a) = in_array(p)
              p = p + 1
-           end do
-         end do
-       end do
+           enddo
+         enddo
+       enddo
 
      case (ab_northwest)
        do a = 1, alt
@@ -534,9 +534,9 @@
            do j = 1 - gcn, 0
              v_out(j, i, a) = in_array(p)
              p = p + 1
-           end do
-         end do
-       end do
+           enddo
+         enddo
+       enddo
 
      case (ab_southeast)
        do a = 1, alt
@@ -544,9 +544,9 @@
            do j = long + 1, long + gcn
              v_out(j, i, a) = in_array(p)
              p = p + 1
-           end do
-         end do
-       end do
+           enddo
+         enddo
+       enddo
 
      case (ab_southwest)
        do a = 1, alt
@@ -554,9 +554,9 @@
            do j = 1 - gcn, 0
              v_out(j, i, a) = in_array(p)
              p = p + 1
-           end do
-         end do
-       end do
+           enddo
+         enddo
+       enddo
 
      end select
 
@@ -596,10 +596,10 @@
                do j = 1, long
                  out_array(p) = v_in(j, i, a, e)
                  p = p + 1
-               end do
-             end do
-           end do
-         end do
+               enddo
+             enddo
+           enddo
+         enddo
        else
          do e = 1, eta
            do a = 1, alt
@@ -607,11 +607,11 @@
                do j = 1, long
                  out_array(p) = v_in(j, i, a, e)
                  p = p + 1
-               end do
-             end do
-           end do
-         end do
-       end if
+               enddo
+             enddo
+           enddo
+         enddo
+       endif
 
      case (ab_south)
        if (pole) then
@@ -621,10 +621,10 @@
              do j = 1, long
                out_array(p) = v_in(j, i, a, e)
                p = p + 1
-             end do
-           end do
-         end do
-         end do
+             enddo
+           enddo
+         enddo
+         enddo
        else
          do e = 1, eta
          do a = 1, alt
@@ -632,11 +632,11 @@
              do j = 1, long
                out_array(p) = v_in(j, i, a, e)
                p = p + 1
-             end do
-           end do
-         end do
-         end do
-       end if
+             enddo
+           enddo
+         enddo
+         enddo
+       endif
 
      case (ab_east)
        do e = 1, eta
@@ -645,10 +645,10 @@
            do j = long - gcn + 1, long
              out_array(p) = v_in(j, i, a, e)
              p = p + 1
-           end do
-         end do
-       end do
-       end do
+           enddo
+         enddo
+       enddo
+       enddo
 
      case (ab_west)
        do e = 1, eta
@@ -657,10 +657,10 @@
            do j = 1, gcn
              out_array(p) = v_in(j, i, a, e)
              p = p + 1
-           end do
-         end do
-       end do
-       end do
+           enddo
+         enddo
+       enddo
+       enddo
 
      case (ab_northeast)
        if (pole) then
@@ -670,10 +670,10 @@
              do j = long - gcn + 1, long
                out_array(p) = v_in(j, i, a, e)
                p = p + 1
-             end do
-           end do
-         end do
-         end do
+             enddo
+           enddo
+         enddo
+         enddo
        else
          do e = 1, eta
          do a = 1, alt
@@ -681,11 +681,11 @@
              do j = long - gcn + 1, long
                out_array(p) = v_in(j, i, a, e)
                p = p + 1
-             end do
-           end do
-         end do
-         end do
-       end if
+             enddo
+           enddo
+         enddo
+         enddo
+       endif
 
      case (ab_northwest)
        if (pole) then
@@ -695,10 +695,10 @@
              do j = 1, gcn
                out_array(p) = v_in(j, i, a, e)
                p = p + 1
-             end do
-           end do
-         end do
-         end do
+             enddo
+           enddo
+         enddo
+         enddo
        else
          do e = 1, eta
          do a = 1, alt
@@ -706,11 +706,11 @@
              do j = 1, gcn
                out_array(p) = v_in(j, i, a, e)
                p = p + 1
-             end do
-           end do
-         end do
-         end do
-       end if
+             enddo
+           enddo
+         enddo
+         enddo
+       endif
 
      case (ab_southeast)
        if (pole) then
@@ -720,10 +720,10 @@
              do j = long - gcn + 1, long
                out_array(p) = v_in(j, i, a, e)
                p = p + 1
-             end do
-           end do
-         end do
-         end do
+             enddo
+           enddo
+         enddo
+         enddo
        else
          do e = 1, eta
          do a = 1, alt
@@ -731,11 +731,11 @@
              do j = long - gcn + 1, long
                out_array(p) = v_in(j, i, a, e)
                p = p + 1
-             end do
-           end do
-         end do
-         end do
-       end if
+             enddo
+           enddo
+         enddo
+         enddo
+       endif
 
      case (ab_southwest)
        if (pole) then
@@ -745,10 +745,10 @@
              do j = 1, gcn
                out_array(p) = v_in(j, i, a, e)
                p = p + 1
-             end do
-           end do
-         end do
-         end do
+             enddo
+           enddo
+         enddo
+         enddo
        else
          do e = 1, eta
          do a = 1, alt
@@ -756,11 +756,11 @@
              do j = 1, gcn
                out_array(p) = v_in(j, i, a, e)
                p = p + 1
-             end do
-           end do
-         end do
-         end do
-       end if
+             enddo
+           enddo
+         enddo
+         enddo
+       endif
 
      end select
 
@@ -784,10 +784,10 @@
            do j = 1, long
              v_out(j, i, a, e) = in_array(p)
              p = p + 1
-           end do
-         end do
-       end do
-       end do
+           enddo
+         enddo
+       enddo
+       enddo
 
      case (ab_south)
        do e = 1, eta
@@ -796,10 +796,10 @@
            do j = 1, long
              v_out(j, i, a, e) = in_array(p)
              p = p + 1
-           end do
-         end do
-       end do
-       end do
+           enddo
+         enddo
+       enddo
+       enddo
 
      case (ab_east)
        do e = 1, eta
@@ -808,10 +808,10 @@
            do j = long + 1, long + gcn
              v_out(j, i, a, e) = in_array(p)
              p = p + 1
-           end do
-         end do
-       end do
-       end do
+           enddo
+         enddo
+       enddo
+       enddo
 
      case (ab_west)
        do e = 1, eta
@@ -820,10 +820,10 @@
            do j = 1 - gcn, 0
              v_out(j, i, a, e) = in_array(p)
              p = p + 1
-           end do
-         end do
-       end do
-       end do
+           enddo
+         enddo
+       enddo
+       enddo
 
      case (ab_northeast)
        do e = 1, eta
@@ -832,10 +832,10 @@
            do j = long + 1, long + gcn
              v_out(j, i, a, e) = in_array(p)
              p = p + 1
-           end do
-         end do
-       end do
-       end do
+           enddo
+         enddo
+       enddo
+       enddo
 
      case (ab_northwest)
        do e = 1, eta
@@ -844,10 +844,10 @@
            do j = 1 - gcn, 0
              v_out(j, i, a, e) = in_array(p)
              p = p + 1
-           end do
-         end do
-       end do
-       end do
+           enddo
+         enddo
+       enddo
+       enddo
 
      case (ab_southeast)
        do e = 1, eta
@@ -856,10 +856,10 @@
            do j = long + 1, long + gcn
              v_out(j, i, a, e) = in_array(p)
              p = p + 1
-           end do
-         end do
-       end do
-       end do
+           enddo
+         enddo
+       enddo
+       enddo
 
      case (ab_southwest)
        do e = 1, eta
@@ -868,10 +868,10 @@
            do j = 1 - gcn, 0
              v_out(j, i, a, e) = in_array(p)
              p = p + 1
-           end do
-         end do
-       end do
-       end do
+           enddo
+         enddo
+       enddo
+       enddo
 
      end select
 
@@ -915,10 +915,10 @@
                shifted_j = mod(j - 1 + half_long, long) + 1
                out_array(p) = v_in(shifted_j, i, a, e)
                p = p + 1
-             end do
-           end do
-         end do
-         end do
+             enddo
+           enddo
+         enddo
+         enddo
        else
          do e = 1, eta
          do a = 1, alt
@@ -926,11 +926,11 @@
              do j = 1, long
                out_array(p) = v_in(j, i, a, e)
                p = p + 1
-             end do
-           end do
-         end do
-         end do
-       end if
+             enddo
+           enddo
+         enddo
+         enddo
+       endif
 
      case (ab_south)
        if (pole) then
@@ -941,10 +941,10 @@
                shifted_j = mod(j - 1 + half_long, long) + 1
                out_array(p) = v_in(shifted_j, i, a, e)
                p = p + 1
-             end do
-           end do
-         end do
-         end do
+             enddo
+           enddo
+         enddo
+         enddo
        else
          do e = 1, eta
          do a = 1, alt
@@ -952,11 +952,11 @@
              do j = 1, long
                out_array(p) = v_in(j, i, a, e)
                p = p + 1
-             end do
-           end do
-         end do
-         end do
-       end if
+             enddo
+           enddo
+         enddo
+         enddo
+       endif
 
      case (ab_east)
        do e = 1, eta
@@ -965,10 +965,10 @@
            do j = long - gcn + 1, long
              out_array(p) = v_in(j, i, a, e)
              p = p + 1
-           end do
-         end do
-       end do
-       end do
+           enddo
+         enddo
+       enddo
+       enddo
 
      case (ab_west)
        do e = 1, eta
@@ -977,10 +977,10 @@
            do j = 1, gcn
              out_array(p) = v_in(j, i, a, e)
              p = p + 1
-           end do
-         end do
-       end do
-       end do
+           enddo
+         enddo
+       enddo
+       enddo
 
      case (ab_northeast)
        if (pole) then
@@ -991,10 +991,10 @@
                shifted_j = mod(j - 1 + half_long, long) + 1
                out_array(p) = v_in(shifted_j, i, a, e)
                p = p + 1
-             end do
-           end do
-         end do
-         end do
+             enddo
+           enddo
+         enddo
+         enddo
        else
          do e = 1, eta
          do a = 1, alt
@@ -1002,11 +1002,11 @@
              do j = long - gcn + 1, long
                out_array(p) = v_in(j, i, a, e)
                p = p + 1
-             end do
-           end do
-         end do
-         end do
-       end if
+             enddo
+           enddo
+         enddo
+         enddo
+       endif
 
      case (ab_northwest)
        if (pole) then
@@ -1017,10 +1017,10 @@
                shifted_j = mod(j - 1 + half_long, long) + 1
                out_array(p) = v_in(shifted_j, i, a, e)
                p = p + 1
-             end do
-           end do
-         end do
-         end do
+             enddo
+           enddo
+         enddo
+         enddo
        else
          do e = 1, eta
          do a = 1, alt
@@ -1028,11 +1028,11 @@
              do j = 1, gcn
                out_array(p) = v_in(j, i, a, e)
                p = p + 1
-             end do
-           end do
-         end do
-         end do
-       end if
+             enddo
+           enddo
+         enddo
+         enddo
+       endif
 
      case (ab_southeast)
        if (pole) then
@@ -1043,10 +1043,10 @@
                shifted_j = mod(j - 1 + half_long, long) + 1
                out_array(p) = v_in(shifted_j, i, a, e)
                p = p + 1
-             end do
-           end do
-         end do
-         end do
+             enddo
+           enddo
+         enddo
+         enddo
        else
          do e = 1, eta
          do a = 1, alt
@@ -1054,11 +1054,11 @@
              do j = long - gcn + 1, long
                out_array(p) = v_in(j, i, a, e)
                p = p + 1
-             end do
-           end do
-         end do
-         end do
-       end if
+             enddo
+           enddo
+         enddo
+         enddo
+       endif
 
      case (ab_southwest)
        if (pole) then
@@ -1069,10 +1069,10 @@
                shifted_j = mod(j - 1 + half_long, long) + 1
                out_array(p) = v_in(shifted_j, i, a, e)
                p = p + 1
-             end do
-           end do
-         end do
-         end do
+             enddo
+           enddo
+         enddo
+         enddo
        else
          do e = 1, eta
          do a = 1, alt
@@ -1080,11 +1080,11 @@
              do j = 1, gcn
                out_array(p) = v_in(j, i, a, e)
                p = p + 1
-             end do
-           end do
-         end do
-         end do
-       end if
+             enddo
+           enddo
+         enddo
+         enddo
+       endif
 
      end select
 
@@ -1108,10 +1108,10 @@
            do j = 1, long
              v_out(j, i, a, e) = in_array(p)
              p = p + 1
-           end do
-         end do
-       end do
-       end do
+           enddo
+         enddo
+       enddo
+       enddo
 
      case (ab_south)
        do e = 1, eta
@@ -1120,10 +1120,10 @@
            do j = 1, long
              v_out(j, i, a, e) = in_array(p)
              p = p + 1
-           end do
-         end do
-       end do
-       end do
+           enddo
+         enddo
+       enddo
+       enddo
 
      case (ab_east)
        do e = 1, eta
@@ -1132,10 +1132,10 @@
            do j = long + 1, long + gcn
              v_out(j, i, a, e) = in_array(p)
              p = p + 1
-           end do
-         end do
-       end do
-       end do
+           enddo
+         enddo
+       enddo
+       enddo
 
      case (ab_west)
        do e = 1, eta
@@ -1144,10 +1144,10 @@
            do j = 1 - gcn, 0
              v_out(j, i, a, e) = in_array(p)
              p = p + 1
-           end do
-         end do
-       end do
-       end do
+           enddo
+         enddo
+       enddo
+       enddo
 
      case (ab_northeast)
        do e = 1, eta
@@ -1156,10 +1156,10 @@
            do j = long + 1, long + gcn
              v_out(j, i, a, e) = in_array(p)
              p = p + 1
-           end do
-         end do
-       end do
-       end do
+           enddo
+         enddo
+       enddo
+       enddo
 
      case (ab_northwest)
        do e = 1, eta
@@ -1168,10 +1168,10 @@
            do j = 1 - gcn, 0
              v_out(j, i, a, e) = in_array(p)
              p = p + 1
-           end do
-         end do
-       end do
-       end do
+           enddo
+         enddo
+       enddo
+       enddo
 
      case (ab_southeast)
        do e = 1, eta
@@ -1180,10 +1180,10 @@
            do j = long + 1, long + gcn
              v_out(j, i, a, e) = in_array(p)
              p = p + 1
-           end do
-         end do
-       end do
-       end do
+           enddo
+         enddo
+       enddo
+       enddo
 
      case (ab_southwest)
        do e = 1, eta
@@ -1192,10 +1192,10 @@
            do j = 1 - gcn, 0
              v_out(j, i, a, e) = in_array(p)
              p = p + 1
-           end do
-         end do
-       end do
-       end do
+           enddo
+         enddo
+       enddo
+       enddo
 
      end select
 

--- a/srcSphereAB/AB_module.f90
+++ b/srcSphereAB/AB_module.f90
@@ -209,15 +209,15 @@ contains
       do j = 1, ab_rnbr_num
         new_abp%nbrs_p(j, i) = -1
         new_abp%nbrs_b(j, i) = -1
-      end do
+      enddo
       new_abp%nbrs_l(i) = ab_level_same
-    end do
+    enddo
 
     ! initialize corners
     do i = 1, ab_num_cnr_nbrs
       new_abp%cnrs_p(i) = -1
       new_abp%cnrs_b(i) = -1
-    end do
+    enddo
 
     ! initialize other entries
     new_abp%x = x
@@ -262,7 +262,7 @@ contains
     else
       grp%blks(index)%nbrs_p(ab_rnbr_none, dir) = nbr_p
       grp%blks(index)%nbrs_b(ab_rnbr_none, dir) = nbr_b
-    end if
+    endif
 
     ! update pole type
     !!!!!!! WARNING NEED TO FILL THIS IN BEFORE USING
@@ -309,22 +309,22 @@ contains
     do i = 1, ab_num_edge_nbrs
       blk%nbrs_p(ab_rnbr_none, i) = nbrs_p(i)
       blk%nbrs_b(ab_rnbr_none, i) = nbrs_b(i)
-    end do
+    enddo
 
     ! set corners
     do i = 1, ab_num_cnr_nbrs
       blk%cnrs_p(i) = nbrs_p(i + ab_cnr_ind_2_dir)
       blk%cnrs_b(i) = nbrs_b(i + ab_cnr_ind_2_dir)
-    end do
+    enddo
 
     ! update pole type
     blk%pole_type = 0
     if (north_pole) then
       blk%pole_type = blk%pole_type + 1
-    end if
+    endif
     if (south_pole) then
       blk%pole_type = blk%pole_type + 2
-    end if
+    endif
 
   end subroutine AB_set_all_nbrs
 
@@ -382,7 +382,7 @@ contains
       ok = .false.
       call AB_ERROR_set("AB_module_setup", "allocate error ", ierror)
       return
-    end if
+    endif
 
   end subroutine AB_module_setup
 
@@ -420,7 +420,7 @@ contains
       ok = .false.
       call AB_ERROR_set("AB_GRP_create", "allocate error ", ierror)
       return
-    end if
+    endif
 
     ! Allocate space for adpt values
     allocate(grp%adpt(num_blks), stat=ierror)
@@ -428,7 +428,7 @@ contains
       ok = .false.
       call AB_ERROR_set("AB_GRP_create_sphere", "allocate error ", ierror)
       return
-    end if
+    endif
 
     ! Initialize adaptation values
     grp%adpt = 0
@@ -541,7 +541,7 @@ contains
     else
       done = .false.
       index = 1
-    end if
+    endif
   end subroutine AB_ITER_reset
 
  !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
@@ -573,7 +573,7 @@ contains
     else
       done = .false.
       index = iter%index
-    end if
+    endif
 
   end subroutine AB_ITER_next
 
@@ -660,7 +660,7 @@ contains
       pole_type = iter%grp%blks(index)%pole_type
       pole = g_pole(dir, pole_type)
       nbr_dir = g_trans_dir(dir, pole_type)
-    end if
+    endif
 
   end subroutine AB_NBR_ITER_reset_pipd
 
@@ -699,7 +699,7 @@ contains
     if (iter%dir > ab_num_nbrs) then
       iter%dir = 1
       iter%index = iter%index + 1
-    end if
+    endif
 
     ! check if we're still in range and if so then do output
     if (iter%index > iter%grp%max_used_blks) then
@@ -720,11 +720,11 @@ contains
       else
         nbr_proc = iter%grp%blks(index)%nbrs_p(ab_rnbr_none, dir)
         nbr_index = iter%grp%blks(index)%nbrs_b(ab_rnbr_none, dir)
-      end if
+      endif
       pole_type = iter%grp%blks(index)%pole_type
       pole = g_pole(dir, pole_type)
       nbr_dir = g_trans_dir(dir, pole_type)
-    end if
+    endif
   end subroutine AB_NBR_ITER_next_pipd
 
  !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
@@ -769,7 +769,7 @@ contains
       dir = 1
       nbr_proc = iter%grp%blks(index)%nbrs_p(ab_rnbr_none, dir)
       nbr_index = iter%grp%blks(index)%nbrs_b(ab_rnbr_none, dir)
-    end if
+    endif
 
   end subroutine AB_NBR_ITER_reset_pi
 
@@ -805,7 +805,7 @@ contains
     if (iter%dir > ab_num_nbrs) then
       iter%dir = 1
       iter%index = iter%index + 1
-    end if
+    endif
 
     ! check if we're still in range and if so then do output
     if (iter%index > iter%grp%max_used_blks) then
@@ -824,8 +824,8 @@ contains
       else
         nbr_proc = iter%grp%blks(index)%nbrs_p(ab_rnbr_none, dir)
         nbr_index = iter%grp%blks(index)%nbrs_b(ab_rnbr_none, dir)
-      end if
-    end if
+      endif
+    endif
   end subroutine AB_NBR_ITER_next_pi
 
   subroutine test_NBR_ITER(grp)
@@ -843,7 +843,7 @@ contains
       write(*, *) i, "[", b, ",", d, "]={", n_p, ",", n_b, "}"
       i = i + 1
       call AB_NBR_ITER_next(iter, b, d, n_p, n_b, done)
-    end do
+    enddo
 
     i = 1
     write(*, *)
@@ -856,7 +856,7 @@ contains
         n_b = grp%blks(b)%nbrs_b(ab_rnbr_none, d)
         write(*, *) i, "[", b, ",", d, "]={", n_p, ",", n_b, "}"
         i = i + 1
-      end do
+      enddo
 
        !! do corner neighbors
       do d = 1, ab_num_cnr_nbrs
@@ -864,8 +864,8 @@ contains
         n_b = grp%blks(b)%cnrs_b(d)
         write(*, *) i, "[", b, ",", d + 4, "]={", n_p, ",", n_b, "}"
         i = i + 1
-      end do
-    end do
+      enddo
+    enddo
 
   end subroutine test_NBR_ITER
 
@@ -956,12 +956,12 @@ contains
     do i = 1, ab_num_edge_nbrs
       nbrs(1, i) = grp%blks(index)%nbrs_b(ab_rnbr_none, i)
       nbrs(2, i) = grp%blks(index)%nbrs_p(ab_rnbr_none, i)
-    end do
+    enddo
 
     do i = 1, ab_num_cnr_nbrs
       nbrs(1, i + ab_cnr_ind_2_dir) = grp%blks(index)%cnrs_b(i)
       nbrs(2, i + ab_cnr_ind_2_dir) = grp%blks(index)%cnrs_p(i)
-    end do
+    enddo
 
   end subroutine AB_get_nbrs
 

--- a/srcSphereAB/Makefile
+++ b/srcSphereAB/Makefile
@@ -1,5 +1,7 @@
 include ../srcMake/Makefile.conf
+include ../Makefile.def
 -include ./Makefile.DEPEND
+
 #
 #  Makefile for AB2D code:
 #
@@ -17,36 +19,20 @@ OBJECTS = \
 	AB_XFER_1blk_util.o
 
 DEPEND:
-	@perl ${SCRIPTDIR}/depend.pl  ./ ../src/ ${LIBDIR} ${OBJECTS} ${MODULES}
+	@perl ${SCRIPTDIR}/depend.pl  ./ ${SEARCH} ${LIBDIR} ${OBJECTS} ${MODULES}
 
-LIB:    libSphere.a
-	@echo libSphere.a has been brought up to date.
 
-libSphere.a:      ${MF} ${MODULES} ${OBJECTS}
+MY_LIB = ${LIBDIR}/libSphere.a
+
+LIB:	DEPEND
+	${MAKE} ${MY_LIB}
+	@echo
+	@echo ${MY_LIB} has been brought up to date.
+	@echo
+
+${MY_LIB}: ${MODULES} ${OBJECTS}
 	@echo 'Creating libSphere library'
-	${AR} libSphere.a ${MODULES} ${OBJECTS}
-
-exposed_objects: AB_module.o AB_XFER_module.o AB_ERROR_module.o \
-	         AB_XFER_array_util.o AB_XFER_1blk_util.o AB_SPH_module.o
-
-AB_module.o: AB_module.o AB_COMM_module.o AB_ARRAY_module.o \
-	AB_ERROR_module.o
-
-AB_XFER_array_util.o:  AB_XFER_array_util.o AB_module.o
-
-AB_XFER_1blk_util.o:  AB_XFER_1blk_util.o AB_module.o
-
-AB_XFER_module.o: AB_XFER_module.o AB_COMM_module.o AB_ARRAY_module.o \
-	AB_ERROR_module.o AB_module.o
-
-AB_SPH_module.o: AB_SPH_module.o AB_module.o AB_COMM_module.o \
-	AB_ERROR_module.o
-
-AB_COMM_module.o:  AB_COMM_module.o AB_ARRAY_module.o AB_ERROR_module.o
-
-AB_ARRAY_module.o:  AB_ARRAY_module.o
-
-AB_ERROR_module.o:  AB_ERROR_module.o
+	${AR} ${MY_LIB} ${MODULES} ${OBJECTS}
 
 clean:
 	rm -f *~ core *.o *.mod fort.* a.out *.exe *.a *.so *.protex

--- a/srcUser/add_sources_mars_thermal.f90
+++ b/srcUser/add_sources_mars_thermal.f90
@@ -22,8 +22,8 @@ subroutine add_sources
       ! The iLon and iLat are dummy variables...
       call UA_calc_electrodynamics(iLon, iLat)
       IsFirstTime = .false.
-    end if
-  end if
+    endif
+  endif
 
   do iBlock = 1, nBlocks
 
@@ -59,7 +59,7 @@ subroutine add_sources
     userdata1D(1, 1, :, 9) = Conduction(1, 1, 1:nAlts)
     do ialt = 1, nalts
       userdata1D(1, 1, iAlt, :) = userdata1D(1, 1, ialt, :)*tempunit(1, 1, iAlt)
-    end do
+    enddo
     !-------------------------------------------
     ! This is an example of a user output:
 
@@ -90,11 +90,11 @@ subroutine add_sources
                 ChemicalHeatingRate(iLon, iLat, iAlt)
               call stop_gitm('Negative Temperature Found')
 
-            end if
-          end do
-        end do
-      end do
-    end do
+            endif
+          enddo
+        enddo
+      enddo
+    enddo
 
     if (iDebugLevel > 2 .and. Is1D) then
 !        do iAlt = 1,nAlts
@@ -108,7 +108,7 @@ subroutine add_sources
         ChemicalHeatingRate(1, 1, iAlt), &
         Conduction(1, 1, iAlt), temperature(1, 1, iAlt, iBlock)
 !        enddo
-    end if
+    endif
 
     iAlt = nAlts - 2
     if (iDebugLevel > 2) &
@@ -135,7 +135,7 @@ subroutine add_sources
         Dt*(VerticalIonDrag(:, :, :, iSpecies)) + &
         NeutralFriction(:, :, :, iSpecies)
 
-    end do
+    enddo
 
     call planet_limited_fluxes(iBlock)
 
@@ -157,9 +157,9 @@ subroutine add_sources
                 NDensityS(iLon, iLat, iAlt, 1:nSpecies, iBlock))
           NDensity(iLon, iLat, iAlt, iBlock) = &
             sum(NDensityS(iLon, iLat, iAlt, 1:nSpecies, iBlock))
-        end do
-      end do
-    end do
+        enddo
+      enddo
+    enddo
 
     Velocity(1:nLons, 1:nLats, 1:nAlts, iUp_, iBlock) = 0.0
     do iSpecies = 1, nSpecies
@@ -169,8 +169,8 @@ subroutine add_sources
         Mass(iSpecies)* &
         NDensityS(1:nLons, 1:nLats, 1:nAlts, iSpecies, iBlock)/ &
         Rho(1:nLons, 1:nLats, 1:nAlts, iBlock)
-    end do
+    enddo
 
-  end do
+  enddo
 
 end subroutine add_sources

--- a/srcUser/user_mars_thermal.f90
+++ b/srcUser/user_mars_thermal.f90
@@ -104,7 +104,7 @@ subroutine output_header_user(cType, iOutputUnit_)
     write(iOutputUnit_, "(I7,A1,a)") 3, " ", "Altitude"
     write(iOutputUnit_, "(I7,A1,a)") 4, " ", "Joule Heating"
 
-  end if
+  endif
 
   ! ------------------------------------------
   ! 1D Output Header
@@ -133,7 +133,7 @@ subroutine output_header_user(cType, iOutputUnit_)
     write(iOutputUnit_, "(I7,A1,a)") 11, " ", "RadCooling"
     write(iOutputUnit_, "(I7,A1,a)") 12, " ", "Conduction"
 
-  end if
+  endif
 
   ! ------------------------------------------
   ! 2D Output Header
@@ -159,7 +159,7 @@ subroutine output_header_user(cType, iOutputUnit_)
     write(iOutputUnit_, "(I7,A1,a)") 5, " ", "Average Energy (keV)"
     write(iOutputUnit_, "(I7,A1,a)") 6, " ", "Total Energy (ergs)"
 
-  end if
+  endif
 
   write(iOutputUnit_, *) ""
 
@@ -187,9 +187,9 @@ subroutine output_3dUser(iBlock, iOutputUnit_)
           Latitude(iLat, iBlock), &
           Altitude_GB(iLon, iLat, iAlt, iBlock), &
           UserData3D(iLon, iLat, iAlt, 1:nVarsUser3d - 3, iBlock)
-      end do
-    end do
-  end do
+      enddo
+    enddo
+  enddo
 
 end subroutine output_3dUser
 
@@ -216,7 +216,7 @@ subroutine output_1dUser(iBlock, iOutputUnit_)
       Latitude(1, iBlock), &
       Altitude_GB(1, 1, iAlt, iBlock), &
       UserData1D(1, 1, iiAlt, 1:nVarsUSer1d - 3)
-  end do
+  enddo
 
 end subroutine output_1dUser
 !----------------------------------------------------------------
@@ -241,8 +241,8 @@ subroutine output_2dUser(iBlock, iOutputUnit_)
         Latitude(iLat, iBlock), &
         Altitude_GB(iLon, iLat, iAlt, iBlock), &
         UserData2D(iLon, iLat, iAlt, 1:nVarsUser2d - 3, iBlock)
-    end do
-  end do
+    enddo
+  enddo
 
 end subroutine output_2dUser
 

--- a/srcUser/vertical_solver_mars_thermal.f90
+++ b/srcUser/vertical_solver_mars_thermal.f90
@@ -160,7 +160,7 @@ subroutine advance_vertical_1stage( &
   do iAlt = -1, nAlts + 2
     Press(iAlt) = NT(iAlt)*Boltzmanns_Constant*Temp(iAlt)
     LogPress(iAlt) = alog(Press(iAlt))
-  end do
+  enddo
 
   call calc_rusanov_alts(LogPress, GradLogPress, DiffLogPress)
   call calc_rusanov_alts(LogRho, GradLogRho, DiffLogRho)
@@ -169,7 +169,7 @@ subroutine advance_vertical_1stage( &
   do iDim = 1, 3
     call calc_rusanov_alts(Vel_GD(:, iDim), &
                            GradVel_CD(:, iDim), DiffVel_CD(:, iDim))
-  end do
+  enddo
 
   ! Add geometrical correction to gradient and obtain divergence
   DivVel = GradVel_CD(:, iUp_) + 2*Vel_GD(1:nAlts, iUp_)*InvRadialDistance_C
@@ -186,13 +186,13 @@ subroutine advance_vertical_1stage( &
     DivVertVel(:, iSpecies) = GradVertVel(:, iSpecies) + &
                               2*VertVel(1:nAlts, iSpecies)*InvRadialDistance_C
 
-  end do
+  enddo
 
   do iSpecies = 1, nIonsAdvect
     call calc_rusanov_alts(LogINS(:, iSpecies), GradTmp, DiffTmp)
     GradLogINS(:, iSpecies) = GradTmp
     DiffLogINS(:, iSpecies) = DiffTmp
-  end do
+  enddo
 
   AmpSP = (1.0/(10.0*Dt))
   kSP = nAltsSponge + 1
@@ -209,13 +209,13 @@ subroutine advance_vertical_1stage( &
                                   VertVel(iAlt, iSpecies)*GradLogNS(iAlt, iSpecies)) + &
                                  Dt*DiffLogNS(iAlt, iSpecies)
 
-    end do
+    enddo
 
     do iSpecies = 1, nIonsAdvect
       NewLogINS(iAlt, iSpecies) = NewLogINS(iAlt, iSpecies) - Dt* &
                                   (IVel(iAlt, iUp_)*GradLogINS(iAlt, iSpecies)) &
                                   + Dt*DiffLogINS(iAlt, iSpecies)
-    end do
+    enddo
 
 !     ! dVr/dt = -[ (V grad V)_r + grad T + T grad ln Rho - g ]
 !     ! and V grad V contains the centripetal acceleration
@@ -237,7 +237,7 @@ subroutine advance_vertical_1stage( &
 
       NuSP = 0.0
 
-    end if
+    endif
 
     do iSpecies = 1, nSpecies
 
@@ -257,11 +257,11 @@ subroutine advance_vertical_1stage( &
         NewVertVel(iAlt, ispecies) = NewVertVel(iAlt, ispecies) + Dt*( &
                                      Centrifugal/InvRadialDistance_C(iAlt) + &
                                      Coriolis*Vel_GD(iAlt, iEast_))
-      end if
+      endif
 
-    end do
+    enddo
 
-  end do
+  enddo
 
   do iAlt = 1, nAlts
 
@@ -274,9 +274,9 @@ subroutine advance_vertical_1stage( &
                               NewVertVel(iAlt, iSpecies)* &
                               (Mass(iSpecies)*NS(iAlt, iSpecies)/Rho(iAlt))
 
-    end do
+    enddo
 
-  end do
+  enddo
 
   StressHeating = 0.0
 
@@ -292,9 +292,9 @@ subroutine advance_vertical_1stage( &
                              GradVel_CD(iAlt, iEast_)**2 &
                              ))
 
-    end do
+    enddo
 
-  end if
+  endif
   userdata1d = 0.0
   do iAlt = 1, nAlts
 
@@ -336,12 +336,12 @@ subroutine advance_vertical_1stage( &
 !             ( (Gamma_1d(iAlt) - 1.0)/Gamma_1d(iAlt) )*&
 !               Temp(iAlt)*GradLogPress(iAlt)
 
-  end do
+  enddo
 
   do iAlt = 1, nAlts
     NewSumRho = sum(Mass(1:nSpecies)*exp(NewLogNS(iAlt, 1:nSpecies)))
     NewLogRho(iAlt) = alog(NewSumRho)
-  end do
+  enddo
 
 end subroutine advance_vertical_1stage
 
@@ -419,7 +419,7 @@ subroutine calc_facevalues_alts(Var, VarLeft, VarRight)
 
 !     write(*,*) dVarUp, dVarDown, dVarLimited(i)
 
-  end do
+  enddo
 
   i = 0
   dVarUp = (Var(i + 1) - Var(i))*InvDAlt_F(i + 1)
@@ -434,7 +434,7 @@ subroutine calc_facevalues_alts(Var, VarLeft, VarRight)
   do i = 1, nAlts + 1
     VarLeft(i) = Var(i - 1) + 0.5*dVarLimited(i - 1)*dAlt_F(i)
     VarRight(i) = Var(i) - 0.5*dVarLimited(i)*dAlt_F(i)
-  end do
+  enddo
 
 end subroutine calc_facevalues_alts
 

--- a/util/DATAREAD/srcIndices/IO_set_inputs.f90
+++ b/util/DATAREAD/srcIndices/IO_set_inputs.f90
@@ -24,50 +24,50 @@ subroutine IO_set_inputs(StringInputLines)
 
       if (index(StringLine, "#NGDC_INDICES") > 0) then
         call read_in_string(NameOfIndexFile)
-      end if
+      endif
 
       if (index(StringLine, "#F107_FILE") > 0) then
         call read_in_string(NameOfIndexFile)
-      end if
+      endif
 
       if (index(StringLine, "#SME_INDICES") > 0) then
         call read_in_string(NameOfIndexFile)
         call read_in_string(NameOfSecondIndexFile)
-      end if
+      endif
 
       if (index(StringLine, "#SWPC_INDICES") > 0) then
         call read_in_string(NameOfIndexFile)
         call read_in_string(NameOfSecondIndexFile)
-      end if
+      endif
 
       if (index(StringLine, "#ACE_DATA") > 0) then
         call read_in_string(NameOfIndexFile)
         call read_in_string(NameOfSecondIndexFile)
-      end if
+      endif
 
       if (index(StringLine, "#NOAAHPI_INDICES") > 0) then
         call read_in_string(NameOfIndexFile)
-      end if
+      endif
 
       if (index(StringLine, "#MHD_INDICES") > 0) then
         call read_in_string(NameOfIndexFile)
-      end if
+      endif
 
       if (index(StringLine, "#END") > 0) then
         IsDone = .true.
-      end if
+      endif
 
       if (iLine >= MaxInputLines) then
         IsDone = .true.
-      end if
+      endif
 
     else
 
       iLine = iLine + 1
 
-    end if
+    endif
 
-  end do
+  enddo
 
 contains
 

--- a/util/DATAREAD/srcIndices/indices_library.f90
+++ b/util/DATAREAD/srcIndices/indices_library.f90
@@ -21,14 +21,14 @@ subroutine check_all_indices(TimeIn, iOutputError)
       if ((IndexTimes_TV(1, iIndex) - TimeIn) > &
           5.0*(IndexTimes_TV(2, iIndex) - IndexTimes_TV(1, iIndex))) then
         iOutputError = 3
-      end if
+      endif
 
       if ((TimeIn - IndexTimes_TV(nIndices_V(iIndex), iIndex)) > &
           5.0*(IndexTimes_TV(2, iIndex) - IndexTimes_TV(1, iIndex))) then
         iOutputError = 3
-      end if
-    end if
-  end do
+      endif
+    endif
+  enddo
 
   return
 end subroutine check_all_indices
@@ -168,7 +168,7 @@ subroutine set_time(TimeIn, iOutputError)
     call get_index(iIndex, SavedTime, 0, IndexValue, iError)
     SavedIndices_V(iIndex) = IndexValue
     SavedErrors_V(iIndex) = iError
-  end do
+  enddo
 
 end subroutine set_time
 
@@ -199,17 +199,17 @@ subroutine get_index(label_, TimeIn, Interpolate, value, iOutputError)
   if (label_ < 1 .or. label_ > nIndices) then
     iOutputError = 1
     return
-  end if
+  endif
 
   if (nIndices_V(label_) == 0) then
     iOutputError = 2
     return
-  end if
+  endif
 
   if (nIndices_V(label_) == 1) then
     value = Indices_TV(1, label_)
     return
-  end if
+  endif
 
   if (TimeIn <= IndexTimes_TV(1, label_)) then
     value = Indices_TV(1, label_)
@@ -218,9 +218,9 @@ subroutine get_index(label_, TimeIn, Interpolate, value, iOutputError)
     if ((IndexTimes_TV(1, label_) - TimeIn) > &
         5.0*(IndexTimes_TV(2, label_) - IndexTimes_TV(1, label_))) then
       iOutputError = 3
-    end if
+    endif
     return
-  end if
+  endif
 
   if (TimeIn >= IndexTimes_TV(nIndices_V(label_), label_)) then
     value = Indices_TV(nIndices_V(label_), label_)
@@ -229,9 +229,9 @@ subroutine get_index(label_, TimeIn, Interpolate, value, iOutputError)
     if ((TimeIn - IndexTimes_TV(nIndices_V(label_), label_)) > &
         5.0*(IndexTimes_TV(2, label_) - IndexTimes_TV(1, label_))) then
       iOutputError = 3
-    end if
+    endif
     return
-  end if
+  endif
 
   iMin = 1
   iMax = nIndices_V(label_)
@@ -254,13 +254,13 @@ subroutine get_index(label_, TimeIn, Interpolate, value, iOutputError)
           iMax = iCenter
         else
           iMin = iCenter
-        end if
+        endif
 
-      end if
+      endif
 
-    end if
+    endif
 
-  end do
+  enddo
 
   if (Interpolate == 1) then
     value = Indices_TV(iMin, label_)
@@ -275,9 +275,9 @@ subroutine get_index(label_, TimeIn, Interpolate, value, iOutputError)
                (IndexTimes_TV(iMax, label_) - IndexTimes_TV(iMin, label_) + 1.0e-6)
       value = DtNorm*Indices_TV(iMax, label_) + &
               (1.0 - DtNorm)*Indices_TV(iMin, label_)
-    end if
+    endif
 
-  end if
+  endif
 
 end subroutine get_index
 
@@ -321,7 +321,7 @@ subroutine get_IMF_Bx_wotime(value, iOutputError)
   else
     value = SavedIndices_V(imf_bx_)
     iOutputError = SavedErrors_V(imf_bx_)
-  end if
+  endif
 
 end subroutine get_IMF_Bx_wotime
 
@@ -361,7 +361,7 @@ subroutine get_IMF_By_wotime(value, iOutputError)
   else
     value = SavedIndices_V(imf_by_)
     iOutputError = SavedErrors_V(imf_by_)
-  end if
+  endif
 
 end subroutine get_IMF_By_wotime
 
@@ -401,7 +401,7 @@ subroutine get_IMF_Bz_wotime(value, iOutputError)
   else
     value = SavedIndices_V(imf_bz_)
     iOutputError = SavedErrors_V(imf_bz_)
-  end if
+  endif
 
 end subroutine get_IMF_Bz_wotime
 
@@ -428,7 +428,7 @@ subroutine get_IMF_B_wtime(TimeIn, value, iOutputError)
     value = sqrt(value_x**2 + value_y**2 + value_z**2)
   else
     value = -1.0e32
-  end if
+  endif
 
 end subroutine get_IMF_B_wtime
 
@@ -455,13 +455,13 @@ subroutine get_IMF_B_wotime(value, iOutputError)
     value_y = SavedIndices_V(imf_by_)
     value_z = SavedIndices_V(imf_bz_)
     iOutputError = SavedErrors_V(imf_bx_)
-  end if
+  endif
 
   if (iOutputError == 0) then
     value = sqrt(value_x**2 + value_y**2 + value_z**2)
   else
     value = -1.0e32
-  end if
+  endif
 
 end subroutine get_IMF_B_wotime
 
@@ -509,7 +509,7 @@ subroutine get_SW_Vx_wotime(value, iOutputError)
   else
     value = SavedIndices_V(sw_vx_)
     iOutputError = SavedErrors_V(sw_vx_)
-  end if
+  endif
 
 end subroutine get_SW_Vx_wotime
 
@@ -553,7 +553,7 @@ subroutine get_SW_Vy_wotime(value, iOutputError)
   else
     value = SavedIndices_V(sw_vy_)
     iOutputError = SavedErrors_V(sw_vy_)
-  end if
+  endif
 
 end subroutine get_SW_Vy_wotime
 
@@ -597,7 +597,7 @@ subroutine get_SW_Vz_wotime(value, iOutputError)
   else
     value = SavedIndices_V(sw_vz_)
     iOutputError = SavedErrors_V(sw_vz_)
-  end if
+  endif
 
 end subroutine get_SW_Vz_wotime
 
@@ -641,7 +641,7 @@ subroutine get_SW_V_wtime(TimeIn, value, iOutputError)
     call get_index(sw_vy_, TimeIn, 0, value_y, iOutputError)
     call get_index(sw_vz_, TimeIn, 0, value_z, iOutputError)
     value = sqrt(value_x**2 + value_y**2 + value_z**2)
-  end if
+  endif
 
 end subroutine get_SW_V_wtime
 
@@ -687,9 +687,9 @@ subroutine get_SW_V_wotime(value, iOutputError)
       value_y = SavedIndices_V(sw_vy_)
       value_z = SavedIndices_V(sw_vz_)
       value = sqrt(value_x**2 + value_y**2 + value_z**2)
-    end if
+    endif
 
-  end if
+  endif
 
 end subroutine get_SW_V_wotime
 
@@ -731,7 +731,7 @@ subroutine get_SW_N_wotime(value, iOutputError)
   else
     value = SavedIndices_V(sw_n_)
     iOutputError = SavedErrors_V(sw_n_)
-  end if
+  endif
 
 end subroutine get_SW_N_wotime
 
@@ -775,7 +775,7 @@ subroutine get_f107_wotime(value, iOutputError)
   else
     value = SavedIndices_V(f107_)
     iOutputError = SavedErrors_V(f107_)
-  end if
+  endif
 
 end subroutine get_f107_wotime
 
@@ -817,7 +817,7 @@ subroutine get_f107a_wotime(value, iOutputError)
   else
     value = SavedIndices_V(f107a_)
     iOutputError = SavedErrors_V(f107a_)
-  end if
+  endif
 
 end subroutine get_f107a_wotime
 
@@ -859,7 +859,7 @@ subroutine get_hpi_wotime(value, iOutputError)
   else
     value = SavedIndices_V(hpi_)
     iOutputError = SavedErrors_V(hpi_)
-  end if
+  endif
 
 end subroutine get_hpi_wotime
 
@@ -897,7 +897,7 @@ subroutine get_hpi_calc_wotime(value, iOutputError)
   else
     value = SavedIndices_V(hpi_calc_)
     iOutputError = SavedErrors_V(hpi_calc_)
-  end if
+  endif
 
 end subroutine get_hpi_calc_wotime
 
@@ -918,8 +918,8 @@ subroutine get_hpi_norm_wtime(TimeIn, value, iOutputError)
     call get_index(hpi_, TimeIn, 0, value, iOutputError)
     if (iOutputError == 0) then
       value = 2.09*ALOG(value)*1.0475
-    end if
-  end if
+    endif
+  endif
 
 end subroutine get_hpi_norm_wtime
 
@@ -942,7 +942,7 @@ subroutine get_hpi_norm_wotime(value, iOutputError)
   else
     value = SavedIndices_V(hpi_norm_)
     iOutputError = SavedErrors_V(hpi_norm_)
-  end if
+  endif
 
 end subroutine get_hpi_norm_wotime
 
@@ -984,7 +984,7 @@ subroutine get_kp_wotime(value, iOutputError)
   else
     value = SavedIndices_V(kp_)
     iOutputError = SavedErrors_V(kp_)
-  end if
+  endif
 
 end subroutine get_kp_wotime
 
@@ -1026,7 +1026,7 @@ subroutine get_ap_wotime(value, iOutputError)
   else
     value = SavedIndices_V(ap_)
     iOutputError = SavedErrors_V(ap_)
-  end if
+  endif
 
 end subroutine get_ap_wotime
 
@@ -1068,7 +1068,7 @@ subroutine get_au_wotime(value, iOutputError)
   else
     value = SavedIndices_V(au_)
     iOutputError = SavedErrors_V(au_)
-  end if
+  endif
 
 end subroutine get_au_wotime
 
@@ -1106,7 +1106,7 @@ subroutine get_al_wotime(value, iOutputError)
   else
     value = SavedIndices_V(al_)
     iOutputError = SavedErrors_V(al_)
-  end if
+  endif
 
 end subroutine get_al_wotime
 
@@ -1144,7 +1144,7 @@ subroutine get_ae_wotime(value, iOutputError)
   else
     value = SavedIndices_V(ae_)
     iOutputError = SavedErrors_V(ae_)
-  end if
+  endif
 
 end subroutine get_ae_wotime
 
@@ -1185,7 +1185,7 @@ subroutine get_onsetut_wotime(value, iOutputError)
   else
     value = SavedIndices_V(onsetut_)
     iOutputError = SavedErrors_V(onsetut_)
-  end if
+  endif
 
 end subroutine get_onsetut_wotime
 
@@ -1223,7 +1223,7 @@ subroutine get_nAE_wotime(value, iOutputError)
   else
     value = SavedIndices_V(nAE_)
     iOutputError = SavedErrors_V(nAE_)
-  end if
+  endif
 
 end subroutine get_nAE_wotime
 
@@ -1265,7 +1265,7 @@ subroutine get_dst_wotime(value, iOutputError)
   else
     value = SavedIndices_V(dst_)
     iOutputError = SavedErrors_V(dst_)
-  end if
+  endif
 
 end subroutine get_dst_wotime
 
@@ -1303,7 +1303,7 @@ subroutine get_nDst_wotime(value, iOutputError)
   else
     value = SavedIndices_V(nDst_)
     iOutputError = SavedErrors_V(nDst_)
-  end if
+  endif
 
 end subroutine get_nDst_wotime
 
@@ -1345,7 +1345,7 @@ subroutine get_jh_calc_wotime(value, iOutputError)
   else
     value = SavedIndices_V(jh_calc_)
     iOutputError = SavedErrors_V(jh_calc_)
-  end if
+  endif
 
 end subroutine get_jh_calc_wotime
 

--- a/util/DATAREAD/srcIndices/indices_set_inputs.f90
+++ b/util/DATAREAD/srcIndices/indices_set_inputs.f90
@@ -24,31 +24,31 @@ subroutine indices_set_inputs(StringInputLines)
 
       if (index(StringLine, "#NGDC_INDICES") > 0) then
         call read_in_string(NameOfIndexFile)
-      end if
+      endif
 
       if (index(StringLine, "#NOAAHPI_INDICES") > 0) then
         call read_in_string(NameOfIndexFile)
-      end if
+      endif
 
       if (index(StringLine, "#MHD_INDICES") > 0) then
         call read_in_string(NameOfIndexFile)
-      end if
+      endif
 
       if (index(StringLine, "#END") > 0) then
         IsDone = .true.
-      end if
+      endif
 
       if (iLine >= MaxInputLines) then
         IsDone = .true.
-      end if
+      endif
 
     else
 
       iLine = iLine + 1
 
-    end if
+    endif
 
-  end do
+  enddo
 
 contains
 

--- a/util/DATAREAD/srcIndices/insert_into_indices_array.f90
+++ b/util/DATAREAD/srcIndices/insert_into_indices_array.f90
@@ -50,11 +50,11 @@ subroutine Insert_into_Indices_Array(array, label_)
       call time_int_to_real(itime, IndexTimes_TV(i, label_))
       Indices_TV(i, label_) = array(6, i)
 
-    end do
+    enddo
 
     nIndices_V(label_) = npts
 
-  end if
+  endif
 
   if (label_ == f107_) then
 
@@ -79,13 +79,13 @@ subroutine Insert_into_Indices_Array(array, label_)
         do while (iStart > 1 .and. &
                   IndexTimes_TV(i, f107_) - dt < IndexTimes_TV(iStart, f107_))
           iStart = iStart - 1
-        end do
+        enddo
 
         iEnd = i
         do while (iEnd < npts .and. &
                   IndexTimes_TV(i, f107_) + dt > IndexTimes_TV(iEnd, f107_))
           iEnd = iEnd + 1
-        end do
+        enddo
 
         nPtsSub = 0
         f107a = 0
@@ -94,18 +94,18 @@ subroutine Insert_into_Indices_Array(array, label_)
           f107a = f107a + Indices_TV(j, f107_)
           time_now = time_now + IndexTimes_TV(j, f107_)
           nPtsSub = nPtsSub + 1
-        end do
+        enddo
 
         IndexTimes_TV(i, f107a_) = time_now/nPtsSub
         Indices_TV(i, f107a_) = f107a/nPtsSub
 
-      end do
+      enddo
 
       nIndices_V(f107a_) = npts
 
-    end if
+    endif
 
-  end if
+  endif
 
 contains
 
@@ -133,13 +133,13 @@ contains
 
         do while (maxval(abs(array(:, Number_of_Points))) > 0)
           Number_of_Points = Number_of_Points + 1
-        end do
+        enddo
 
         Number_of_Points = Number_of_Points - 1
 
-      end if
+      endif
 
-    end if
+    endif
 
   end function Number_of_Points
 

--- a/util/DATAREAD/srcIndices/read_MHDIMF_indices.f90
+++ b/util/DATAREAD/srcIndices/read_MHDIMF_indices.f90
@@ -28,7 +28,7 @@ subroutine read_MHDIMF_Indices(iOutputError)
   if (ierror .ne. 0) then
     iOutputError = 1
     return
-  end if
+  endif
 
   done = .false.
 
@@ -45,7 +45,7 @@ subroutine read_MHDIMF_Indices(iOutputError)
     if (index(line, '#DELAY') > 0) then
       read(LunIndices_, *, iostat=iError) TimeDelay
       if (iError /= 0) done = .true.
-    end if
+    endif
 
     if (index(line, '#START') > 0) then
 
@@ -99,15 +99,15 @@ subroutine read_MHDIMF_Indices(iOutputError)
           iIMF = iIMF + 1
           if (abs(Indices_TV(iSW, sw_n_)) < 900.0) iSW = iSW + 1
 
-        end if
+        endif
 
-      end do
+      enddo
 
       done = done_inner
 
-    end if
+    endif
 
-  end do
+  enddo
 
   close(LunIndices_)
 

--- a/util/DATAREAD/srcIndices/read_NGDC_indices.f90
+++ b/util/DATAREAD/srcIndices/read_NGDC_indices.f90
@@ -37,7 +37,7 @@ subroutine read_NGDC_Indices(iOutputError)
   if (ierror .ne. 0) then
     iOutputError = 1
     return
-  end if
+  endif
 
   done = .false.
 
@@ -53,76 +53,76 @@ subroutine read_NGDC_Indices(iOutputError)
     if (index(line, '#Element: dst') > 0) then
       call read_values
       call Insert_into_Indices_Array(tmp, dst_)
-    end if
+    endif
 
     if (index(line, '#Element: kp') > 0) then
       call read_values
       call Insert_into_Indices_Array(tmp, kp_)
-    end if
+    endif
 
     if (index(line, '#Element: ap') > 0) then
       call read_values
       call Insert_into_Indices_Array(tmp, ap_)
-    end if
+    endif
 
     if (index(line, '#Element: bx') > 0) then
       read(LunIndices_, '(a)', iostat=ierror) line
       if (index(line, '#Table: IMFMin') > 0) then
         call read_values
         call Insert_into_Indices_Array(tmp, imf_bx_)
-      end if
-    end if
+      endif
+    endif
 
     if (index(line, '#Element: by') > 0) then
       read(LunIndices_, '(a)', iostat=ierror) line
       if (index(line, '#Table: IMFMin') > 0) then
         call read_values
         call Insert_into_Indices_Array(tmp, imf_by_)
-      end if
-    end if
+      endif
+    endif
 
     if (index(line, '#Element: bz') > 0) then
       read(LunIndices_, '(a)', iostat=ierror) line
       if (index(line, '#Table: IMFMin') > 0) then
         call read_values
         call Insert_into_Indices_Array(tmp, imf_bz_)
-      end if
-    end if
+      endif
+    endif
 
     if (index(line, '#Element: flow') > 0) then
       call read_values
       call Insert_into_Indices_Array(tmp, sw_v_)
-    end if
+    endif
 
     if (index(line, '#Element: swVelX') > 0) then
       call read_values
       call Insert_into_Indices_Array(tmp, sw_vx_)
-    end if
+    endif
 
     if (index(line, '#Element: swVelY') > 0) then
       call read_values
       call Insert_into_Indices_Array(tmp, sw_vy_)
-    end if
+    endif
 
     if (index(line, '#Element: swVelZ') > 0) then
       call read_values
       call Insert_into_Indices_Array(tmp, sw_vz_)
-    end if
+    endif
 
     if (index(line, '#Element: observed') > 0) then
       call read_values
       call Insert_into_Indices_Array(tmp, f107_)
-    end if
+    endif
 
     if (index(line, '#Element: adjusted') > 0) then
       call read_values
       call Insert_into_Indices_Array(tmp, f107_)
-    end if
+    endif
 
     if (index(line, '#Element: flux') > 0 .or. index(line, '#Table: Flux') > 0) then
       call read_values
       call Insert_into_Indices_Array(tmp, f107_)
-    end if
+    endif
 
     ! This has to be before the DMSP stuff because of the
     ! extra N and S on the end of the Element line.
@@ -134,7 +134,7 @@ subroutine read_NGDC_Indices(iOutputError)
       call read_values
       call merge_hpi_data
 !           endif
-    end if
+    endif
 !     else
 !        if(index(line,'#Element: power')>0)then
 !           read(LunIndices_,'(a)', iostat = ierror ) line
@@ -153,7 +153,7 @@ subroutine read_NGDC_Indices(iOutputError)
 !        endif
 !     endif
 
-  end do
+  enddo
 
   close(LunIndices_)
 
@@ -165,7 +165,7 @@ subroutine read_NGDC_Indices(iOutputError)
       call time_real_to_int(ut_keep(i), itime)
       tmp(1:5, i) = itime(1:5)
       tmp(6, i) = data_keep(i)
-    end do
+    enddo
 
     call Insert_into_Indices_Array(tmp, hpi_)
 
@@ -178,10 +178,10 @@ subroutine read_NGDC_Indices(iOutputError)
       if (Indices_TV(i, hpi_) > 0) then
         Indices_TV(i, hpi_norm_) = &
           2.09*ALOG(Indices_TV(i, hpi_))*1.0475
-      end if
-    end do
+      endif
+    enddo
 
-  end if
+  endif
 
   if (Input_Coor_System == GSE_) then
 
@@ -195,9 +195,9 @@ subroutine read_NGDC_Indices(iOutputError)
       Indices_TV(i, imf_bx_:imf_bz_) = &
         matmul(GsmGse_DD, Indices_TV(i, imf_bx_:imf_bz_))
 
-    end do
+    enddo
 
-  end if
+  endif
 
 contains
 
@@ -222,7 +222,7 @@ contains
 
       if (index(line, 'GSE') > 0) Input_Coor_System = GSE_
 
-    end do
+    enddo
 
     missingPlusTol = missing + abs(missing)*0.01
     missingMinusTol = missing - abs(missing)*0.01
@@ -245,14 +245,14 @@ contains
             i = i + 1
           else
             tmp(1:6, i) = 0.0
-          end if
-        end if
+          endif
+        endif
 
-      end do
+      enddo
 
       npts = i - 1
 
-    end if
+    endif
 
   end subroutine read_values
 
@@ -266,7 +266,7 @@ contains
       itime(1:5) = tmp(1:5, i)
       call time_int_to_real(itime, ut_new(i))
       data_new(i) = tmp(6, i)
-    end do
+    enddo
 
     if (npts_hpi == 0) then
       npts_hpi = npts
@@ -308,15 +308,15 @@ contains
               data_keep(k) = data_new(i)
               k = k + 1
               i = i + 1
-            end if
-          end if
-        end if
+            endif
+          endif
+        endif
 
-      end do
+      enddo
 
       npts_hpi = npts_hpi + npts
 
-    end if
+    endif
 
   end subroutine merge_hpi_data
 

--- a/util/DATAREAD/srcIndices/read_NOAAHPI_indices.f90
+++ b/util/DATAREAD/srcIndices/read_NOAAHPI_indices.f90
@@ -35,7 +35,7 @@ subroutine read_NOAAHPI_Indices(iOutputError)
   if (ierror .ne. 0) then
     iOutputError = 1
     return
-  end if
+  endif
 
   done = .false.
 
@@ -52,9 +52,9 @@ subroutine read_NOAAHPI_Indices(iOutputError)
 
       call read_values
       call merge_hpi_data
-    end if
+    endif
 
-  end do
+  enddo
 
   close(LunIndices_)
 
@@ -66,7 +66,7 @@ subroutine read_NOAAHPI_Indices(iOutputError)
       call time_real_to_int(ut_keep(i), itime)
       tmp(1:5, i) = itime(1:5)
       tmp(6, i) = data_keep(i)
-    end do
+    enddo
 
     call Insert_into_Indices_Array(tmp, hpi_)
 
@@ -79,10 +79,10 @@ subroutine read_NOAAHPI_Indices(iOutputError)
       if (Indices_TV(i, hpi_) > 0) then
         Indices_TV(i, hpi_norm_) = &
           2.09*ALOG(Indices_TV(i, hpi_))*1.0475
-      end if
-    end do
+      endif
+    enddo
 
-  end if
+  endif
 
 contains
 
@@ -116,7 +116,7 @@ contains
           read(LunIndices_, '(a10,f3.0,f2.0,f2.0,f8.1)', iostat=ierror) &
             line, tmp(3:6, i)
           if (tmp(3, i) < 1) iError = 1
-        end if
+        endif
 
         if (datatype .eq. 2) then
           ! NEW NOAA HPI FILES
@@ -124,19 +124,19 @@ contains
                iostat=ierror) &
             tmp(1, i), line, tmp(2, i), line, tmp(3, i), line, tmp(4, i), line, tmp(5, i), line, tmp(6, i), &
             line, tmp(6, i)
-        end if
+        endif
 
         if (ierror /= 0) then
           done_inner = .true.
         else
           i = i + 1
-        end if
+        endif
 
-      end do
+      enddo
 
       npts = i - 1
 
-    end if
+    endif
 
   end subroutine read_values
 
@@ -150,7 +150,7 @@ contains
       itime(1:5) = tmp(1:5, i)
       call time_int_to_real(itime, ut_new(i))
       data_new(i) = tmp(6, i)
-    end do
+    enddo
 
     if (npts_hpi == 0) then
       npts_hpi = npts
@@ -192,15 +192,15 @@ contains
               data_keep(k) = data_new(i)
               k = k + 1
               i = i + 1
-            end if
-          end if
-        end if
+            endif
+          endif
+        endif
 
-      end do
+      enddo
 
       npts_hpi = npts_hpi + npts
 
-    end if
+    endif
 
   end subroutine merge_hpi_data
 

--- a/util/DATAREAD/srcIndices/read_SWPC_indices.f90
+++ b/util/DATAREAD/srcIndices/read_SWPC_indices.f90
@@ -28,7 +28,7 @@ subroutine read_SWPC_Indices(iOutputError)
   if (ierror .ne. 0) then
     iOutputError = 1
     return
-  end if
+  endif
 
   done = .false.
 
@@ -78,15 +78,15 @@ subroutine read_SWPC_Indices(iOutputError)
 
           iIMF = iIMF + 1
 
-        end if
+        endif
 
-      end do
+      enddo
 
       done = done_inner
 
-    end if
+    endif
 
-  end do
+  enddo
 
   close(LunIndices_)
 
@@ -95,7 +95,7 @@ subroutine read_SWPC_Indices(iOutputError)
   if (ierror .ne. 0) then
     iOutputError = 1
     return
-  end if
+  endif
 
   done = .false.
 
@@ -152,15 +152,15 @@ subroutine read_SWPC_Indices(iOutputError)
           iSW = iSW + 1
           if (abs(Indices_TV(iSW, sw_n_)) < 900.0) iSW = iSW + 1
 
-        end if
+        endif
 
-      end do
+      enddo
 
       done = done_inner
 
-    end if
+    endif
 
-  end do
+  enddo
 
   close(LunIndices_)
 

--- a/util/EMPIRICAL/srcEE/EEE_ModArch.f90
+++ b/util/EMPIRICAL/srcEE/EEE_ModArch.f90
@@ -49,10 +49,10 @@ contains
 
     if (rDipole >= 1.0 .or. rDipole < 0.0) then
       call CON_stop('rDipole in #ARCH should be inside the Sun')
-    end if
+    endif
     if (nDipole < 1) then
       call CON_stop('nDipole need to be larger than 0 in #ARCH')
-    end if
+    endif
 
   end subroutine set_parameters_arch
 
@@ -89,13 +89,13 @@ contains
         xDip_DI(z_, iDipole) = 0.0
 
         Bdp = DipoleStrengthSi*Si2No_V(UnitB_)
-      end do
+      enddo
 
       ! Orientation rotates clockwise
       Rotate_DD = matmul(rot_matrix_x(OrientationCme*cDegToRad), &
                          rot_matrix_y(LatitudeCme*cDegToRad))
       Rotate_DD = matmul(Rotate_DD, rot_matrix_z(-LongitudeCme*cDegToRad))
-    end if
+    endif
 
     x_D = matmul(Rotate_DD, x0_D)
 
@@ -113,7 +113,7 @@ contains
       Dp = dot_product(Bdp_D, xShift_D)*3.0*r2_inv
 
       B_D = B_D + (Dp*xShift_D - Bdp_D)*r3_inv
-    end do
+    enddo
 
     B0_D = matmul(B_D, Rotate_DD)
 

--- a/util/EMPIRICAL/srcEE/EEE_ModCms.f90
+++ b/util/EMPIRICAL/srcEE/EEE_ModCms.f90
@@ -116,10 +116,10 @@ contains
                                   maxval(CmsData(iLevel)%CoordCms2_I), &
                                   maxval(CmsData(iLevel)%CoordCms3_I)/)
 
-      end do
+      enddo
 
       IsFirst = .false.
-    end if
+    endif
 
     call xyz_to_sph(x_D, xSph_D)
 
@@ -144,7 +144,7 @@ contains
         xCms_D(1) = xCms_D(1) + cTwoPi
       else
         CYCLE
-      end if
+      endif
 
       ! Obtain magnetic at x_D via trilinear interpolation of
       ! CMS domin level
@@ -177,7 +177,7 @@ contains
       B_D = B_D*No2Si_V(UnitB_)*RescaleB
 
       EXIT
-    end do
+    enddo
 
   end subroutine get_cms
 

--- a/util/EMPIRICAL/srcEE/EEE_ModGL98.f90
+++ b/util/EMPIRICAL/srcEE/EEE_ModGL98.f90
@@ -151,8 +151,8 @@ contains
         write(*, *) prefix, 'LatitudeCme = ', LatitudeCme, '[degrees]'
         write(*, *) prefix, 'OrientationCme = ', OrientationCme, '[degrees]'
         write(*, *) prefix
-      end if
-    end if
+      endif
+    endif
 
     a1scl = cme_a1*Io2No_V(UnitB_)
     rho1scl = cme_rho1*Si2No_V(UnitRho_)
@@ -183,7 +183,7 @@ contains
       x = delta*sin_theta*cos_phi
       y = delta*sin_theta*sin_phi
       z = delta*cos_theta
-    end if
+    endif
     !\
     ! CALCULATE CELL CENTER FOR TRANSFORMED SPHERICAL COORDINATES
     ! stretching transformation of variables r --> r - a
@@ -220,7 +220,7 @@ contains
       y_2 = delta*sin_theta2*cos_phi2
       z_2 = delta*sin_theta2*sin_phi2
       x_2 = delta*cos_theta2
-    end if
+    endif
     alpha0 = 5.763854/cme_r0
     ga0r0 = sin(alpha0*cme_r0)/(alpha0*cme_r0) - cos(alpha0*cme_r0)
     A2 = (4.0*cPi*a1scl/alpha0**2)*((cme_r0**2/ga0r0) &
@@ -372,7 +372,7 @@ contains
 
     else
       B_GL98_D = 0.0; rho_GL98 = 0.0; p_GL98 = 0.0
-    end if
+    endif
 
   end subroutine get_GL98_fluxrope
 
@@ -391,7 +391,7 @@ contains
       Rho = Rho
     else
       Rho = ModulationRho*Rho
-    end if
+    endif
 
     !\
     ! Add just `ModulationP' times of the CME pressure
@@ -401,7 +401,7 @@ contains
       p = p
     else
       p = ModulationP*p
-    end if
+    endif
 
   end subroutine adjust_GL98_fluxrope
 

--- a/util/EMPIRICAL/srcEE/EEE_ModGetB0.f90
+++ b/util/EMPIRICAL/srcEE/EEE_ModGetB0.f90
@@ -31,7 +31,7 @@ contains
       call get_arch(x_D, B_D)
 
       B0_D = B0_D + B_D
-    end if
+    endif
 
   end subroutine EEE_get_B0
 

--- a/util/EMPIRICAL/srcEE/EEE_ModMain.f90
+++ b/util/EMPIRICAL/srcEE/EEE_ModMain.f90
@@ -139,7 +139,7 @@ contains
         case default
           call CON_stop(NameSub//': invalid value for TypeCme='//TypeCme)
         end select
-      end if
+      endif
 
       ! The remaining commands are preserved for backwards compatibility
       ! and possibly for expert use (more options than #CME command)
@@ -195,19 +195,19 @@ contains
       if (.not. DoBqField) U1_D = 0.0
 
       Rho = Rho + Rho1; U_D = U_D + U1_D; B_D = B_D + B1_D
-    end if
+    endif
 
     if (UseGL) then
       ! Add Gibson & Low (GL98) flux rope
       call get_GL98_fluxrope(x_D, Rho1, p1, B1_D)
       B_D = B_D + B1_D
-    end if
+    endif
 
     if (UseShearFlow) then
       call get_shearflow(x_D, Time, U1_D, iteration_number)
 
       U_D = U_D + U1_D
-    end if
+    endif
 
     if (UseCms) call get_cms(x_D, B_D)
 
@@ -241,14 +241,14 @@ contains
       call get_transformed_TD99fluxrope(x_D, B1_D, &
                                         U1_D, n_step, iteration_number, Rho1)
       Rho = Rho + Rho1; U_D = U_D + U1_D; B_D = B_D + B1_D
-    end if
+    endif
 
     if (UseGL) then
       ! Add Gibson & Low (GL98) flux rope
       call get_GL98_fluxrope(x_D, Rho1, p1, B1_D)
       call adjust_GL98_fluxrope(Rho1, p1)
       Rho = Rho + Rho1; B_D = B_D + B1_D; p = p + p1
-    end if
+    endif
 
     if (UseCms) call get_cms(x_D, B_D)
 

--- a/util/EMPIRICAL/srcEE/EEE_ModShearFlow.f90
+++ b/util/EMPIRICAL/srcEE/EEE_ModShearFlow.f90
@@ -96,7 +96,7 @@ contains
 
       FlowWidthAngle = FlowWidthAngle*cDegToRad
       MaxBr = abs(MaxBrActiveRegion)*Si2No_V(UnitB_)
-    end if
+    endif
 
     if (Time < StartTime .or. Time > StopTime) then
       U_D = 0.0
@@ -106,8 +106,8 @@ contains
         TimeProfile = (StopTime - Time)/RampDownTime
       else
         TimeProfile = min((Time - StartTime)/RampUpTime, 1.0)
-      end if
-    end if
+      endif
+    endif
     !!! TimeProfile = 1.0
 
     R = sqrt(sum(x_D**2))
@@ -142,7 +142,7 @@ contains
       else
         UTheta = 1.0/FullBr &
                  *(ShearProfileR - ShearProfileL)/(R*SinTheta*dPhi)
-      end if
+      endif
 
       ShearProfileL = shear_profile(R, Theta - 0.5*dTheta, Phi, Time, FullBrL)
       ShearProfileR = shear_profile(R, Theta + 0.5*dTheta, Phi, Time, FullBrR)
@@ -152,8 +152,8 @@ contains
       else
         UPhi = -1.0/FullBr &
                *(ShearProfileR - ShearProfileL)/(R*dTheta)
-      end if
-    end if
+      endif
+    endif
 
     U_D(1) = UTheta*CosTheta*CosPhi - UPhi*SinPhi
     U_D(2) = UTheta*CosTheta*SinPhi + UPhi*CosPhi
@@ -163,7 +163,7 @@ contains
       U_D = FlowAmplitude*U_D
     else
       U_D = FlowAmplitude*U_D*TimeProfile
-    end if
+    endif
 
   end subroutine get_shearflow
 

--- a/util/EMPIRICAL/srcEE/EEE_ModTD99.f90
+++ b/util/EMPIRICAL/srcEE/EEE_ModTD99.f90
@@ -135,7 +135,7 @@ contains
     if (DoFirstCallTD99) then
       call init_TD99_parameters
       DoFirstCallTD99 = .false.
-    end if
+    endif
     if (present(Time) .and. UseVariedCurrent) &
       Itube_TD99 = varied_current(Time)
 
@@ -148,7 +148,7 @@ contains
                        (Time .lt. CurrentRiseTime))
     else
       DoMaintainEpot = .false.
-    end if
+    endif
 
     ! Compute the flux rope, and transform coordinates and vectors to
     ! position the flux rope in the desired way::
@@ -163,11 +163,11 @@ contains
         B1FRope_D = B1FRope_D + B1FRopeTemp_D
         Itube_TD99 = Itemp
         atube_TD99 = atemp
-      end if
+      endif
     else
       B1FRope_D = 0.0
       RhoFRope = 0.0
-    end if
+    endif
     U1VorC_D = 0.0
     if (DoBqField) then
       if (present(Time)) then
@@ -176,9 +176,9 @@ contains
       else
         call compute_TD99_BqField(R1Face_D, B1qField_D, &
                                   U1VorC_D, DoMaintainEpot, n_step, Iteration_Number)
-      end if
+      endif
       B1FRope_D = B1FRope_D + B1qField_D
-    end if
+    endif
     BFRope_D = matmul(B1FRope_D, RotateTD99_DD)
     UVorC_D = matmul(U1VorC_D, RotateTD99_DD)
 
@@ -281,8 +281,8 @@ contains
         write(*, *) prefix, 'CurrentStartTime = ', CurrentStartTime, '[s]'
         write(*, *) prefix, 'CurrentRiseTime  = ', CurrentRiseTime, '[s]'
         write(*, *) prefix
-      end if
-    end if
+      endif
+    endif
     if (DoEquilItube) then
 
       ! Compute the equilibrium toroidal current, Itube_TD99, based
@@ -294,7 +294,7 @@ contains
                    /(alog(8.0*Rtube_TD99/atube_TD99) &
                      - 1.5 + Li_TD99/2.0)                           ! in [-]
       WFRope = 0.5*LInduct*(ItubeDim)**2*1.0e7      ! in [ergs]
-    end if
+    endif
     if (DoEquilItube .and. iProc == 0) then
       write(*, *) prefix, 'The strapping field, Bq, is added and the EQUILIBRIUM value'
       write(*, *) prefix, 'of Itube_TD99 is computed!!!'
@@ -302,7 +302,7 @@ contains
       write(*, *) prefix, 'The value of Itube_TD99 is reset to :: ', Itube_TD99
       write(*, *) prefix, 'The free energy of the flux rope is :: ', WFRope, 'Ergs.'
       write(*, *) prefix
-    end if
+    endif
 
   end subroutine init_TD99_parameters
 
@@ -344,7 +344,7 @@ contains
       RMins_D(x_) = RFace_D(x_) + L_TD99
       RPlus_D(y_) = RFace_D(y_)
       RMins_D(y_) = RPlus_D(y_)
-    end if
+    endif
     RPlus_D(z_) = RFace_D(z_) + d_TD99 - 1.0
     RMins_D(z_) = RPlus_D(z_)
     R2Plus = sqrt(dot_product(RPlus_D, RPlus_D))
@@ -360,7 +360,7 @@ contains
       nStepSaved = n_step
       BqZMaxSaved = BqZMax
       BqZMax = 0.0
-    end if
+    endif
     if (iteration_number == 1) &
       BqZMaxSaved = BqZMax0/No2Io_V(UnitB_)
     BqZMax = max(abs(BqField_D(z_)), BqZMax)
@@ -388,7 +388,7 @@ contains
                      *AlphaRamp*BqZFunction*BqZOverBqZ0*exp(-BqZFunction)
       else
         GradPsiC_D = 0.0
-      end if
+      endif
 
       ! Compute the potential electric field on the solar surface to
       ! be applied at one of the spots -- EpotC_D(x_:z_).
@@ -421,13 +421,13 @@ contains
         UTranC_D(z_) = 0.0
       else
         UTranC_D = 0.0
-      end if
+      endif
       ! Add the translational velocity, UTranC_D, to UVorC_D::
       UVorC_D = UVorC_D + UTranC_D
     else
       EpotC_D = 0.0
       UVorC_D = 0.0
-    end if
+    endif
 
   end subroutine compute_TD99_BqField
 
@@ -494,7 +494,7 @@ contains
     else
       CHIin_TD99 = 0.0
       CHIex_TD99 = 1.0
-    end if
+    endif
 
     ! Add the prominence material inside the flux rope, assuming that the
     ! total amount mass is 10^13kg, and that the desnity scale-height is
@@ -658,7 +658,7 @@ contains
         DESIRED_CEI_ACCURACY = 1.0E-15
       else
         DESIRED_CEI_ACCURACY = 1.0E-7
-      end if
+      endif
 
       ! Initialize some variables::
 
@@ -678,7 +678,7 @@ contains
           K_ell_sum_old = K_ell_sum
           K_ell_sum = K_ell_sum + (TwoN_1FactOverNFact/2.0**iN)**2 &
                       *pK**(2*iN)*cPi/2.0
-        end do
+        enddo
       else
         if (abs(pK) .lt. pK_LIMIT2) then
           K_ell_sum_old = 0.0
@@ -690,7 +690,7 @@ contains
             K_ell_sum_old = K_ell_sum
             K_ell_sum = K_ell_sum + (TwoN_1FactOverNFact/2.0**iN)**2 &
                         *((1.0 - pK1)/(1.0 + pK1))**(2*iN)*cPi/(1.0 + pK1)
-          end do
+          enddo
         else
           K_ell_sum = alog(4.0/pK1) + (alog(4.0/pK1) - 1.0)*pK1**2/4.0 &
                       + (alog(4.0/pK1) - 1.0 - 1.0/3.0/2.0)*pK1**4*(3.0/2.0/4.0)**2 &
@@ -698,8 +698,8 @@ contains
                       *pK1**6*(3.0*5.0/2.0/4.0/6.0)**2 &
                       + (alog(4.0/pK1) - 1.0 - 1.0/3.0/2.0 - 1.0/5.0/3.0 &
                          - 1.0/7.0/4.0)*pK1**8*(3.0*5.0*7.0/2.0/4.0/6.0/8.0)**2
-        end if
-      end if
+        endif
+      endif
       K_elliptic = K_ell_sum
 
     end subroutine calc_elliptic_int_1kind
@@ -731,7 +731,7 @@ contains
         DESIRED_CEI_ACCURACY = 1.0E-15
       else
         DESIRED_CEI_ACCURACY = 1.0E-7
-      end if
+      endif
 
       ! Initialize some variables::
 
@@ -752,7 +752,7 @@ contains
           E_ell_sum_old = E_ell_sum
           E_ell_sum = E_ell_sum - (TwoN_1FactOverNFact/2.0**iN)**2 &
                       /(2.0*iN - 1.0)*pK**(2*iN)*cPi/2.0
-        end do
+        enddo
       else
         if (abs(pK) .lt. pK_LIMIT2) then
           E_ell_sum_old = 0.0
@@ -764,7 +764,7 @@ contains
             E_ell_sum_old = E_ell_sum
             E_ell_sum = E_ell_sum + (TwoN_3FactOverNFact/2.0**iN)**2 &
                         *((1.0 - pK1)/(1.0 + pK1))**(2*iN)*cPi*(1.0 + pK1)/4.0
-          end do
+          enddo
         else
           E_ell_sum = 1.0 + (alog(4.0/pK1) - 1.0/2.0)*pK1**2/2.0 &
                       + (alog(4.0/pK1) - 1.0 - 1.0/3.0/4.0)*pK1**4*(3.0/4.0/4.0) &
@@ -772,8 +772,8 @@ contains
                       *pK1**6*(3.0/2.0/4.0)**2*5.0/6.0 &
                       + (alog(4.0/pK1) - 1.0 - 1.0/3.0/2.0 - 1.0/5.0/3.0 &
                          - 1.0/7.0/8.0)*pK1**8*(3.0*5.0/2.0/4.0/6.0)**2*7.0/8.0
-        end if
-      end if
+        endif
+      endif
       E_elliptic = E_ell_sum
 
     end subroutine calc_elliptic_int_2kind

--- a/util/EMPIRICAL/srcIE/AMIE_Library.f90
+++ b/util/EMPIRICAL/srcIE/AMIE_Library.f90
@@ -58,9 +58,9 @@ subroutine AMIE_GetLats(LatsOut)
   do i = 1, AMIE_nMLTs
     do j = AMIE_nLats, 1, -1
       LatsOut(i, j, AMIE_North_) = AMIE_Lats(AMIE_nLats - j + 1)
-    end do
+    enddo
     LatsOut(i, 1:AMIE_nLats, AMIE_South_) = -AMIE_Lats(1:AMIE_nLats)
-  end do
+  enddo
 
 end subroutine AMIE_GetLats
 
@@ -77,7 +77,7 @@ subroutine AMIE_GetMLTs(MLTsOut)
   do j = 1, AMIE_nLats
     MLTsOut(1:AMIE_nMLTs, j, 1) = AMIE_MLTs(1:AMIE_nMLTs)
     MLTsOut(1:AMIE_nMLTs, j, 2) = AMIE_MLTs(1:AMIE_nMLTs)
-  end do
+  enddo
 
 end subroutine AMIE_GetMLTs
 
@@ -98,7 +98,7 @@ subroutine report_error_and_crash(iError, StringSource)
     write(*, *) "Source : ", StringSource
     write(*, *) cErrorCodes(iError)
     isOk = .false.
-  end if
+  endif
 
 end subroutine report_error_and_crash
 
@@ -206,7 +206,7 @@ subroutine AMIE_GetIonEFlux_New(TimeIn, Method, IonEFluxOut, iError)
     IonEFluxOut = AMIE_Interpolated
   else
     IonEFluxOut = rDummyeFlux
-  end if
+  endif
 
 end subroutine AMIE_GetIonEFlux_New
 
@@ -230,7 +230,7 @@ subroutine AMIE_GetIonAveE_New(TimeIn, Method, IonAveEOut, iError)
     IonAveEOut = AMIE_Interpolated
   else
     IonAveEOut = rDummyIonAveE
-  end if
+  endif
 
 end subroutine AMIE_GetIonAveE_New
 
@@ -254,7 +254,7 @@ subroutine AMIE_GetEleWaveEflux_New(TimeIn, Method, EleWaveEfluxOut, iError)
     EleWaveEfluxOut = AMIE_Interpolated
   else
     EleWaveEfluxOut = rDummyeFlux
-  end if
+  endif
 
 end subroutine AMIE_GetEleWaveEflux_New
 
@@ -278,7 +278,7 @@ subroutine AMIE_GetEleWaveAveE_New(TimeIn, Method, EleWaveAveEOut, iError)
     EleWaveAveEOut = AMIE_Interpolated
   else
     EleWaveAveEOut = rDummyAveE
-  end if
+  endif
 
 end subroutine AMIE_GetEleWaveAveE_New
 
@@ -302,7 +302,7 @@ subroutine AMIE_GetEleMonoEflux_New(TimeIn, Method, EleMonoEfluxOut, iError)
     EleMonoEfluxOut = AMIE_Interpolated
   else
     EleMonoEfluxOut = rDummyeFlux
-  end if
+  endif
 
 end subroutine AMIE_GetEleMonoEflux_New
 
@@ -326,7 +326,7 @@ subroutine AMIE_GetEleMonoAveE_New(TimeIn, Method, EleMonoAveEOut, iError)
     EleMonoAveEOut = AMIE_Interpolated
   else
     EleMonoAveEOut = rDummyAveE
-  end if
+  endif
 
 end subroutine AMIE_GetEleMonoAveE_New
 
@@ -363,9 +363,9 @@ subroutine AMIE_GetValue_New2(iVarIn, TimeIn, Method, iError)
       if ((iTime == AMIE_nTimes) .and. (.not. IsDone)) then
         iTime = iTime + 1
         IsDone = .true.
-      end if
+      endif
       iTime = iTime + 1
-    end do
+    enddo
 
     if (iTime <= AMIE_nTimes + 1) then
 
@@ -381,8 +381,8 @@ subroutine AMIE_GetValue_New2(iVarIn, TimeIn, Method, iError)
           AMIE_Interpolated = -1.0e32
           iError = ecBeforeStartTime_
           return
-        end if
-      end if
+        endif
+      endif
     else
       dT = AMIE_Time(2, iBLK) - AMIE_Time(1, iBLK)
 
@@ -395,8 +395,8 @@ subroutine AMIE_GetValue_New2(iVarIn, TimeIn, Method, iError)
         AMIE_Interpolated = -1.0e32
         iError = ecAfterEndTime_
         return
-      end if
-    end if
+      endif
+    endif
 
     if (Method == AMIE_After_ .or. &
         Method == AMIE_Closest_) then
@@ -406,8 +406,8 @@ subroutine AMIE_GetValue_New2(iVarIn, TimeIn, Method, iError)
           if (abs(TimeIn - AMIE_Time(iTime, iBLK)) > &
               abs(TimeIn - AMIE_Time(iTime - 1, iBLK))) &
             iTime = iTime - 1
-        end if
-      end if
+        endif
+      endif
 
       if (iBLK == AMIE_South_) then
         AMIE_Interpolated(1:AMIE_nMLTs, 1:AMIE_nLats, iBLK) = &
@@ -417,10 +417,10 @@ subroutine AMIE_GetValue_New2(iVarIn, TimeIn, Method, iError)
         do iLat = AMIE_nLats, 1, -1
           AMIE_Interpolated(1:AMIE_nMLTs, iLat, iBLK) = &
             AMIE_Storage(iVarIn, 1:AMIE_nMLTs, AMIE_nLats - iLat + 1, iTime, iBLK)
-        end do
-      end if
+        enddo
+      endif
 
-    end if
+    endif
 
     if (Method == AMIE_Interpolate_) then
       ! This will do extrapolation if it is before the first time
@@ -442,11 +442,11 @@ subroutine AMIE_GetValue_New2(iVarIn, TimeIn, Method, iError)
           AMIE_Interpolated(1:AMIE_nMLTs, iLat, iBLK) = &
             (1.0 - dt)*AMIE_Storage(iVarIn, 1:AMIE_nMLTs, iL, iTime, iBLK) + &
             dt*AMIE_Storage(iVarIn, 1:AMIE_nMLTs, iL, iTime - 1, iBLK)
-        end do
-      end if
-    end if
+        enddo
+      endif
+    endif
 
-  end do
+  enddo
 
 end subroutine AMIE_GetValue_New2
 
@@ -476,21 +476,21 @@ subroutine get_AMIE_values(rtime)
   else
     EIEr3_HaveIonAveE = EIE_fill_IonAveE
     EIEr3_HaveIonEFlux = EIE_fill_eFlux
-  end if
+  endif
   if (useWave) then
     call AMIE_GetEleWaveAveE_New(rtime, EIE_Closest_, EIEr3_HaveWaveAveE, iError)
     call AMIE_GetEleWaveEFlux_New(rtime, EIE_Closest_, EIEr3_HaveWaveEFlux, iError)
   else
     EIEr3_HaveWaveAveE = EIE_fill_AveE
     EIEr3_HaveWaveEFlux = EIE_fill_eFlux
-  end if
+  endif
   if (useMono) then
     call AMIE_GetEleMonoAveE_New(rtime, EIE_Closest_, EIEr3_HaveMonoAveE, iError)
     call AMIE_GetEleMonoEFlux_New(rtime, EIE_Closest_, EIEr3_HaveMonoEFlux, iError)
   else
     EIEr3_HaveMonoAveE = EIE_fill_AveE
     EIEr3_HaveMonoEFlux = EIE_fill_eFlux
-  end if
+  endif
 
 end subroutine get_AMIE_values
 

--- a/util/EMPIRICAL/srcIE/ED_Interface.f90
+++ b/util/EMPIRICAL/srcIE/ED_Interface.f90
@@ -57,7 +57,7 @@ subroutine ED_Get_Grid(grid, PressureCoordinates, iError)
 
       grid(i) = R_EDEP_ALT_VALUE(I, 2)
 
-    end do
+    enddo
 
   else
 
@@ -67,9 +67,9 @@ subroutine ED_Get_Grid(grid, PressureCoordinates, iError)
 
       grid(i) = R_EDEP_ALT_VALUE(I, 4)*100.0
 
-    end do
+    enddo
 
-  end if
+  endif
 
 end subroutine ED_Get_Grid
 
@@ -133,6 +133,6 @@ subroutine ED_Get_Energies(energies)
 
   do i = 1, spectra_levels
     energies(spectra_levels - (i - 1)) = 10.0**(logmin + (i - 1)*de)
-  end do
+  enddo
 
 end subroutine ED_Get_Energies

--- a/util/EMPIRICAL/srcIE/ED_ReadIonHeat.f90
+++ b/util/EMPIRICAL/srcIE/ED_ReadIonHeat.f90
@@ -28,7 +28,7 @@ subroutine ReadIonHeat(filename, IsIonizationFile)
   ! skip the first 3 lines
   do i = 1, 3
     read(UnitTmp_, '(a120)') fileline
-  end do
+  enddo
 
   ! number of altitude
   read(UnitTmp_, *) NAlt
@@ -38,13 +38,13 @@ subroutine ReadIonHeat(filename, IsIonizationFile)
     ALLOCATE(glat(NLat))
     ALLOCATE(alt(NAlt))
     IsFirstTime = .false.
-  end if
+  endif
 
   if (IsIonizationFile) then
     ALLOCATE(IonizationRate(NLng, NLat, NAlt))
   else
     ALLOCATE(HeatingRate(NLng, NLat, NAlt))
-  end if
+  endif
 
   ! altitude grid
   read(UnitTmp_, *) (alt(kalt), kalt=NAlt, 1, -1)
@@ -59,19 +59,19 @@ subroutine ReadIonHeat(filename, IsIonizationFile)
       else
         read(UnitTmp_, *) glng(ilng), glat(jlat), &
           (HeatingRate(ilng, jlat, kalt), kalt=NAlt, -1)
-      end if
+      endif
 
       ! data(ilng,jlat,kalt) is on the geographic longitude of glng(ilng),
       ! the geographic latitude of glat(jlat) and the altitude of alt(kalt)
 
-    end do ! jlat
-  end do ! ilng
+    enddo ! jlat
+  enddo ! ilng
 
   if (IsIonizationFile) then
     IonizationRate = IonizationRate*1.0e6
   else
     HeatingRate = HeatingRate*1.0e6*1.602e-19
-  end if
+  endif
 
   close(UnitTmp_)
 
@@ -123,16 +123,16 @@ subroutine interpolate_ions(nLons, nLats, nAlts, &
     iLons(iLon) = int(rLons(iLon))
     rLons(iLon) = rLons(iLon) - iLons(iLon)
     if (iLons(iLon) > NLng) iLons(iLon) = 0
-  end do
+  enddo
 
   do iLat = 1, nLats
     if (LatsDeg(iLat) <= glat(1)) iLats(iLat) = -1
     do i = 1, NLat
       if (LatsDeg(iLat) >= glat(i)) iLats(iLat) = i
-    end do
+    enddo
     i = iLats(iLat)
     if (i > 0) rLats(iLat) = (LatsDeg(iLat) - glat(i))/(glat(2) - glat(1))
-  end do
+  enddo
 
   do iLon = 1, nLons
     do iLat = 1, nLats
@@ -146,17 +146,17 @@ subroutine interpolate_ions(nLons, nLats, nAlts, &
         else
           do i = 1, NAlt
             if (AltsKms(iAlt) >= alt(i)) iAlts(iAlt) = i
-          end do
-        end if
+          enddo
+        endif
         i = iAlts(iAlt)
         if (i >= 1) then
           if (i == NAlt) then
             rAlts(iAlt) = (AltsKms(iAlt) - alt(NAlt))/(alt(NAlt) - alt(NAlt - 1))
           else
             rAlts(iAlt) = (AltsKms(iAlt) - alt(i))/(alt(i + 1) - alt(i))
-          end if
-        end if
-      end do
+          endif
+        endif
+      enddo
 
       do iAlt = 1, nAlts
         if (iAlts(iAlt) < 1 .or. iAlts(iAlt) >= nAlt) CYCLE
@@ -188,8 +188,8 @@ subroutine interpolate_ions(nLons, nLats, nAlts, &
           (rlo)*(rla)*(ral)*HeatingRate(i + 1, j + 1, k + 1) + &
           (1 - rlo)*(rla)*(ral)*HeatingRate(i, j + 1, k + 1)
 
-      end do
-    end do
-  end do
+      enddo
+    enddo
+  enddo
 
 end subroutine interpolate_ions

--- a/util/EMPIRICAL/srcIE/EIE_Initialize.f90
+++ b/util/EMPIRICAL/srcIE/EIE_Initialize.f90
@@ -44,7 +44,7 @@ subroutine EIE_Initialize(iOutputError)
 
   if (index(EIE_NameOfEFieldModel, 'zero') > 0) then
     IsFound_EFieldModel = .true.
-  end if
+  endif
 
   if (index(EIE_NameOfEFieldModel, 'weimer96') > 0) then
     IsFound_EFieldModel = .true.
@@ -53,10 +53,10 @@ subroutine EIE_Initialize(iOutputError)
     if (iError /= 0) then
       write(6, *) 'Error opening file :', weimer96_file
       iOutputError = ecFileNotFound_
-    end if
+    endif
     call ReadCoef96(UnitTmp_)
     close(UnitTmp_)
-  end if
+  endif
 
   if (index(EIE_NameOfEFieldModel, 'weimer01') > 0) then
     IsFound_EFieldModel = .true.
@@ -66,10 +66,10 @@ subroutine EIE_Initialize(iOutputError)
     if (iError /= 0) then
       write(6, *) 'Error opening file :', weimer01_file
       iOutputError = ecFileNotFound_
-    end if
+    endif
     call ReadCoef01(UnitTmp_)
     close(UnitTmp_)
-  end if
+  endif
 
   if (index(EIE_NameOfEFieldModel, 'weimer05') > 0) then
     IsFound_EFieldModel = .true.
@@ -82,7 +82,7 @@ subroutine EIE_Initialize(iOutputError)
     inFileName = 'W05scBndy.dat'
     call merge_str(EIE_NameOfModelDir, inFileName)
     call read_bndy(inFileName)
-  end if
+  endif
 
 !  if (index(EIE_NameOfEFieldModel,'samie') > 0) then
 !     IsFound_EFieldModel = .true.
@@ -103,10 +103,10 @@ subroutine EIE_Initialize(iOutputError)
     if (iError /= 0) then
       write(6, *) 'Error opening file :', millstone_hill_i_file
       iOutputError = ecFileNotFound_
-    end if
+    endif
     call mhinit(1, UnitTmp_, 1, iDebugLevel)
     close(UnitTmp_)
-  end if
+  endif
 
   if (index(EIE_NameOfEFieldModel, 'millstone_imf') > 0) then
     IsFound_EFieldModel = .true.
@@ -115,10 +115,10 @@ subroutine EIE_Initialize(iOutputError)
     if (iError /= 0) then
       write(6, *) 'Error opening file :', millstone_hill_s_file
       iOutputError = ecFileNotFound_
-    end if
+    endif
     call mhinit(2, UnitTmp_, 1, iDebugLevel)
     close(UnitTmp_)
-  end if
+  endif
 
   if (index(EIE_NameOfEFieldModel, 'hmr89') > 0) then
     IsFound_EFieldModel = .true.
@@ -127,10 +127,10 @@ subroutine EIE_Initialize(iOutputError)
     if (iError /= 0) then
       write(6, *) 'Error opening file :', hepner_maynard_file
       iOutputError = ecFileNotFound_
-    end if
+    endif
     call gethmr(UnitTmp_)
     close(UnitTmp_)
-  end if
+  endif
 
   if (index(EIE_NameOfEFieldModel, 'izmem') > 0) then
     IsFound_EFieldModel = .true.
@@ -139,10 +139,10 @@ subroutine EIE_Initialize(iOutputError)
     if (iError /= 0) then
       write(6, *) 'Error opening file :', izmem_file
       iOutputError = ecFileNotFound_
-    end if
+    endif
     call izinit(UnitTmp_)
     close(UnitTmp_)
-  end if
+  endif
 
   !\
   ! --------------------------------------------------------------------
@@ -177,7 +177,7 @@ subroutine EIE_Initialize(iOutputError)
     else
       call AMIE_SetFileName(AMIEFileSouth)
       call readAMIEOutput(South_, .false., iDebugLevel, iError)
-    end if
+    endif
 
     call AMIE_GetnLats(nAmieLats)
     call AMIE_GetnMLTs(nAmieMlts)
@@ -189,11 +189,11 @@ subroutine EIE_Initialize(iOutputError)
 
     return
 
-  end if
+  endif
 
   if (.not. IsFound_EFieldModel) then
     iOutputError = ecEFieldModelNotFound_
-  end if
+  endif
 
   if (iDebugLevel > 3) write(*, *) "====> Done with EIE_Initialize"
 
@@ -225,84 +225,84 @@ subroutine EIE_InitGrid(nLats, nMlts, nBlocks, iOutputError)
     write(*, *) "=> EIEi_HavenBLKs : ", EIEi_HavenBLKs
     write(*, *) "=> EIEi_HavenLats : ", EIEi_HavenLats
     write(*, *) "=> EIEi_HavenMLTs : ", EIEi_HavenMLTs
-  end if
+  endif
 
   allocate(EIEr3_HaveLats(EIEi_HavenMlts, EIEi_HavenLats, EIEi_HavenBLKs), &
            stat=iError)
   if (iError /= 0) then
     write(*, *) "Error in allocating array EIEr3_HaveLats in Interface"
     stop
-  end if
+  endif
 
   allocate(EIEr3_HaveMlts(EIEi_HavenMlts, EIEi_HavenLats, EIEi_HavenBLKs), &
            stat=iError)
   if (iError /= 0) then
     write(*, *) "Error in allocating array EIEr3_HaveMlts in Interface"
     stop
-  end if
+  endif
 
   allocate(EIEr3_HavePotential(EIEi_HavenMlts, EIEi_HavenLats, EIEi_HavenBLKs), &
            stat=iError)
   if (iError /= 0) then
     write(*, *) "Error in allocating array EIEr3_HavePotential in Interface"
     stop
-  end if
+  endif
 
   allocate(EIEr3_HaveEFlux(EIEi_HavenMlts, EIEi_HavenLats, EIEi_HavenBLKs), &
            stat=iError)
   if (iError /= 0) then
     write(*, *) "Error in allocating array EIEr3_HaveEFlux in Interface"
     stop
-  end if
+  endif
 
   allocate(EIEr3_HaveAveE(EIEi_HavenMlts, EIEi_HavenLats, EIEi_HavenBLKs), &
            stat=iError)
   if (iError /= 0) then
     write(*, *) "Error in allocating array EIEr3_HaveAveE in Interface"
     stop
-  end if
+  endif
 
   allocate(EIEr3_HaveIonEFlux(EIEi_HavenMlts, EIEi_HavenLats, EIEi_HavenBLKs), &
            stat=iError)
   if (iError /= 0) then
     write(*, *) "Error in allocating array EIEr3_HaveIonEFlux in Interface"
     stop
-  end if
+  endif
 
   allocate(EIEr3_HaveIonAveE(EIEi_HavenMlts, EIEi_HavenLats, EIEi_HavenBLKs), &
            stat=iError)
   if (iError /= 0) then
     write(*, *) "Error in allocating array EIEr3_HaveIonAveE in Interface"
     stop
-  end if
+  endif
 
   allocate(EIEr3_HaveMonoEFlux(EIEi_HavenMlts, EIEi_HavenLats, EIEi_HavenBLKs), &
            stat=iError)
   if (iError /= 0) then
     write(*, *) "Error in allocating array EIEr3_HaveMonoEFlux in Interface"
     stop
-  end if
+  endif
 
   allocate(EIEr3_HaveMonoAveE(EIEi_HavenMlts, EIEi_HavenLats, EIEi_HavenBLKs), &
            stat=iError)
   if (iError /= 0) then
     write(*, *) "Error in allocating array EIEr3_HaveMonoAveE in Interface"
     stop
-  end if
+  endif
 
   allocate(EIEr3_HaveWaveEFlux(EIEi_HavenMlts, EIEi_HavenLats, EIEi_HavenBLKs), &
            stat=iError)
   if (iError /= 0) then
     write(*, *) "Error in allocating array EIEr3_HaveWaveEFlux in Interface"
     stop
-  end if
+  endif
 
   allocate(EIEr3_HaveWaveAveE(EIEi_HavenMlts, EIEi_HavenLats, EIEi_HavenBLKs), &
            stat=iError)
   if (iError /= 0) then
     write(*, *) "Error in allocating array EIEr3_HaveWaveAveE in Interface"
     stop
-  end if
+  endif
 
   iOutputError = iError
 
@@ -327,7 +327,7 @@ subroutine EIE_FillLats(Lats, iOutputError)
 
   do iMlt = 1, EIEi_HavenMlts
     EIEr3_HaveLats(iMlt, :, 1) = Lats
-  end do
+  enddo
 
 end subroutine EIE_FillLats
 
@@ -351,7 +351,7 @@ subroutine EIE_FillMltsOffset(Mlts, iOutputError)
   do iLat = 1, EIEi_HavenLats
     EIEr3_HaveMlts(1, iLat, 1) = Mlts(EIEi_HavenMlts - 2) - 360.0
     EIEr3_HaveMlts(2:EIEi_HavenMlts, iLat, 1) = Mlts
-  end do
+  enddo
 
 end subroutine EIE_FillMltsOffset
 

--- a/util/EMPIRICAL/srcIE/EIE_IoLibrary.f90
+++ b/util/EMPIRICAL/srcIE/EIE_IoLibrary.f90
@@ -143,9 +143,9 @@ subroutine IO_SetMLTs(MLTsIn, iError)
     do i = 1, IOi_NeednMLTs
       do j = 1, IOi_NeednLats
         IOr2_NeedMLTs(i, j) = mod((MLTsIn(i, j) + 24.0), 24.0)
-      end do
-    end do
-  end if
+      enddo
+    enddo
+  endif
 
 end subroutine IO_SetMLTs
 
@@ -170,7 +170,7 @@ subroutine IO_SetLats(LatsIn, iError)
   else
     IOr2_NeedLats(1:IOi_NeednMLTs, 1:IOi_NeednLats) = &
       LatsIn(1:IOi_NeednMLTs, 1:IOi_NeednLats)
-  end if
+  endif
 
 end subroutine IO_SetLats
 
@@ -207,7 +207,7 @@ subroutine IO_SetGrid(MLTsIn, LatsIn, iError)
     if (iError /= 0) then
       iError = ecAllocationError_
       return
-    end if
+    endif
 
     if (allocated(IOr3_InterpolationRatios)) &
       deallocate(IOr3_InterpolationRatios)
@@ -216,7 +216,7 @@ subroutine IO_SetGrid(MLTsIn, LatsIn, iError)
     if (iError /= 0) then
       iError = ecAllocationError_
       return
-    end if
+    endif
 
     do i = 1, IOi_NeednLats
       do j = 1, IOi_NeednMLTs
@@ -231,12 +231,12 @@ subroutine IO_SetGrid(MLTsIn, LatsIn, iError)
           IOr3_InterpolationRatios(j, i, 1:2) = EIEr1_Location(4:5)
         else
           IOi3_InterpolationIndices(j, i, 1) = -1
-        end if
+        endif
 
-      end do
-    end do
+      enddo
+    enddo
 
-  end if
+  endif
 
 end subroutine IO_SetGrid
 
@@ -269,7 +269,7 @@ subroutine IO_GetPotential(PotentialOut, iError)
       stop
     else
       PotentialOut = ValueOut
-    end if
+    endif
 
   else
 
@@ -279,9 +279,9 @@ subroutine IO_GetPotential(PotentialOut, iError)
       PotentialOut = ValueOut
     else
       PotentialOut = -1.0e32
-    end if
+    endif
 
-  end if
+  endif
 
 end subroutine IO_GetPotential
 
@@ -314,66 +314,66 @@ subroutine IO_GetNonGridBasedPotential(PotentialOut, iError)
 
   if (index(EIE_NameOfEFieldModel, 'zero') > 0) then
     return
-  end if
+  endif
 
   if (IOd_NeedTime < 0.0) then
     iError = ecTimeNotSet_
     return
-  end if
+  endif
 
   if (index(EIE_NameOfEFieldModel, 'hpi') <= 0) then
     if (IOr_NeedIMFBz < -1000.0) then
       iError = ecIMFBzNotSet_
       return
-    end if
+    endif
     if (IOr_NeedIMFBy < -1000.0) then
       iError = ecIMFByNotSet_
       return
-    end if
-  end if
+    endif
+  endif
 
   if (index(EIE_NameOfEFieldModel, 'weimer05') > 0) then
     if (IOr_NeedSWV < -1000.0) then
       iError = ecSWVNotSet_
       return
-    end if
+    endif
     if (IOr_NeedSWN < -1000.0) then
       iError = ecSWNNotSet_
       return
-    end if
+    endif
     iChange = 1
-  end if
+  endif
 
   if (index(EIE_NameOfEFieldModel, 'weimer01') > 0) then
     if (IOr_NeedSWV < -1000.0) then
       iError = ecSWVNotSet_
       return
-    end if
+    endif
     iChange = 1
-  end if
+  endif
 
   if (index(EIE_NameOfEFieldModel, 'weimer96') > 0) then
     if (IOr_NeedSWV < -1000.0) then
       iError = ecSWVNotSet_
       return
-    end if
+    endif
     iChange = 1
-  end if
+  endif
 
   if (index(EIE_NameOfEFieldModel, 'millstone') > 0) then
     if (IOr_NeedHPI < -1000.0) then
       iError = ecHPINotSet_
       return
-    end if
-  end if
+    endif
+  endif
 
   if (index(EIE_NameOfEFieldModel, 'hmr89') > 0) then
     if (IOr_NeedKP < -1000.0) then
       iError = ecKPNotSet_
       return
-    end if
+    endif
     iChange = 1
-  end if
+  endif
 
   call time_real_to_int(IOd_NeedTime, itime)
 
@@ -394,7 +394,7 @@ subroutine IO_GetNonGridBasedPotential(PotentialOut, iError)
       else
         if (IOr2_NeedLats(iMLT, iLat)*IOr2_NeedLats(iMLT, iLat - 1) <= 0.0) &
           iChange = 1
-      end if
+      endif
 
       MLT = IOr2_NeedMLTs(iMLT, iLat)
       Lat = IOr2_NeedLats(iMLT, iLat)
@@ -405,11 +405,11 @@ subroutine IO_GetNonGridBasedPotential(PotentialOut, iError)
         else
           Lat = abs(Lat)
           iHemisphere = -1
-        end if
+        endif
       else
         iHemisphere = -1
         if (Lat < 0.0) Lat = abs(Lat)
-      end if
+      endif
 
       if (index(EIE_NameOfEFieldModel, 'weimer05') > 0) then
         if (abs(lat) >= 45.0) then
@@ -424,8 +424,8 @@ subroutine IO_GetNonGridBasedPotential(PotentialOut, iError)
           Potential = 0.0
           ETheta = 0.0
           EPhi = 0.0
-        end if
-      end if
+        endif
+      endif
 
       if (index(EIE_NameOfEFieldModel, 'weimer96') > 0) then
         if (abs(lat) >= 45.0) then
@@ -440,38 +440,38 @@ subroutine IO_GetNonGridBasedPotential(PotentialOut, iError)
           Potential = 0.0
           ETheta = 0.0
           EPhi = 0.0
-        end if
-      end if
+        endif
+      endif
 
       if (index(EIE_NameOfEFieldModel, 'millstone_hpi') > 0) then
         call MHEMODL(Lat, mlt, IOr_NeedHPI, IOr_NeedIMFBy, &
                      IOr_NeedIMFBz, 1, ETheta, EPhi, Potential)
         Potential = Potential*1000.0
-      end if
+      endif
 
       if (index(EIE_NameOfEFieldModel, 'millstone_imf') > 0) then
         call MHEMODL(lat, mlt, IOr_NeedHPI, IOr_NeedIMFBy, &
                      IOr_NeedIMFBz, 2, ETheta, EPhi, Potential)
         Potential = Potential*1000.0
-      end if
+      endif
 
       if (index(EIE_NameOfEFieldModel, 'hmr89') > 0) then
         call HMREPOT(lat, mlt, IOr_NeedIMFBy, IOr_NeedIMFBz, &
                      IOr_NeedKp, iChange, ETheta, EPhi, Potential)
         Potential = Potential*1000.0
         iChange = 0
-      end if
+      endif
 
       if (index(EIE_NameOfEFieldModel, 'izmem') > 0) then
         call IZEPOT(iMonth, lat, mlt, iHemisphere*IOr_NeedIMFBy, &
                     IOr_NeedIMFBz, ETheta, EPhi, Potential)
         Potential = Potential*1000.0
-      end if
+      endif
 
       PotentialOut(iMLT, iLat) = Potential
 
-    end do
-  end do
+    enddo
+  enddo
 
 end subroutine IO_GetNonGridBasedPotential
 
@@ -501,7 +501,7 @@ subroutine IO_GetAveE(AveEOut, iError)
       write(*, *) cErrorCodes(iError)
     else
       AveEOut = ValueOut
-    end if
+    endif
 
   else
 
@@ -511,9 +511,9 @@ subroutine IO_GetAveE(AveEOut, iError)
       AveEOut = ValueOut
     else
       AveEOut = -1.0e32
-    end if
+    endif
 
-  end if
+  endif
 
 end subroutine IO_GetAveE
 
@@ -535,7 +535,7 @@ subroutine IO_GetNonGridBasedAveE(AveEOut, iError)
   if (IOr_NeedHPINorm < -1000.0) then
     iError = ecHPINotSet_
     return
-  end if
+  endif
 
   do iMLT = 1, IOi_NeednMLTs
     do iLat = 1, IOi_NeednLats
@@ -549,8 +549,8 @@ subroutine IO_GetNonGridBasedAveE(AveEOut, iError)
 
       AveEOut(iMLT, iLat) = avkev
 
-    end do
-  end do
+    enddo
+  enddo
 
 end subroutine IO_GetNonGridBasedAveE
 
@@ -573,7 +573,7 @@ subroutine IO_GetNonGridBasedEFlux(EFluxOut, iError)
   if (IOr_NeedHPINorm < -1000.0) then
     iError = ecHPINotSet_
     return
-  end if
+  endif
 
   do iMLT = 1, IOi_NeednMLTs
     do iLat = 1, IOi_NeednLats
@@ -587,8 +587,8 @@ subroutine IO_GetNonGridBasedEFlux(EFluxOut, iError)
       ! Need to convert from erg/cm2/s to W/m2
       EFluxOut(iMLT, iLat) = eflx !* 1.0e-7 * 100.0 * 100.0
 
-    end do
-  end do
+    enddo
+  enddo
 
 end subroutine IO_GetNonGridBasedEFlux
 
@@ -619,7 +619,7 @@ subroutine IO_GetEFlux(EFluxOut, iError)
       stop
     else
       EFluxOut = ValueOut
-    end if
+    endif
 
   else
 
@@ -629,9 +629,9 @@ subroutine IO_GetEFlux(EFluxOut, iError)
       EFluxOut = ValueOut
     else
       EFluxOut = -1.0e32
-    end if
+    endif
 
-  end if
+  endif
 
 end subroutine IO_GetEFlux
 
@@ -674,10 +674,10 @@ subroutine IO_GetValue(ValueIn, ValueOut, Filler, iError)
           (dM)*(dL)*ValueIn(iM + 1, IL + 1, iB) + &
           (dM)*(1.0 - dL)*ValueIn(iM + 1, IL, iB)
 
-      end if
+      endif
 
-    end do
-  end do
+    enddo
+  enddo
 
 end subroutine IO_GetValue
 

--- a/util/EMPIRICAL/srcIE/EIE_Library.f90
+++ b/util/EMPIRICAL/srcIE/EIE_Library.f90
@@ -43,16 +43,16 @@ subroutine EIE_FindPoint(LocIn, LocOut, iError)
   if (LatIn > 90.0) then
     LatIn = 180.0 - LatIn
     MLTIn = mod(MLTIn + 12.0, 24.0)
-  end if
+  endif
   if (LatIn < -90.0) then
     LatIn = -180.0 - LatIn
     MLTIn = mod(MLTIn + 12.0, 24.0)
-  end if
+  endif
 
   if (MLTIn > 24.0 .or. MLTIn < 0 .or. LatIn > 90.0 .or. LatIn < -90.0) then
     iError = ecPointOutofRange_
     return
-  end if
+  endif
 
   iBLK = 1
   do while (iBLK <= EIEi_HavenBLKs)
@@ -92,18 +92,18 @@ subroutine EIE_FindPoint(LocIn, LocOut, iError)
           j = EIEi_HavenMLTs
           i = EIEi_HavenLats
 
-        end if
+        endif
 
         i = i + 1
 
-      end do
+      enddo
 
       j = j + 1
 
-    end do
+    enddo
 
     iBLK = iBLK + 1
 
-  end do
+  enddo
 
 end subroutine EIE_FindPoint

--- a/util/EMPIRICAL/srcIE/EIE_UaLibrary.f90
+++ b/util/EMPIRICAL/srcIE/EIE_UaLibrary.f90
@@ -72,9 +72,9 @@ subroutine UA_SetMLTs(MLTsIn, iError)
     do i = 1, UAi_NeednMLTs
       do j = 1, UAi_NeednLats
         UAr2_NeedMLTs(i, j) = mod((MLTsIn(i, j) + 24.0), 24.0)
-      end do
-    end do
-  end if
+      enddo
+    enddo
+  endif
 
 end subroutine UA_SetMLTs
 
@@ -99,7 +99,7 @@ subroutine UA_SetLats(LatsIn, iError)
   else
     UAr2_NeedLats(1:UAi_NeednMLTs, 1:UAi_NeednLats) = &
       LatsIn(1:UAi_NeednMLTs, 1:UAi_NeednLats)
-  end if
+  endif
 
 end subroutine UA_SetLats
 
@@ -136,7 +136,7 @@ subroutine UA_SetGrid(MLTsIn, LatsIn, iError)
     if (iError /= 0) then
       iError = ecAllocationError_
       return
-    end if
+    endif
 
     if (allocated(UAr3_InterpolationRatios)) &
       deallocate(UAr3_InterpolationRatios)
@@ -145,7 +145,7 @@ subroutine UA_SetGrid(MLTsIn, LatsIn, iError)
     if (iError /= 0) then
       iError = ecAllocationError_
       return
-    end if
+    endif
 
     do i = 1, UAi_NeednLats
       do j = 1, UAi_NeednMLTs
@@ -160,12 +160,12 @@ subroutine UA_SetGrid(MLTsIn, LatsIn, iError)
           UAr3_InterpolationRatios(j, i, 1:2) = EIEr1_Location(4:5)
         else
           UAi3_InterpolationIndices(j, i, 1) = -1
-        end if
+        endif
 
-      end do
-    end do
+      enddo
+    enddo
 
-  end if
+  endif
 
 end subroutine UA_SetGrid
 
@@ -210,10 +210,10 @@ subroutine UA_GetValue(ValueIn, ValueOut, Filler, iError)
           (dM)*(dL)*ValueIn(iM + 1, IL + 1, iB) + &
           (dM)*(1.0 - dL)*ValueIn(iM + 1, IL, iB)
 
-      end if
+      endif
 
-    end do
-  end do
+    enddo
+  enddo
 
 end subroutine UA_GetValue
 
@@ -249,7 +249,7 @@ subroutine UA_GetPotential(PotentialOut, iError)
       stop
     else
       PotentialOut = ValueOut
-    end if
+    endif
 
   else
 
@@ -269,12 +269,12 @@ subroutine UA_GetPotential(PotentialOut, iError)
                                      ValueOut(iMlt, iLat - 1) + &
                                      ValueOut(iMlt + 1, iLat) + &
                                      ValueOut(iMlt, iLat + 1))/4.0
-            end if
-          end if
-        end do
-      end do
+            endif
+          endif
+        enddo
+      enddo
 
-    end if
+    endif
 
     if (iError == 0) then
       PotentialOut = ValueOut
@@ -282,9 +282,9 @@ subroutine UA_GetPotential(PotentialOut, iError)
       write(*, *) 'error in UA_GetPotential (nongrid): ', cErrorCodes(iError)
       stop
       PotentialOut = -1.0e32
-    end if
+    endif
 
-  end if
+  endif
 
 end subroutine UA_GetPotential
 
@@ -321,66 +321,66 @@ subroutine UA_GetNonGridBasedPotential(PotentialOut, iError)
 
   if (index(EIE_NameOfEFieldModel, 'zero') > 0) then
     return
-  end if
+  endif
 
   if (IOd_NeedTime < 0.0) then
     iError = ecTimeNotSet_
     return
-  end if
+  endif
 
   if (index(EIE_NameOfEFieldModel, 'hpi') <= 0) then
     if (IOr_NeedIMFBz < -1000.0) then
       iError = ecIMFBzNotSet_
       return
-    end if
+    endif
     if (IOr_NeedIMFBy < -1000.0) then
       iError = ecIMFByNotSet_
       return
-    end if
-  end if
+    endif
+  endif
 
   if (index(EIE_NameOfEFieldModel, 'weimer05') > 0) then
     if (IOr_NeedSWV < -1000.0) then
       iError = ecSWVNotSet_
       return
-    end if
+    endif
     if (IOr_NeedSWN < -1000.0) then
       iError = ecSWNNotSet_
       return
-    end if
+    endif
     iChange = 1
-  end if
+  endif
 
   if (index(EIE_NameOfEFieldModel, 'weimer01') > 0) then
     if (IOr_NeedSWV < -1000.0) then
       iError = ecSWVNotSet_
       return
-    end if
+    endif
     iChange = 1
-  end if
+  endif
 
   if (index(EIE_NameOfEFieldModel, 'weimer96') > 0) then
     if (IOr_NeedSWV < -1000.0) then
       iError = ecSWVNotSet_
       return
-    end if
+    endif
     iChange = 1
-  end if
+  endif
 
   if (index(EIE_NameOfEFieldModel, 'millstone') > 0) then
     if (IOr_NeedHPI < -1000.0) then
       iError = ecHPINotSet_
       return
-    end if
-  end if
+    endif
+  endif
 
   if (index(EIE_NameOfEFieldModel, 'hmr89') > 0) then
     if (IOr_NeedKP < -1000.0) then
       iError = ecKPNotSet_
       return
-    end if
+    endif
     iChange = 1
-  end if
+  endif
 
   call time_real_to_int(IOd_NeedTime, itime)
 
@@ -401,7 +401,7 @@ subroutine UA_GetNonGridBasedPotential(PotentialOut, iError)
       else
         if (UAr2_NeedLats(iMLT, iLat)*UAr2_NeedLats(iMLT, iLat - 1) <= 0.0) &
           iChange = 1
-      end if
+      endif
 
       MLT = UAr2_NeedMLTs(iMLT, iLat)
       Lat = UAr2_NeedLats(iMLT, iLat)
@@ -412,11 +412,11 @@ subroutine UA_GetNonGridBasedPotential(PotentialOut, iError)
         else
           Lat = abs(Lat)
           iHemisphere = -1
-        end if
+        endif
       else
         iHemisphere = -1
         if (Lat < 0.0) Lat = abs(Lat)
-      end if
+      endif
 
       if (index(EIE_NameOfEFieldModel, 'weimer05') > 0) then
         if (abs(lat) >= 45.0) then
@@ -425,7 +425,7 @@ subroutine UA_GetNonGridBasedPotential(PotentialOut, iError)
             tilt = 0.0
           else
             tilt = iHemisphere*get_tilt(iYear, iMonth, iDay, hr)
-          end if
+          endif
           call setmodel(IOr_NeedIMFBy, IOr_NeedIMFBz, tilt, &
                         IOr_NeedSWV, IOr_NeedSWN, 'epot')
           call epotval(lat, mlt, 0.0, Potential)
@@ -435,8 +435,8 @@ subroutine UA_GetNonGridBasedPotential(PotentialOut, iError)
           Potential = 0.0
           ETheta = 0.0
           EPhi = 0.0
-        end if
-      end if
+        endif
+      endif
 
       if (index(EIE_NameOfEFieldModel, 'weimer96') > 0) then
         if (abs(lat) >= 45.0) then
@@ -451,38 +451,38 @@ subroutine UA_GetNonGridBasedPotential(PotentialOut, iError)
           Potential = 0.0
           ETheta = 0.0
           EPhi = 0.0
-        end if
-      end if
+        endif
+      endif
 
       if (index(EIE_NameOfEFieldModel, 'millstone_hpi') > 0) then
         call MHEMODL(Lat, mlt, IOr_NeedHPI, IOr_NeedIMFBy, &
                      IOr_NeedIMFBz, 1, ETheta, EPhi, Potential)
         Potential = Potential*1000.0
-      end if
+      endif
 
       if (index(EIE_NameOfEFieldModel, 'millstone_imf') > 0) then
         call MHEMODL(lat, mlt, IOr_NeedHPI, IOr_NeedIMFBy, &
                      IOr_NeedIMFBz, 2, ETheta, EPhi, Potential)
         Potential = Potential*1000.0
-      end if
+      endif
 
       if (index(EIE_NameOfEFieldModel, 'hmr89') > 0) then
         call HMREPOT(lat, mlt, IOr_NeedIMFBy, IOr_NeedIMFBz, &
                      IOr_NeedKp, iChange, ETheta, EPhi, Potential)
         Potential = Potential*1000.0
         iChange = 0
-      end if
+      endif
 
       if (index(EIE_NameOfEFieldModel, 'izmem') > 0) then
         call IZEPOT(iMonth, lat, mlt, iHemisphere*IOr_NeedIMFBy, &
                     IOr_NeedIMFBz, ETheta, EPhi, Potential)
         Potential = Potential*1000.0
-      end if
+      endif
 
       PotentialOut(iMLT, iLat) = Potential
 
-    end do
-  end do
+    enddo
+  enddo
 
 end subroutine UA_GetNonGridBasedPotential
 
@@ -514,7 +514,7 @@ subroutine UA_GetAveE(AveEOut, iError)
       write(*, *) cErrorCodes(iError)
     else
       AveEOut = ValueOut
-    end if
+    endif
 
   else
 
@@ -524,9 +524,9 @@ subroutine UA_GetAveE(AveEOut, iError)
       AveEOut = ValueOut
     else
       AveEOut = -1.0e32
-    end if
+    endif
 
-  end if
+  endif
 
 end subroutine UA_GetAveE
 
@@ -552,7 +552,7 @@ subroutine UA_GetNonGridBasedAveE(AveEOut, iError)
   if (IOr_NeedHPINorm < -1000.0) then
     iError = ecHPINotSet_
     return
-  end if
+  endif
 
   do iMLT = 1, UAi_NeednMLTs
     do iLat = 1, UAi_NeednLats
@@ -566,8 +566,8 @@ subroutine UA_GetNonGridBasedAveE(AveEOut, iError)
 
       AveEOut(iMLT, iLat) = avkev
 
-    end do
-  end do
+    enddo
+  enddo
 
 end subroutine UA_GetNonGridBasedAveE
 
@@ -600,7 +600,7 @@ subroutine UA_GetEFlux(EFluxOut, iError)
       stop
     else
       EFluxOut = ValueOut
-    end if
+    endif
 
   else
 
@@ -610,9 +610,9 @@ subroutine UA_GetEFlux(EFluxOut, iError)
       EFluxOut = ValueOut
     else
       EFluxOut = -1.0e32
-    end if
+    endif
 
-  end if
+  endif
 
 end subroutine UA_GetEFlux
 
@@ -639,7 +639,7 @@ subroutine UA_GetNonGridBasedEFlux(EFluxOut, iError)
   if (IOr_NeedHPINorm < -1000.0) then
     iError = ecHPINotSet_
     return
-  end if
+  endif
 
   do iMLT = 1, UAi_NeednMLTs
     do iLat = 1, UAi_NeednLats
@@ -652,8 +652,8 @@ subroutine UA_GetNonGridBasedEFlux(EFluxOut, iError)
 
       EFluxOut(iMLT, iLat) = eflx
 
-    end do
-  end do
+    enddo
+  enddo
 
 end subroutine UA_GetNonGridBasedEFlux
 
@@ -685,7 +685,7 @@ subroutine UA_GetIonAveE(IonAveEOut, iError)
       write(*, *) cErrorCodes(iError)
     else
       IonAveEOut = ValueOut
-    end if
+    endif
 
   else
 
@@ -695,9 +695,9 @@ subroutine UA_GetIonAveE(IonAveEOut, iError)
       IonAveEOut = ValueOut
     else
       IonAveEOut = 0.0
-    end if
+    endif
 
-  end if
+  endif
 
 end subroutine UA_GetIonAveE
 
@@ -749,7 +749,7 @@ subroutine UA_GetIonEFlux(IonEFluxOut, iError)
       stop
     else
       IonEFluxOut = ValueOut
-    end if
+    endif
 
   else
 
@@ -759,9 +759,9 @@ subroutine UA_GetIonEFlux(IonEFluxOut, iError)
       IonEFluxOut = ValueOut
     else
       IonEFluxOut = -1.0e32
-    end if
+    endif
 
-  end if
+  endif
 
 end subroutine UA_GetIonEFlux
 

--- a/util/EMPIRICAL/srcIE/EIE_set_inputs.f90
+++ b/util/EMPIRICAL/srcIE/EIE_set_inputs.f90
@@ -77,7 +77,7 @@ subroutine EIE_set_inputs(StringInputLines)
         UseGridBasedEIE = .false.
         UAl_UseGridBasedEIE = .false.
 
-      end if
+      endif
 
       if (index(StringLine, "#AMIEFILES") > 0) then
         call read_in_string(AMIEFileNorth)
@@ -85,35 +85,35 @@ subroutine EIE_set_inputs(StringInputLines)
         EIE_NameOfEFieldModel = "amie"
         UseGridBasedEIE = .true.
         UAl_UseGridBasedEIE = .true.
-      end if
+      endif
 
       if (index(StringLine, "#DEBUG") > 0) then
         call read_in_int(iDebugLevel)
         call read_in_int(iDebugProc)
         if (iDebugProc >= 0 .and. iProc /= iDebugProc) then
           iDebugLevel = -1
-        end if
-      end if
+        endif
+      endif
 
       if (index(StringLine, "#FIXTILT") > 0) then
         call read_in_logical(IsFixedTilt)
-      end if
+      endif
 
       if (index(StringLine, "#END") > 0) then
         IsDone = .true.
-      end if
+      endif
 
       if (iLine >= MaxInputLines) then
         IsDone = .true.
-      end if
+      endif
 
     else
 
       iLine = iLine + 1
 
-    end if
+    endif
 
-  end do
+  enddo
 
 contains
 

--- a/util/EMPIRICAL/srcIE/GM_Library.f90
+++ b/util/EMPIRICAL/srcIE/GM_Library.f90
@@ -43,9 +43,9 @@ subroutine GM_SetMLTs(MLTsIn, iError)
     do i = 1, GMi_NeednMLTs
       do j = 1, GMi_NeednLats
         GMr2_NeedMLTs(i, j) = mod((MLTsIn(i, j) + 24.0), 24.0)
-      end do
-    end do
-  end if
+      enddo
+    enddo
+  endif
 
 end subroutine GM_SetMLTs
 
@@ -70,7 +70,7 @@ subroutine GM_SetLats(LatsIn, iError)
   else
     GMr2_NeedLats(1:GMi_NeednMLTs, 1:GMi_NeednLats) = &
       LatsIn(1:GMi_NeednMLTs, 1:GMi_NeednLats)
-  end if
+  endif
 
 end subroutine GM_SetLats
 
@@ -103,14 +103,14 @@ subroutine GM_SetGrid(MLTsIn, LatsIn, iError)
   if (iError /= 0) then
     iError = ecAllocationError_
     return
-  end if
+  endif
 
   allocate(GMr3_InterpolationRatios(GMi_NeednMLTs, GMi_NeednLats, 2), &
            stat=iError)
   if (iError /= 0) then
     iError = ecAllocationError_
     return
-  end if
+  endif
 
   do i = 1, GMi_NeednLats
     do j = 1, GMi_NeednMLTs
@@ -125,10 +125,10 @@ subroutine GM_SetGrid(MLTsIn, LatsIn, iError)
         GMr3_InterpolationRatios(j, i, 1:2) = EIEr1_Location(4:5)
       else
         GMi3_InterpolationIndices(j, i, 1) = -1
-      end if
+      endif
 
-    end do
-  end do
+    enddo
+  enddo
 
 end subroutine GM_SetGrid
 
@@ -228,8 +228,8 @@ subroutine GM_GetValue(ValueIn, ValueOut, iError)
         (dM)*(1.0 - dL)*ValueIn(iM + 1, IL, iB) + &
         (1.0 - dM)*(dL)*ValueIn(iM, IL + 1, iB)
 
-    end do
-  end do
+    enddo
+  enddo
 
 end subroutine GM_GetValue
 

--- a/util/EMPIRICAL/srcIE/MHD_Library.f90
+++ b/util/EMPIRICAL/srcIE/MHD_Library.f90
@@ -89,9 +89,9 @@ subroutine MHD_GetLats(EIEi_nMLTs, EIEi_nLats, EIEi_nBLKs, LatsOut)
   do i = 1, EIEi_nMLTs
     do j = EIEi_nLats, 1, -1
       LatsOut(i, j, MHD_North_) = MHD_Lats(EIEi_nLats - j + 1)
-    end do
+    enddo
     LatsOut(i, 1:EIEi_nLats, MHD_South_) = -MHD_Lats(1:EIEi_nLats)
-  end do
+  enddo
 
 end subroutine MHD_GetLats
 
@@ -110,7 +110,7 @@ subroutine MHD_GetMLTs(EIEi_nMLTs, EIEi_nLats, EIEi_nBLKs, MLTsOut)
   do j = 1, EIEi_nLats
     MLTsOut(1:EIEi_nMLTs, j, 1) = MHD_MLTs(1:EIEi_nMLTs)
     MLTsOut(1:EIEi_nMLTs, j, 2) = MHD_MLTs(1:EIEi_nMLTs)
-  end do
+  enddo
 
 end subroutine MHD_GetMLTs
 
@@ -141,7 +141,7 @@ subroutine MHD_GetPotential(TimeIn, Method, &
     stop
   else
     PotentialOut = ValueOut
-  end if
+  endif
 
 end subroutine MHD_GetPotential
 
@@ -172,7 +172,7 @@ subroutine MHD_GetEFlux(TimeIn, Method, &
     stop
   else
     EFluxOut = ValueOut
-  end if
+  endif
 
 end subroutine MHD_GetEFlux
 
@@ -202,7 +202,7 @@ subroutine MHD_GetAveE(TimeIn, Method, &
     stop
   else
     AveEOut = ValueOut
-  end if
+  endif
 
 end subroutine MHD_GetAveE
 
@@ -237,9 +237,9 @@ subroutine MHD_GetValue(TimeIn, Method, &
       if ((iTime == MHD_nTimes) .and. (.not. IsDone)) then
         iTime = iTime + 1
         IsDone = .true.
-      end if
+      endif
       iTime = iTime + 1
-    end do
+    enddo
 
     if (iTime <= MHD_nTimes + 1) then
 
@@ -255,8 +255,8 @@ subroutine MHD_GetValue(TimeIn, Method, &
           ValueOut = -1.0e32
           iError = ecBeforeStartTime_
           return
-        end if
-      end if
+        endif
+      endif
     else
       dT = MHD_Time(2, iBLK) - MHD_Time(1, iBLK)
 
@@ -269,8 +269,8 @@ subroutine MHD_GetValue(TimeIn, Method, &
         ValueOut = -1.0e32
         iError = ecAfterEndTime_
         return
-      end if
-    end if
+      endif
+    endif
 
     if (Method == MHD_After_) then
       if (iBLK == MHD_South_) then
@@ -281,16 +281,16 @@ subroutine MHD_GetValue(TimeIn, Method, &
         do iLat = MHD_nLats, 1, -1
           ValueOut(1:MHD_nMLTs, iLat, iBLK) = &
             MHD_Value(1:MHD_nMLTs, MHD_nLats - iLat + 1, iTime, iBLK)
-        end do
-      end if
-    end if
+        enddo
+      endif
+    endif
 
     if (Method == MHD_Closest_) then
       if (iTime > 1) then
         if (abs(TimeIn - MHD_Time(iTime, iBLK)) > &
             abs(TimeIn - MHD_Time(iTime - 1, iBLK))) &
           iTime = iTime - 1
-      end if
+      endif
       if (iBLK == MHD_South_) then
         ValueOut(1:MHD_nMLTs, 1:MHD_nLats, iBLK) = &
           MHD_Value(1:MHD_nMLTs, 1:MHD_nLats, iTime, iBLK)
@@ -299,9 +299,9 @@ subroutine MHD_GetValue(TimeIn, Method, &
         do iLat = MHD_nLats, 1, -1
           ValueOut(1:MHD_nMLTs, iLat, iBLK) = &
             MHD_Value(1:MHD_nMLTs, MHD_nLats - iLat + 1, iTime, iBLK)
-        end do
-      end if
-    end if
+        enddo
+      endif
+    endif
 
     if (Method == MHD_Interpolate_) then
       ! This will do extrapolation if it is before the first time
@@ -322,11 +322,11 @@ subroutine MHD_GetValue(TimeIn, Method, &
             (1.0 - dt)*MHD_Value(1:MHD_nMLTs, MHD_nLats - iLat + 1, &
                                  iTime, iBLK) + &
             dt*MHD_Value(1:MHD_nMLTs, MHD_nLats - iLat + 1, iTime - 1, iBLK)
-        end do
-      end if
-    end if
+        enddo
+      endif
+    endif
 
-  end do
+  enddo
 
 end subroutine MHD_GetValue
 

--- a/util/EMPIRICAL/srcIE/ModAMIE_Interface.f90
+++ b/util/EMPIRICAL/srcIE/ModAMIE_Interface.f90
@@ -89,14 +89,14 @@ contains
     if (iError /= 0) then
       write(*, *) "Error in allocating array AMIE_Lats in "
       stop
-    end if
+    endif
 
     if (allocated(AMIE_Mlts)) deallocate(AMIE_Mlts)
     allocate(AMIE_Mlts(AMIE_nMlts), stat=iError)
     if (iError /= 0) then
       write(*, *) "Error in allocating array Mlts in "
       stop
-    end if
+    endif
 
     ! ------------------------------------------------------------
     ! This is the variable that holds all of the variables to allo
@@ -116,7 +116,7 @@ contains
     if (iError /= 0) then
       write(*, *) "Error in allocating array AMIE_Storage in readAMIEoutput"
       stop
-    end if
+    endif
 
     if (AMIE_iDebugLevel > 1) write(*, *) '  --> allocated the big array!'
 
@@ -140,7 +140,7 @@ contains
     if (iError /= 0) then
       write(*, *) "Error in allocating array AMIE_Value in "
       stop
-    end if
+    endif
 
     AMIE_Value = 0.0
 
@@ -152,7 +152,7 @@ contains
     if (iError /= 0) then
       write(*, *) "Error in allocating array AMIE_Interpolated in "
       stop
-    end if
+    endif
 
     AMIE_Value = 0.0
 
@@ -163,7 +163,7 @@ contains
     if (iError /= 0) then
       write(*, *) "Error in allocating array AMIETimes in "
       stop
-    end if
+    endif
 
     if (AMIE_iDebugLevel > 1) write(*, *) '  --> done allocating!'
 
@@ -186,45 +186,45 @@ contains
           iMap_(iVal) = iField
           if (AMIE_iDebugLevel > 1) &
             write(*, *) "<--- ", trim(AMIE_Names(iVal)), " Found", iField
-        end if
-      end do
-    end do
+        endif
+      enddo
+    enddo
     if (AMIE_iDebugLevel > 1) then
       write(*, *) 'Summary of variables found in AMIE file : '
       do iVal = 1, nValues
         if (iMap_(iVal) > 0) then
           write(*, *) 'Expected : ', trim(AMIE_Names(iVal)), &
             '; found : ', trim(Fields(iMap_(iVal)))
-        end if
-      end do
-    end if
+        endif
+      enddo
+    endif
 
     ! Check to see if some of these exist:
     if (iMap_(iPotential_) < 1) then
       call report_error_and_crash(1, "Could not find Potential in file!")
-    end if
+    endif
     if ((iMap_(iEle_diff_eflux_) < 1) .or. (iMap_(iEle_diff_avee_) < 0)) then
       call report_error_and_crash(1, "Could not find Electron Diffuse in file!")
-    end if
+    endif
 
     if ((iMap_(iIon_diff_eflux_) > 0) .and. (iMap_(iIon_diff_avee_) > 0)) then
       useIons = .true.
       if (AMIE_iDebugLevel > 1) write(*, *) "Input Electrodynamics is using Ions!"
     else
       useIons = .false.
-    end if
+    endif
     if ((iMap_(iEle_mono_eflux_) > 0) .and. (iMap_(iEle_mono_avee_) > 0)) then
       useMono = .true.
       if (AMIE_iDebugLevel > 1) write(*, *) "Input Electrodynamics is using Mono!"
     else
       useMono = .false.
-    end if
+    endif
     if ((iMap_(iEle_wave_eflux_) > 0) .and. (iMap_(iEle_wave_avee_) > 0)) then
       useWave = .true.
       if (AMIE_iDebugLevel > 1) write(*, *) "Input Electrodynamics is using Ions!"
     else
       useWave = .false.
-    end if
+    endif
 
   end subroutine AMIE_link_vars_to_keys
 

--- a/util/EMPIRICAL/srcIE/ModWeimer05.f90
+++ b/util/EMPIRICAL/srcIE/ModWeimer05.f90
@@ -51,27 +51,27 @@ contains
       write(6, "('>>> read_potential: file ',a,': incompatable csize: ',&
         &'csize_rd=',i4,' csize=',i4)") fname, csize_rd, csize
       stop 'csize'
-    end if
+    endif
     if (d1_rd /= d1_pot) then
       write(6, "('>>> read_potential: file ',a,': incompatable d1: ',&
         &'d1_rd=',i4,' d1_pot=',i4)") fname, d1_rd, d1_pot
       stop 'd1'
-    end if
+    endif
     if (d2_rd /= d2_pot) then
       write(6, "('>>> read_potential: file ',a,': incompatable d2: ',&
         &'d2_rd=',i4,' d2_pot=',i4)") fname, d2_rd, d2_pot
       stop 'd2'
-    end if
+    endif
     do i = 1, csize
       read(lu, "(6e20.9)") alschfits(:, i)
-    end do
+    enddo
     read(lu, "(2f10.3)") ex_pot
     read(lu, "(28i3)") ls
     read(lu, "(2i3)") maxl_pot, maxm_pot
     read(lu, "(28i3)") ms
     do i = 1, csize
       read(lu, "(6e20.9)") schfits(:, i)
-    end do
+    enddo
 
 !  write(6,"(/,'read_potential: Opened file ',a)") infile
 !  write(6,"('ab=',28i3)") ab
@@ -113,8 +113,8 @@ contains
     do i = 1, d3_scha
       do j = 1, d2_scha
         read(lu, "(6e20.9)") allnkm(:, j, i)
-      end do
-    end do
+      enddo
+    enddo
     read(lu, "(8f10.4)") th0s
 !
 ! write(6,"(/,'read_schatable: Opened file ',a)") infile
@@ -152,12 +152,12 @@ contains
       write(6, "('>>> read_potential: file ',a,': incompatable na: ',&
         &'rd_na=',i4,' na=',i4)") fname, rd_na, na
       stop 'na'
-    end if
+    endif
     if (rd_nb /= nb) then
       write(6, "('>>> read_potential: file ',a,': incompatable nb: ',&
         &'rd_nb=',i4,' nb=',i4)") fname, rd_nb, nb
       stop 'nb'
-    end if
+    endif
     read(lu, "(8e20.9)") bndya
     read(lu, "(8e20.9)") bndyb
     read(lu, "(8e20.9)") ex_bndy
@@ -211,7 +211,7 @@ contains
       write(6, "('>>> model=',a)") trim(model)
       write(6, "('>>> setmodel: model must be either epot or bpot')")
       stop 'setmodel'
-    end if
+    endif
 
 !   write(6,"('setmodel: by=',f8.2,' bz=',f8.2,' tilt=',f8.2,' swvel=',&
 !     &f8.2,' swden=',f8.2)") by,bz,tilt,swvel,swden
@@ -241,7 +241,7 @@ contains
       cos2a = 1.+bt*(cos2a - 1.)
       sina = bt*sina
       sin2a = bt*sin2a
-    end if
+    endif
     cfits = schfits ! schfits(d1_pot,csize) is in module read_data
     a = (/c0, swe, stilt, stilt2, swp, &
           swe*cosa, stilt*cosa, stilt2*cosa, swp*cosa, &
@@ -252,18 +252,18 @@ contains
       do j = 1, csize
         do i = 1, int(d1_pot)
           esphc(j) = esphc(j) + cfits(i, j)*a(i)
-        end do
-      end do
+        enddo
+      enddo
 !      write(6,"('setmodel: esphc=',/,(6e12.4))") esphc
     else
       bsphc(:) = 0.
       do j = 1, csize
         do i = 1, int(d1_pot)
           bsphc(j) = bsphc(j) + cfits(i, j)*a(i)
-        end do
-      end do
+        enddo
+      enddo
 !      write(6,"('setmodel: bsphc=',/,(6e12.4))") bsphc
-    end if
+    endif
   end subroutine setmodel
 !-----------------------------------------------------------------------
   subroutine setboundary(angle, bt, tilt, swvel, swden)
@@ -307,13 +307,13 @@ contains
       btx = btx*bt**ex_bndy(2)
     else
       cosa = 1.+bt*(cosa - 1.) ! remove angle dependency for IMF under 1 nT
-    end if
+    endif
     x = (/1., cosa, btx, btx*cosa, swvel, swp/)
     c = bndya
     bndyfitr = 0.
     do i = 1, na
       bndyfitr = bndyfitr + x(i)*c(i)
-    end do
+    enddo
 
 !   write(6,"('setboundary: cosa=',f8.3,' btx=',f8.3)") cosa,btx
 !   write(6,"('setboundary: x=',/,(6e12.4))") x
@@ -342,7 +342,7 @@ contains
     if (inside == 0) then
       epot = fill
       return
-    end if
+    endif
 !
 ! IDL code:
 ! phim=phir # replicate(1,maxm) * ((indgen(maxm)+1) ## replicate(1,n_elements(phir)))
@@ -364,7 +364,7 @@ contains
       if (skip == 1) then
         skip = 0
         cycle
-      end if
+      endif
       m = ms(j)
       if (ab(j) == 1) then
         plm = scplm(j, colat, nlm) ! scplm function is in this module
@@ -378,10 +378,10 @@ contains
         else
           z = z + plm*(esphc(j)*cospm(m) + esphc(j + 1)*sinpm(m))
           skip = 1
-        end if
+        endif
 
-      end if ! ab(j)
-    end do
+      endif ! ab(j)
+    enddo
     epot = z
   end subroutine epotval
 !-----------------------------------------------------------------------
@@ -409,7 +409,7 @@ contains
     if (inside == 0) then
       fac = fill
       return
-    end if
+    endif
 !
     phim(1) = phir
     phim(2) = phir*2.
@@ -421,7 +421,7 @@ contains
       if (skip == 1) then
         skip = 0
         cycle
-      end if
+      endif
       if (ls(j) >= 11) exit jloop
       m = ms(j)
       if (ab(j) == 1) then
@@ -434,9 +434,9 @@ contains
         else
           z = z - (plm*(bsphc(j)*cospm(m) + bsphc(j + 1)*sinpm(m)))
           skip = 1
-        end if
-      end if
-    end do jloop ! j=1,csize
+        endif
+      endif
+    enddo jloop ! j=1,csize
     pi = 4.*atan(1.)
     cfactor = -1.e5/(4.*pi*re**2) ! convert to uA/m2
     z = z*cfactor
@@ -468,14 +468,14 @@ contains
         write(6, "('>>> tablesize > mxtablesize: tablesize=',i5,&
           &' mxtablesize=',i5,' tn0=',e12.4)") tablesize, mxtablesize, th0
         stop 'tablesize'
-      end if
+      endif
 !     write(6,"('scplm: index=',i3,' colat=',f8.3,' th0=',e12.4,&
 !       &' tablesize=',i3)") index,colat,th0,tablesize
 !
       do i = 1, tablesize
         colattable(i) = float(i - 1)*(th0/float(tablesize - 1))
         cth(i) = cos(colattable(i)*deg2rad)
-      end do
+      enddo
 
 !     write(6,"('scplm: tablesize=',i4,' colattable=',/,(6f8.3))") &
 !       tablesize,colattable(1:tablesize)
@@ -488,7 +488,7 @@ contains
         if (skip == 1) then
           skip = 0
           cycle
-        end if
+        endif
         l = ls(j)
         m = ms(j)
 
@@ -507,11 +507,11 @@ contains
           plmtable(1, j + 1) = plmtable(1, j)
           nlms(j + 1) = nlms(j)
           skip = 1
-        end if
+        endif
 
-      end do ! j=1,csize
+      enddo ! j=1,csize
 
-    end if ! prevth0
+    endif ! prevth0
     nlm = nlms(index)
     colata(1) = colat
 
@@ -544,8 +544,8 @@ contains
     else
       do i = 1, tablesize
         a(i) = sqrt(1.-cth(i)**2)**m
-      end do
-    end if
+      enddo
+    endif
     xn = r*(r + 1.)
     x(:) = (1.-cth(:))/2.
 
@@ -563,7 +563,7 @@ contains
         rk = float(k)
         a(i) = a(i)*(x(i)*((rk + rm - 1.)*(rk + rm) - xn)/(rk*(rk + rm)))
         table(i) = table(i) + a(i) ! "result" in idl code
-      end do
+      enddo
 
 !     write(6,"('pm_n: k=',i3,' a=',/,(6(1pe12.4)))") k,a
 !     write(6,"('pm_n: k=',i3,' table=',/,(6(1pe12.4)))") k,table
@@ -573,7 +573,7 @@ contains
         div = abs(table(i))
         if (div <= 1.e-6) div = 1.e-6
         tmp(i) = abs(a(i))/div
-      end do
+      enddo
 
 !     write(6,"('pm_n: k=',i3,' abs(a)=',/,(6(1pe12.4)))") k,abs(a)
 !     write(6,"('pm_n: k=',i3,' abs(table)=',/,(6(1pe12.4)))") k,abs(table)
@@ -584,7 +584,7 @@ contains
 !       k,minval(table),maxval(table),minval(tmp),maxval(tmp)
 
       if (maxval(tmp) < 1.e-6) exit pmn_loop
-    end do pmn_loop
+    enddo pmn_loop
     ans = km_n(m, r)
 
 !   write(6,"('pm_n: ans=',1pe12.4,' table=',/,(6(1pe12.4)))") ans,table(1:tablesize)
@@ -610,7 +610,7 @@ contains
     if (m == 0) then
       km_n = 1.
       return
-    end if
+    endif
 
     rm = float(m)
     km_n = sqrt(2.*exp(lngamma(rn + rm + 1.) - lngamma(rn - rm + 1.)))/(2.**m*factorial(m))
@@ -635,22 +635,22 @@ contains
     if (th0 == 90.) then
       nkmlookup = float(k)
       return
-    end if
+    endif
     th0a(1) = th0
     kk = k + 1
     mm = m + 1
     if (kk > maxk_scha) then
       write(6, "('>>> nkmlookup: kk > maxk: kk=',i4,' maxk=',i4)") kk, maxk_scha
       call interpol_quad(allnkm(maxk_scha, mm, :), th0s, th0a, out)
-    end if
+    endif
     if (mm > maxm_scha) then
       write(6, "('>>> nkmlookup: mm > maxm: kk=',i4,' maxm=',i4)") kk, maxm_scha
       call interpol_quad(allnkm(kk, maxm_scha, :), th0s, th0a, out)
-    end if
+    endif
     if (th0 < th0s(1)) then
       write(6, "('>>> nkmlookup: th0 < th0s(1): th0=',e12.4,' th0s(1)=',e12.4)") &
         th0, th0s(1)
-    end if
+    endif
 
 !   write(6,"('nkmlookup call interpol: kk=',i3,' mm=',i3,' th0=',e12.4,&
 !     &' allnkm=',/,(6(1pe12.4)))") kk,mm,th0a,allnkm(kk,mm,:)
@@ -710,7 +710,7 @@ contains
 !
     do i = 1, 3
       pos(i) = tmat(1, i)*a + tmat(2, i)*b + tmat(3, i)*stc
-    end do
+    enddo
 
     latout = asin(pos(3))*rad2deg
     lonout = atan2(pos(2), pos(1))*rad2deg
@@ -741,13 +741,13 @@ contains
       write(6, "('>>> interpol_quad: nx /= nv: nx=',i4,' nv=',i4)") nx, nv
       p(:) = 0.
       return
-    end if
+    endif
     do i = 1, nu
       ix = value_locate(x, u(i))
       if (ix <= 1 .or. ix >= nx) then ! bug fix by btf 12/23/09
         p(i) = 0.
         cycle                       ! bug fix by btf 12/23/09
-      end if
+      endif
       x1 = x(ix)
       x0 = x(ix - 1)
       x2 = x(ix + 1)
@@ -755,7 +755,7 @@ contains
              v(ix)*(u(i) - x0)*(u(i) - x2)/((x1 - x0)*(x1 - x2)) + &
              v(ix + 1)*(u(i) - x0)*(u(i) - x1)/((x2 - x0)*(x2 - x1))
 
-    end do
+    enddo
 !   write(6,"('interpol_quad: nu=',i4,' p=',/,(1pe12.4)") nu,p
 
   end subroutine interpol_quad
@@ -780,13 +780,13 @@ contains
     if (val > vec(n)) then
       value_locate = n
       return
-    end if
+    endif
     do i = 1, n - 1
       if (val >= vec(i) .and. val <= vec(i + 1)) then
         value_locate = i
         return
-      end if
-    end do
+      endif
+    enddo
 
   end function value_locate
 !-----------------------------------------------------------------------
@@ -810,7 +810,7 @@ contains
     do j = 1, 5
       y = y + 1
       ser = ser + cof(j)/y
-    end do
+    enddo
     lngamma = -tmp + log(2.5066282746310005*ser/x)
   end function lngamma
 !-----------------------------------------------------------------------
@@ -822,15 +822,15 @@ contains
       write(6, "('>>> factorial: n must be positive: n=',i4)") n
       factorial = 0.
       return
-    end if
+    endif
     if (n == 1) then
       factorial = 1.
       return
-    end if
+    endif
     factorial = float(n)
     do m = n - 1, 1, -1
       factorial = factorial*float(m)
-    end do
+    enddo
   end function factorial
 !-----------------------------------------------------------------------
 end module w05sc

--- a/util/EMPIRICAL/srcIE/amies.f90
+++ b/util/EMPIRICAL/srcIE/amies.f90
@@ -26,7 +26,7 @@ subroutine amiedt(ilat, ilon, ntime, etheta, ephi, potkv)
     potkv = 0.0
     etheta = 0.0
     ephi = 0.0
-  end if
+  endif
 
 end subroutine amiedt
 
@@ -216,7 +216,7 @@ subroutine amiespot(by, bz, rmlat, rmlt, etheta, ephi, potkv)
   if (fmla1 > 90.) then
     fmla1 = 180.-fmla1
     xmlt1 = xmlt1 + 12.
-  end if
+  endif
   call amiemodel(xmlt1, fmla1, by, bz, p1, IncludeBackground)
   call amiemodel(xmlt, fmla - 1., by, bz, p2, IncludeBackground)
   etheta = (p1 - p2)/stepa
@@ -248,10 +248,10 @@ subroutine amiespot(by, bz, rmlat, rmlt, etheta, ephi, potkv)
     if (fmla1 .gt. 90.) then
       fmla1 = 180.-fmla1
       xmlt1 = xmlt1 + 12.
-    end if
+    endif
     call amiemodel(xmlt1, fmla1, by, bz, p1, IncludeBackground)
     call amiemodel(xmlt, fmla - 1., by, bz, p2, IncludeBackground)
-  end if
+  endif
 
   ephi = (p2 - p1)/step2
 
@@ -282,7 +282,7 @@ subroutine amiemodel(inmlt, inmlat, by, bz, pot, IncludeBackground)
   if (DebugLevel > 3) then
     write(*, *) "  ====> In subroutine amiemodel"
     write(*, *) "        inputs : ", inmlt, inmlat, by, bz, IncludeBackground
-  end if
+  endif
 
   ! turn latitude and mlt into grid point number
   ! with floating point, so if it is between a grid point, then we can
@@ -349,7 +349,7 @@ subroutine amiemodel(inmlt, inmlat, by, bz, pot, IncludeBackground)
 
     back = 0.0
 
-  end if
+  endif
 
   if (by <= 0.0) then
     poty = by*aspyn(ilon1, ilat1)*lowt1*lawt1 + &
@@ -361,7 +361,7 @@ subroutine amiemodel(inmlt, inmlat, by, bz, pot, IncludeBackground)
            by*aspyp(ilon1, ilat2)*lowt1*lawt2 + &
            by*aspyp(ilon2, ilat1)*lowt2*lawt1 + &
            by*aspyp(ilon2, ilat2)*lowt2*lawt2
-  end if
+  endif
 
   poty = poty/(lowt1*lawt1 + lowt1*lawt2 + lowt2*lawt1 + lowt2*lawt2)
 
@@ -375,7 +375,7 @@ subroutine amiemodel(inmlt, inmlat, by, bz, pot, IncludeBackground)
            bz*aspzp(ilon1, ilat2)*lowt1*lawt2 + &
            bz*aspzp(ilon2, ilat1)*lowt2*lawt1 + &
            bz*aspzp(ilon2, ilat2)*lowt2*lawt2
-  end if
+  endif
 
   potz = potz/(lowt1*lawt1 + lowt1*lawt2 + lowt2*lawt1 + lowt2*lawt2)
 
@@ -420,63 +420,63 @@ subroutine read_amies(unitin)
     read(unitin, '(A100)') line
     do i = 1, inlat
       read(unitin, fmt) (aspx(k, i), k=1, inlon)
-    end do
+    enddo
 
     read(unitin, '(A100)') line
     do i = 1, inlat
       read(unitin, fmt) (aspxi(k, i), k=1, inlon)
-    end do
+    enddo
 
     read(unitin, '(A100)') line
     do i = 1, inlat
       read(unitin, fmt) (aspyn(k, i), k=1, inlon)
-    end do
+    enddo
 
     read(unitin, '(A100)') line
     do i = 1, inlat
       read(unitin, fmt) (aspyni(k, i), k=1, inlon)
-    end do
+    enddo
 
     read(unitin, '(A100)') line
     do i = 1, inlat
       read(unitin, fmt) (aspyp(k, i), k=1, inlon)
-    end do
+    enddo
 
     read(unitin, '(A100)') line
     do i = 1, inlat
       read(unitin, fmt) (aspypi(k, i), k=1, inlon)
-    end do
+    enddo
 
     read(unitin, '(A100)') line
     do i = 1, inlat
       read(unitin, fmt) (aspzn(k, i), k=1, inlon)
-    end do
+    enddo
 
     read(unitin, '(A100)') line
     do i = 1, inlat
       read(unitin, fmt) (aspzni(k, i), k=1, inlon)
-    end do
+    enddo
 
     read(unitin, '(A100)') line
     do i = 1, inlat
       read(unitin, fmt) (aspzp(k, i), k=1, inlon)
-    end do
+    enddo
 
     read(unitin, '(A100)') line
     do i = 1, inlat
       read(unitin, fmt) (aspzpi(k, i), k=1, inlon)
-    end do
+    enddo
 
     read(unitin, '(A100)') line
     do i = 1, inlat
       read(unitin, fmt) (aspf(k, i), k=1, inlon)
-    end do
+    enddo
 
     read(unitin, '(A100)') line
     do i = 1, inlat
       read(unitin, fmt) (aspfi(k, i), k=1, inlon)
-    end do
+    enddo
 
-  end if
+  endif
 
 end subroutine read_amies

--- a/util/EMPIRICAL/srcIE/ihp.f90
+++ b/util/EMPIRICAL/srcIE/ihp.f90
@@ -41,7 +41,7 @@ subroutine read_conductance_model(iOutputError)
     if (ierr /= 0) then
       write(6, *) 'Error opening file :', ihp_file
       iOutputError = ecFileNotFound_
-    end if
+    endif
 
     longmx = 30
     latmx = 20
@@ -50,7 +50,7 @@ subroutine read_conductance_model(iOutputError)
 
     do n = 1, 4
       read(iunit, *) char80
-    end do
+    enddo
 
     if (iDebugLevel > 2) write(*, *) "===> Hall"
     read(iunit, *) char80
@@ -58,8 +58,8 @@ subroutine read_conductance_model(iOutputError)
       do ilat = latmx, 0, -1
         read(iunit, "(15f7.0)") (halar(ilon, ilat, n), ilon=0, 14)
         read(iunit, "(15f7.0)") (halar(ilon, ilat, n), ilon=15, 29)
-      end do
-    end do
+      enddo
+    enddo
     halar(longmx, :, :) = halar(0, :, :)
 
     halar(0:30, 0:latmx, 1:ndx) = scale*halar(0:30, 0:latmx, 1:ndx)
@@ -70,8 +70,8 @@ subroutine read_conductance_model(iOutputError)
       do ilat = latmx, 0, -1
         read(iunit, "(15f7.0)") (pedar(ilon, ilat, n), ilon=0, 14)
         read(iunit, "(15f7.0)") (pedar(ilon, ilat, n), ilon=15, 29)
-      end do
-    end do
+      enddo
+    enddo
     pedar(longmx, :, :) = pedar(0, :, :)
     pedar(0:30, 0:latmx, 1:ndx) = scale*pedar(0:30, 0:latmx, 1:ndx)
 
@@ -84,9 +84,9 @@ subroutine read_conductance_model(iOutputError)
         do ilon = 0, 29
           if (avkar(ilon, ilat, n) == 2855) &
             avkar(ilon, ilat, n) = ConductanceBackground(avee_)/scale
-        end do
-      end do
-    end do
+        enddo
+      enddo
+    enddo
     avkar(longmx, :, :) = avkar(0, :, :)
     avkar(0:30, 0:latmx, 1:ndx) = scale*avkar(0:30, 0:latmx, 1:ndx)
 
@@ -96,7 +96,7 @@ subroutine read_conductance_model(iOutputError)
       do ilat = latmx, 0, -1
         read(iunit, "(15f7.0)") (efxar(ilon, ilat, n), ilon=0, 14)
         read(iunit, "(15f7.0)") (efxar(ilon, ilat, n), ilon=15, 29)
-      end do
+      enddo
 !        if (UseExperimentalCode) then
 !           do ilon=0,29
 !              maxflx = 0
@@ -109,7 +109,7 @@ subroutine read_conductance_model(iOutputError)
 !              efxar(ilon,ilatsave,n) = efxar(ilon,ilatsave,n)*2
 !           enddo
 !        endif
-    end do
+    enddo
     efxar(longmx, :, :) = efxar(0, :, :)
     efxar(0:30, 0:latmx, 1:ndx) = scale*efxar(0:30, 0:latmx, 1:ndx)
 
@@ -130,18 +130,18 @@ subroutine read_conductance_model(iOutputError)
     open(iunit, file=pem_file, status='old', iostat=ierr)
     if (ierr /= 0) then
       write(6, *) 'Error opening file :', pem_file
-    end if
+    endif
 
     do n = 1, 4
       read(iunit, *) char80
-    end do
+    enddo
 
     do n = 1, ndx
       read(iunit, "(a80)") char80
       do ilat = latmx, 0, -1
         read(iunit, "(24f6.0)") (halar(ilon, ilat, n), ilon=0, 23)
-      end do
-    end do
+      enddo
+    enddo
     halar(longmx, :, :) = halar(0, :, :)
     halar = scale*halar
 
@@ -149,8 +149,8 @@ subroutine read_conductance_model(iOutputError)
       read(iunit, "(a80)") char80
       do ilat = latmx, 0, -1
         read(iunit, "(24f6.0)") (pedar(ilon, ilat, n), ilon=0, 23)
-      end do
-    end do
+      enddo
+    enddo
     pedar(longmx, :, :) = pedar(0, :, :)
     pedar = scale*pedar
 
@@ -158,8 +158,8 @@ subroutine read_conductance_model(iOutputError)
       read(iunit, "(a80)") char80
       do ilat = latmx, 0, -1
         read(iunit, "(24f6.0)") (avkar(ilon, ilat, n), ilon=0, 23)
-      end do
-    end do
+      enddo
+    enddo
     avkar(longmx, :, :) = avkar(0, :, :)
     avkar = scale*avkar
 
@@ -167,14 +167,14 @@ subroutine read_conductance_model(iOutputError)
       read(iunit, "(a80)") char80
       do ilat = latmx, 0, -1
         read(iunit, "(24f6.0)") (efxar(ilon, ilat, n), ilon=0, 23)
-      end do
-    end do
+      enddo
+    enddo
     efxar(longmx, :, :) = efxar(0, :, :)
     efxar = scale*efxar
 
     close(iunit)
 
-  end if
+  endif
 
   ! get minimum or average long. value at lowest lat.
 
@@ -192,12 +192,12 @@ subroutine read_conductance_model(iOutputError)
       pedmin(n) = amin1(pedmin(n), pedar(ilon, latmx, n))
       avk50(n) = avk50(n) + avkar(1, latmx, n)
       efx50(n) = efx50(n) + efxar(1, latmx, n)
-    end do
+    enddo
 
     avk50(n) = avk50(n)/float(longmx)
     efx50(n) = efx50(n)/float(longmx)
 
-  end do
+  enddo
 
   if (iDebugLevel > 3) write(*, *) "====> Done with read_conductance_model"
 
@@ -262,7 +262,7 @@ subroutine get_auroral_conductance(alatd, amlt, hpi, ped, hal, avkev, eflx)
     if (avkev < ConductanceBackground(avee_)) avkev = ConductanceBackground(avee_)
     if (eflx < ConductanceBackground(eflux_)) eflx = ConductanceBackground(eflux_)
 
-  end if
+  endif
 
   return
 

--- a/util/EMPIRICAL/srcIE/main_1.f90
+++ b/util/EMPIRICAL/srcIE/main_1.f90
@@ -32,42 +32,42 @@ program Interface
     write(*, *) "EIEi_HavenBLKs : ", EIEi_HavenBLKs
     write(*, *) "EIEi_HavenLats : ", EIEi_HavenLats
     write(*, *) "EIEi_HavenMLTs : ", EIEi_HavenMLTs
-  end if
+  endif
 
   allocate(EIEr3_HaveLats(EIEi_HavenMlts, EIEi_HavenLats, EIEi_HavenBLKs), &
            stat=iError)
   if (iError /= 0) then
     write(*, *) "Error in allocating array EIEr3_HaveLats in Interface"
     stop
-  end if
+  endif
 
   allocate(EIEr3_HaveMlts(EIEi_HavenMlts, EIEi_HavenLats, EIEi_HavenBLKs), &
            stat=iError)
   if (iError /= 0) then
     write(*, *) "Error in allocating array EIEr3_HaveMlts in Interface"
     stop
-  end if
+  endif
 
   allocate(EIEr3_HavePotential(EIEi_HavenMlts, EIEi_HavenLats, EIEi_HavenBLKs), &
            stat=iError)
   if (iError /= 0) then
     write(*, *) "Error in allocating array EIEr3_HavePotential in Interface"
     stop
-  end if
+  endif
 
   allocate(EIEr3_HaveEFlux(EIEi_HavenMlts, EIEi_HavenLats, EIEi_HavenBLKs), &
            stat=iError)
   if (iError /= 0) then
     write(*, *) "Error in allocating array EIEr3_HaveEFlux in Interface"
     stop
-  end if
+  endif
 
   allocate(EIEr3_HaveAveE(EIEi_HavenMlts, EIEi_HavenLats, EIEi_HavenBLKs), &
            stat=iError)
   if (iError /= 0) then
     write(*, *) "Error in allocating array EIEr3_HaveAveE in Interface"
     stop
-  end if
+  endif
 
   call AMIE_GetLats(EIEi_HavenMlts, EIEi_HavenLats, EIEi_HavenBLKs, &
                     EIEr3_HaveLats, iError)

--- a/util/EMPIRICAL/srcIE/main_2.f90
+++ b/util/EMPIRICAL/srcIE/main_2.f90
@@ -65,7 +65,7 @@ program GetEIE
   lats = 75.0
   do i = 1, 25
     mlts(i, 1) = float(i)
-  end do
+  enddo
 
   write(*, *) "Setting grid"
 
@@ -77,7 +77,7 @@ program GetEIE
     write(*, *) "Error : ", cErrorCodes(iError)
   else
     write(*, *) TempPotential
-  end if
+  endif
 
   call EIE_End(iError)
 

--- a/util/EMPIRICAL/srcIE/merge_str.f90
+++ b/util/EMPIRICAL/srcIE/merge_str.f90
@@ -12,19 +12,19 @@ subroutine merge_str(str1, str2)
             iachar(str1(i:i)) /= 9 .and. &
             i < 100)
     i = i + 1
-  end do
+  enddo
 
   j = 1
   do while (iachar(str2(j:j)) /= 32 .and. &
             iachar(str2(j:j)) /= 9 .and. &
             j < 100)
     j = j + 1
-  end do
+  enddo
 
   temp = str1
   do k = i, 100
     temp(k:k) = ' '
-  end do
+  enddo
 
   if (i + j - 1 > 100) j = 100 - i + 1
 
@@ -46,6 +46,6 @@ subroutine strlen(str1, len)
             iachar(str1(len:len)) /= 9 .and. &
             len < 100)
     len = len + 1
-  end do
+  enddo
 
 end subroutine strlen

--- a/util/EMPIRICAL/srcIE/readAMIEoutput.f90
+++ b/util/EMPIRICAL/srcIE/readAMIEoutput.f90
@@ -27,15 +27,15 @@ subroutine readAMIEvariables(AmieFile, nVars, varNames, iDebugLevel)
   read(iUnitTmp_) nVars
   do iVar = 1, nVars
     read(iUnitTmp_) varNames(iVar)
-  end do
+  enddo
   close(iUnitTmp_)
 
   if (iDebugLevel > 1) then
     write(*, *) "AMIE Variables : "
     do iVar = 1, nVars
       write(*, *) iVar, '. ', trim(varNames(iVar))
-    end do
-  end if
+    enddo
+  endif
   return
 end subroutine readAMIEvariables
 
@@ -92,7 +92,7 @@ subroutine readAMIEoutput(iBLK, IsMirror, iDebugGitm, iError)
   if (iError .ne. 0) then
     write(*, *) "Error opening file:", trim(AMIE_FileName)
     stop
-  end if
+  endif
   AMIE_nLats = 0
   IsBinary = .true.
 
@@ -100,7 +100,7 @@ subroutine readAMIEoutput(iBLK, IsMirror, iDebugGitm, iError)
   if ((iError .ne. 0) .or. (AMIE_nlats .gt. 500)) then
     write(*, *) "Error reading variables AMIE_nlats, AMIE_nmlts, AMIE_ntimes"
     IsBinary = .false.
-  end if
+  endif
   close(UnitTmp_)
 
   if (IsBinary) then
@@ -113,7 +113,7 @@ subroutine readAMIEoutput(iBLK, IsMirror, iDebugGitm, iError)
   else
     open(UnitTmp_, file=AMIE_FileName, status='old')
     read(UnitTmp_, *) AMIE_nlats, AMIE_nmlts, AMIE_ntimes
-  end if
+  endif
 
   !\
   ! We have run into a problem with AMIE during storms.
@@ -142,7 +142,7 @@ subroutine readAMIEoutput(iBLK, IsMirror, iDebugGitm, iError)
   if (iError /= 0) then
     write(*, *) "Error in allocating array AllData in "
     stop
-  end if
+  endif
 
   ! ---------------------------------------------------------------
   ! Read and extrapolate AMIE grid
@@ -157,12 +157,12 @@ subroutine readAMIEoutput(iBLK, IsMirror, iDebugGitm, iError)
     read(UnitTmp_, *) (AMIE_Lats(i), i=1, AMIE_nLats)
     read(UnitTmp_, *) (AMIE_Mlts(i), i=1, AMIE_nMlts)
     read(UnitTmp_, *) nFields
-  end if
+  endif
 
   if (nFields > nFieldsMax) then
     write(*, *) "Maximum number of fields in AMIE is ", nFieldsMax
     stop
-  end if
+  endif
 
   AMIE_Lats = 90.0 - AMIE_Lats
 
@@ -178,19 +178,19 @@ subroutine readAMIEoutput(iBLK, IsMirror, iDebugGitm, iError)
     if (iError /= 0) then
       write(*, *) "Error in allocating array TempLats in "
       stop
-    end if
+    endif
     TempLats = AMIE_Lats
     do i = 1, AMIE_nLats
       AMIE_Lats(i) = TempLats(AMIE_nLats + 1 - i)
-    end do
+    enddo
     ReverseLats = .true.
     deallocate(TempLats)
-  end if
+  endif
 
   do i = AMIE_nLats + 1, AMIE_nLats + nCellsPad
     AMIE_Lats(i) = AMIE_Lats(i - 1) + &
                    (AMIE_Lats(AMIE_nLats) - AMIE_Lats(AMIE_nLats - 1))
-  end do
+  enddo
 
   energyfluxconvert = .false.
 
@@ -199,8 +199,8 @@ subroutine readAMIEoutput(iBLK, IsMirror, iDebugGitm, iError)
       read(UnitTmp_) Fields(iField)
     else
       read(UnitTmp_, '(a)') Fields(iField)
-    end if
-  end do
+    endif
+  enddo
 
   ! Need to convert from W/m^2 to erg/cm2/s
   factor = 1.0
@@ -210,7 +210,7 @@ subroutine readAMIEoutput(iBLK, IsMirror, iDebugGitm, iError)
     unitConvert(iIon_diff_eflux_) = factor
     unitConvert(iEle_mono_eflux_) = factor
     unitConvert(iEle_wave_eflux_) = factor
-  end if
+  endif
 
   if (AMIE_iDebugLevel > 1) write(*, *) 'Reading AMIE data now...'
 
@@ -230,8 +230,8 @@ subroutine readAMIEoutput(iBLK, IsMirror, iDebugGitm, iError)
         else
           read(UnitTmp_) &
             ((AllData(j, i, iField), j=1, AMIE_nMlts), i=1, AMIE_nLats)
-        end if
-      end do
+        endif
+      enddo
 
     else
 
@@ -245,10 +245,10 @@ subroutine readAMIEoutput(iBLK, IsMirror, iDebugGitm, iError)
         else
           read(UnitTmp_, *) &
             ((AllData(j, i, iField), j=1, AMIE_nMlts), i=1, AMIE_nLats)
-        end if
-      end do
+        endif
+      enddo
 
-    end if
+    endif
 
     itime_i(1) = iyr
     itime_i(2) = imo
@@ -274,15 +274,15 @@ subroutine readAMIEoutput(iBLK, IsMirror, iDebugGitm, iError)
           do i = 1, AMIE_nMlts
             AMIE_Storage(iVal, i, 1:AMIE_nLats, iTime, iBLK) = &
               -AllData(AMIE_nMlts + 1 - i, 1:AMIE_nLats, iMap_(iVal))
-          end do
+          enddo
         else
           ! This is the default :
           !    (need loop for optimization issues in gfortran...)
           do i = 1, AMIE_nMlts
             AMIE_Storage(iVal, i, 1:AMIE_nLats, iTime, iBLK) = &
               AllData(i, 1:AMIE_nLats, iMap_(iVal))
-          end do
-        end if
+          enddo
+        endif
 
         ! If the variable is the potential, linearly interpolate it to lower
         ! latitudes, and then smooth it in mlt:
@@ -293,8 +293,8 @@ subroutine readAMIEoutput(iBLK, IsMirror, iDebugGitm, iError)
             do j = AMIE_nLats + 1, AMIE_nLats + nCellsPad
               AMIE_Storage(iVal, i, j, iTime, iBLK) = &
                 AMIE_Storage(iVal, i, j - 1, iTime, iBLK) - dPotential
-            end do
-          end do
+            enddo
+          enddo
           ! Then smooth the extension in MLT:
           do j = AMIE_nLats + 1, AMIE_nLats + nCellsPad
             ! We are going to smooth more and more as we go down in latitude
@@ -310,7 +310,7 @@ subroutine readAMIEoutput(iBLK, IsMirror, iDebugGitm, iError)
                   (AMIE_Storage(iVal, i - 1, j, iTime, iBLK) + &
                    2*AMIE_Storage(iVal, i, j, iTime, iBLK) + &
                    AMIE_Storage(iVal, i + 1, j, iTime, iBLK))/4.0
-              end do
+              enddo
 
               i = AMIE_nMlts
               AMIE_Storage(iVal, i, j, iTime, iBLK) = &
@@ -318,13 +318,13 @@ subroutine readAMIEoutput(iBLK, IsMirror, iDebugGitm, iError)
                  2*AMIE_Storage(iVal, i, j, iTime, iBLK) + &
                  AMIE_Storage(iVal, 2, j, iTime, iBLK))/4.0
 
-            end do
-          end do
-        end if
-      end if
-    end do
+            enddo
+          enddo
+        endif
+      endif
+    enddo
     if (AMIE_iDebugLevel > 1) write(*, *) '  --> Done with time '
-  end do
+  enddo
 
   if (AMIE_iDebugLevel > 1) write(*, *) 'Done Reading AMIE file '
   close(UnitTmp_)

--- a/util/EMPIRICAL/srcIE/readMHDoutput.f90
+++ b/util/EMPIRICAL/srcIE/readMHDoutput.f90
@@ -68,15 +68,15 @@ subroutine readMHDoutput(iBLK, iError)
         if (iFirstFile < 0) iFirstFile = ihr*60 + imi + 1
         MHD_ntimes = MHD_ntimes + 1
         FileNameList(ihr*60 + imi + 1) = FileName
-      end if
+      endif
 
-    end do
-  end do
+    enddo
+  enddo
 
   if (iFirstFile < 0) then
     write(*, *) "Could not find any MHD files which you specified!!!"
     stop
-  end if
+  endif
 
   FileName = FileNameList(iFirstFile)
 
@@ -84,7 +84,7 @@ subroutine readMHDoutput(iBLK, iError)
   if (iError .ne. 0) then
     write(*, *) "Error opening file:", FileName
     stop
-  end if
+  endif
   MHD_nLats = 0
 
   IsDone = .false.
@@ -112,14 +112,14 @@ subroutine readMHDoutput(iBLK, iError)
       if (iError /= 0) then
         write(*, *) "Error in allocating array MHD_Lats in "
         stop
-      end if
+      endif
 
       if (allocated(MHD_Mlts)) deallocate(MHD_Mlts)
       allocate(MHD_Mlts(MHD_nMlts), stat=iError)
       if (iError /= 0) then
         write(*, *) "Error in allocating array Mlts in "
         stop
-      end if
+      endif
 
       if (.not. allocated(MHD_Potential)) then
 
@@ -128,52 +128,52 @@ subroutine readMHDoutput(iBLK, iError)
         if (iError /= 0) then
           write(*, *) "Error in allocating array MHD_Potential in "
           stop
-        end if
+        endif
 
         allocate(MHD_EFlux(MHD_nMlts, MHD_nLats, &
                            MHD_nTimes, 2), stat=iError)
         if (iError /= 0) then
           write(*, *) "Error in allocating array MHD_EFlux in "
           stop
-        end if
+        endif
 
         allocate(MHD_AveE(MHD_nMlts, MHD_nLats, &
                           MHD_nTimes, 2), stat=iError)
         if (iError /= 0) then
           write(*, *) "Error in allocating array MHD_AveE in "
           stop
-        end if
+        endif
 
         allocate(MHD_Value(MHD_nMlts, MHD_nLats, &
                            MHD_nTimes, 2), stat=iError)
         if (iError /= 0) then
           write(*, *) "Error in allocating array MHD_Value in "
           stop
-        end if
+        endif
 
         allocate(SigmaP(MHD_nMlts, MHD_nLats, &
                         MHD_nTimes, 2), stat=iError)
         if (iError /= 0) then
           write(*, *) "Error in allocating array SigmaP in "
           stop
-        end if
+        endif
 
         allocate(SigmaH(MHD_nMlts, MHD_nLats, &
                         MHD_nTimes, 2), stat=iError)
         if (iError /= 0) then
           write(*, *) "Error in allocating array SigmaH in "
           stop
-        end if
+        endif
 
         allocate(MHD_Time(MHD_nTimes, 2), stat=iError)
         if (iError /= 0) then
           write(*, *) "Error in allocating array MHDTimes in "
           stop
-        end if
+        endif
 
-      end if
+      endif
 
-    end if
+    endif
 
     if (index(cLine, "BEGIN") > 0) then
 
@@ -183,14 +183,14 @@ subroutine readMHDoutput(iBLK, iError)
         i = mod(iMLT + (MHD_nMlts - 1)/2 - 1, (MHD_nMlts - 1)) + 1
         do iLat = 1, MHD_nLats
           read(UnitTmp_, *) MHD_Lats(iLat), MHD_Mlts(i)
-        end do
-      end do
+        enddo
+      enddo
 
       IsDone = .true.
 
-    end if
+    endif
 
-  end do
+  enddo
 
   MHD_Mlts(MHD_nMLTs) = MHD_Mlts(1)
 
@@ -200,20 +200,20 @@ subroutine readMHDoutput(iBLK, iError)
   do iMLT = 1, MHD_nMlts - 1
     if (MHD_Mlts(iMLT) - 12 > MHD_Mlts(iMLT + 1)) &
       MHD_Mlts(iMLT) = MHD_Mlts(iMLT) - 24
-  end do
+  enddo
 
   MHD_Lats = 90.0 - MHD_Lats
 
   if (nFields > nFieldsMax) then
     write(*, *) "Maximum number of fields in MHD is ", nFieldsMax
     stop
-  end if
+  endif
 
   allocate(AllData(MHD_nMlts, MHD_nLats, nFields), stat=iError)
   if (iError /= 0) then
     write(*, *) "Error in allocating array AllData in "
     stop
-  end if
+  endif
 
   MHD_iDebugLevel = 0
 
@@ -222,7 +222,7 @@ subroutine readMHDoutput(iBLK, iError)
       read(UnitTmp_) Fields(iField)
     else
       read(UnitTmp_, '(a)') Fields(iField)
-    end if
+    endif
 
     if (MHD_iDebugLevel > 1) write(*, *) Fields(iField)
 
@@ -230,21 +230,21 @@ subroutine readMHDoutput(iBLK, iError)
         (index(Fields(iField), "odel") < 1)) then
       iPot_ = iField
       if (MHD_iDebugLevel > 1) write(*, *) "<--- Potential Found", iPot_
-    end if
+    endif
 
     if ((index(Fields(iField), "Mean Energy") > 0) .and. &
         (index(Fields(iField), "odel") < 1)) then
       iAveE_ = iField
       if (MHD_iDebugLevel > 1) write(*, *) "<--- Mean Energy Found", iAveE_
-    end if
+    endif
 
     if ((index(Fields(iField), "Energy Flux") > 0) .and. &
         (index(Fields(iField), "odel") < 1)) then
       iEFlux_ = iField
       if (MHD_iDebugLevel > 1) write(*, *) "<--- Energy Flux Found", iEFlux_
-    end if
+    endif
 
-  end do
+  enddo
 
   do iTime = 1, MHD_ntimes
 
@@ -255,7 +255,7 @@ subroutine readMHDoutput(iBLK, iError)
 
       do iField = 1, nfields
         read(UnitTmp_) ((AllData(j, i, iField), j=1, MHD_nMlts), i=1, MHD_nLats)
-      end do
+      enddo
 
     else
 
@@ -264,9 +264,9 @@ subroutine readMHDoutput(iBLK, iError)
 
       do iField = 1, nfields
         read(UnitTmp_, *) ((AllData(j, i, iField), j=1, MHD_nMlts), i=1, MHD_nLats)
-      end do
+      enddo
 
-    end if
+    endif
 
     itime_i(1) = iyr
     itime_i(2) = imo
@@ -300,10 +300,10 @@ subroutine readMHDoutput(iBLK, iError)
         MHD_Potential(i, j, iTime, iBLK) = &
           MHD_Potential(i, j - 1, iTime, iBLK) - dPotential
 
-      end do
-    end do
+      enddo
+    enddo
 
-  end do
+  enddo
 
   MHD_nLats = MHD_nLats + nCellsPad
 

--- a/util/NOMPI/src/NOMPI.f90
+++ b/util/NOMPI/src/NOMPI.f90
@@ -67,8 +67,8 @@ integer function MPI_TYPE_SIZE(datatype)
       byte_i = byte_i/byte_c
       byte_r = byte_r/byte_c
       byte_d = byte_d/byte_c
-    end if
-  end if
+    endif
+  endif
 
   ! Some datatype values may coincide, so we use IF ELSEIF instead of CASE
 
@@ -85,7 +85,7 @@ integer function MPI_TYPE_SIZE(datatype)
   else
     write(*, *) 'Error in MPI_TYPE_SIZE: unknown datatype=', datatype
     MPI_TYPE_SIZE = -1
-  end if
+  endif
 
 end function MPI_TYPE_SIZE
 
@@ -131,7 +131,7 @@ subroutine MPI_SIMPLE_COPY(caller, sendbuf, sendcount, sendtype, &
     write(*, *) 'Error in MPI_SIMPLE_COPY called from '//caller// &
       'unknown data type(s)'
     stop
-  end if
+  endif
 
   if (recvbyte < sendbyte) then
     write(*, *) 'sendcount,sendtype,recvcount,recvtype,sendbyte,recvbyte=', &
@@ -139,7 +139,7 @@ subroutine MPI_SIMPLE_COPY(caller, sendbuf, sendcount, sendtype, &
     write(*, *) 'Error in MPI_SIMPLE_COPY called from '//caller// &
       ': recvbyte<sendbyte'
     stop
-  end if
+  endif
 
   recvbuf(1:sendbyte) = sendbuf(1:sendbyte)
 
@@ -189,13 +189,13 @@ subroutine MPI_LOCAL_MSG(caller, buf, count, datatype, rank, tag)
     write(*, *) 'Error in MPI_LOCAL_MSG called by '//caller// &
       ': source/dest rank is not 0'
     stop
-  end if
+  endif
 
   if (tag < 0 .and. tag /= MPI_ANY_TAG) then
     write(*, *) 'count,datatype,tag=', count, datatype, tag
     write(*, *) 'Error in MPI_LOCAL_MSG called by '//caller//': invalid tag'
     stop
-  end if
+  endif
 
   msg_length = MPI_TYPE_SIZE(datatype)*count
 
@@ -203,7 +203,7 @@ subroutine MPI_LOCAL_MSG(caller, buf, count, datatype, rank, tag)
     write(*, *) 'count,datatype,tag,msg_length=', count, datatype, tag, msg_length
     write(*, *) 'Error in MPI_LOCAL_MSG called by '//caller//': msg_length<1'
     stop
-  end if
+  endif
 
   if (.not. allocated(buffer)) then
     !write(*,*)'initial allocation: max_msg_length,max_msg_number=',&
@@ -214,7 +214,7 @@ subroutine MPI_LOCAL_MSG(caller, buf, count, datatype, rank, tag)
       msg_len(max_msg_number))
     msg_tag = MPI_ANY_TAG - 1
     msg_len = 0
-  end if
+  endif
 
   if (index(caller, 'RECV') > 0) then
     !write(*,*)'Receiving'
@@ -233,15 +233,15 @@ subroutine MPI_LOCAL_MSG(caller, buf, count, datatype, rank, tag)
           write(*, *) 'Error in MPI_LOCAL_MSG called by '//caller// &
             ': receive buffer is shorter than message'
           stop
-        end if
+        endif
         do j = 1, msg_len(i)
           buf(j:j) = buffer(j, i)
-        end do
+        enddo
         msg_tag(i) = MPI_ANY_TAG - 1
         msg_len(i) = 0
         RETURN
-      end if
-    end do
+      endif
+    enddo
     ! No matching message tag was found
     write(*, *) 'tag,count,datatype=', tag, count, datatype
     write(*, *) caller, ' was issued before corresponding SEND'
@@ -249,8 +249,8 @@ subroutine MPI_LOCAL_MSG(caller, buf, count, datatype, rank, tag)
       stop 'Error in MPI_LOCAL_COPY: change order of IRECV/SEND'
     else
       stop 'Error in MPI_LOCAL_COPY: incorrect order of RECV/SEND'
-    end if
-  end if ! RECV
+    endif
+  endif ! RECV
 
   ! SEND: store message into buffer
 
@@ -270,7 +270,7 @@ subroutine MPI_LOCAL_MSG(caller, buf, count, datatype, rank, tag)
 
     !write(*,*)'Increased max_msg_length from,to=',max_msg_length,2*msg_length
     max_msg_length = 2*msg_length
-  end if
+  endif
 
   if (msg_number > max_msg_number) then
     ! Increase second dimension of buffer, and length of msg_tag, msg_len
@@ -296,7 +296,7 @@ subroutine MPI_LOCAL_MSG(caller, buf, count, datatype, rank, tag)
     !write(*,*)'Increased max_msg_number from,to=',&
     !     max_msg_number,2*max_msg_number
     max_msg_number = 2*max_msg_number
-  end if
+  endif
 
   ! Store message into buffer
   do i = 1, msg_number
@@ -304,12 +304,12 @@ subroutine MPI_LOCAL_MSG(caller, buf, count, datatype, rank, tag)
       ! write(*,*)'Storing message into line i=',i
       do j = 1, msg_length
         buffer(j, i) = buf(j:j)
-      end do
+      enddo
       msg_tag(i) = tag
       msg_len(i) = msg_length
       RETURN
-    end if
-  end do
+    endif
+  enddo
 
   stop 'Impossible to get here in MPI_LOCAL_MSG'
 

--- a/util/TIMING/src/timing.f90
+++ b/util/TIMING/src/timing.f90
@@ -236,16 +236,16 @@ function timing_func_d(func_name, iclock, name, parent_name)
   if (.not. UseTiming) then
     timing_func_d = -1.0
     RETURN
-  end if
+  endif
 
   do i = 1, ntiming
     if (sa_name(i) == name .and. sa_name(ia_parent(i)) == parent_name) EXIT
-  end do
+  enddo
 
   if (i > ntiming) then
     timing_func_d = -1.0
     RETURN
-  end if
+  endif
 
   qclock = min(max(iclock, 1), maxclock)
 
@@ -253,7 +253,7 @@ function timing_func_d(func_name, iclock, name, parent_name)
     qsum = da_sum(i, qclock) + timing_cpu() - da_start(i)
   else
     qsum = da_sum(i, qclock)
-  end if
+  endif
 
   select case (func_name)
   case ('sum')
@@ -299,7 +299,7 @@ subroutine timing_start(name)
   do i = i_last + 1, ntiming
     if (ia_depth(i) == current_depth .and. &
         sa_name(i) == name) goto 100
-  end do
+  enddo
   ! New name
   if (ntiming == maxtiming - 1) write(*, *) &
     'WARNING: number of timings has reached maxtiming in ModTiming'
@@ -366,7 +366,7 @@ subroutine timing_stop(name)
   if (lVerbose > 2) then
     write(*, *) 'index, stop :', i, qnow
     write(*, *) 'clocks:', da_sum(i, :)
-  end if
+  endif
 
 end subroutine timing_stop
 
@@ -426,8 +426,8 @@ subroutine timing_reset(name, nclock)
       ia_iter(i, 1:nclock) = 0
       ia_call(i, 1:nclock) = 0
       da_sum(i, 1:nclock) = 0.0
-    end if
-  end do
+    endif
+  enddo
 
   if (name == '#all') step_reset(2:nclock) = step
 
@@ -473,7 +473,7 @@ subroutine timing_show(name, iclock)
       qsum = da_sum(i, qclock) + qnow - da_start(i)
     else
       qsum = da_sum(i, qclock)
-    end if
+    endif
 
     if (qclock == 1) then
       write(iUnit, '(5a,f8.2,a)') &
@@ -481,13 +481,13 @@ subroutine timing_show(name, iclock)
         ' (', s_parent(1:len_trim(s_parent)), '):', &
         qsum, ' sec'
       RETURN
-    end if
+    endif
 
     if (la_active(i_parent)) then
       qsumparent = da_sum(i_parent, qclock) + qnow - da_start(i_parent)
     else
       qsumparent = da_sum(i_parent, qclock)
-    end if
+    endif
     if (qsumparent <= 0.0) qsumparent = -1.0
 
     qiter = ia_iter(i, qclock); if (qiter < 1) qiter = -1
@@ -499,13 +499,13 @@ subroutine timing_show(name, iclock)
     else
       write(iUnit, '(a,i8,a,i8,a)') &
         ' from step', step_reset(qclock), ' to', step, ' :'
-    end if
+    endif
     write(iUnit, '(f8.2,a,f8.3,a,f8.3,a,f8.2,2a)') &
       qsum, ' sec, ', &
       qsum/qiter, ' s/iter', &
       qsum/qcall, ' s/call', &
       100*qsum/qsumparent, ' % of ', s_parent(1:len_trim(s_parent))
-  end do
+  enddo
 
 end subroutine timing_show
 
@@ -594,12 +594,12 @@ subroutine timing_tree(iclock, show_depth)
       write(iUnitT0, '(a,i8,a)') 'TITLE = "Timing at it=', step, '"'
       write(iUnitT0, '(a)') 'VARIABLES = '
       write(iUnitT0, '(a)') '  "PE"'
-    end if
+    endif
     iUnitT = io_unit_new()
     write(filename, '(a,i8.8,a,i6.6,a)') 'STDOUT/timing_it', step, '_pe', iProc, '.tec'
     open(UNIT=iUnitT, FILE=trim(filename), STATUS='unknown', FORM='formatted')
     write(iUnitT, *) iProc
-  end if
+  endif
 
   qclock = min(max(iclock, 2), maxclock)
 
@@ -612,7 +612,7 @@ subroutine timing_tree(iclock, show_depth)
       ' from step', step_reset(qclock), ' to', step
   else
     write(iUnit, '(a,i8)', ADVANCE='NO') ' at step', step
-  end if
+  endif
   write(iUnit, '(a,i4)') ' '//NameComp//' on PE ', iProc
 
   write(iUnit, '(a20,a7,a8,a9,a9,a9,a9)') &
@@ -627,13 +627,13 @@ subroutine timing_tree(iclock, show_depth)
     if (la_active(i)) then
       da_sum(i, :) = da_sum(i, :) + qnow - da_start(i)
       da_start(i) = qnow
-    end if
+    endif
     qsum = da_sum(i, qclock)
     if (DoSaveFile) then
       if (ia_iter(i, qclock) < 1) CYCLE
     else
       if (qsum < 0.0005) CYCLE
-    end if
+    endif
 
     qsumparent = da_sum(ia_parent(i), qclock)
     if (qsumparent < qsum) qsumparent = qsum
@@ -655,9 +655,9 @@ subroutine timing_tree(iclock, show_depth)
     if (DoSaveFile) then
       if (iProc == 0) then
         write(iUnitT0, '(a)') '  ".'//repeat(' ', indent)//trim(sa_name(i))//'"'
-      end if
+      endif
       write(iUnitT, *) qsum
-    end if
+    endif
 
     if (ia_depth(i) == 1) write(iUnit, '(a79)') sepline
 
@@ -668,7 +668,7 @@ subroutine timing_tree(iclock, show_depth)
       da_sum_other(i_depth) = qsum
     else
       da_sum_other(i_depth) = da_sum_other(i_depth) + qsum
-    end if
+    endif
 
     i_parent = i
     do qdepth = i_depth, ia_depth(i + 1) + 1, -1
@@ -698,13 +698,13 @@ subroutine timing_tree(iclock, show_depth)
       if (DoSaveFile) then
         if (iProc == 0) then
           write(iUnitT0, '(a)') '  ".'//repeat(' ', indent)//'#others'//'"'
-        end if
+        endif
         write(iUnitT, *) qsum
-      end if
+      endif
 
-    end do
+    enddo
     qdepth = i_depth
-  end do
+  enddo
   write(iUnit, '(a79)') sepline
 
   if (DoSaveFile) then
@@ -712,7 +712,7 @@ subroutine timing_tree(iclock, show_depth)
     write(iUnitT0, '(a)') ' I=NPEs, J=1, K=1, ZONETYPE=Ordered, DATAPACKING=POINT'
     close(iUnitT0)
     close(iUnitT)
-  end if
+  endif
 
 end subroutine timing_tree
 
@@ -758,18 +758,18 @@ subroutine timing_sort(iclock, show_length, unique)
       ! Check if the same name occured before or not
       do j = 1, qntiming
         if (sa_name(i) == sa_qname(j)) EXIT
-      end do
+      enddo
       sa_qname(j) = sa_name(i)
       if (la_active(i)) then
         qsum = da_sum(i, qclock) + qnow - da_start(i)
       else
         qsum = da_sum(i, qclock)
-      end if
+      endif
       da_qsum(j) = da_qsum(j) + qsum
       ia_qiter(j) = ia_qiter(j) + ia_iter(i, qclock)
       ia_qcall(j) = ia_qcall(j) + ia_call(i, qclock)
       if (j > qntiming) qntiming = j
-    end do
+    enddo
   else
     qntiming = ntiming
     sa_qname(1:ntiming) = sa_name(1:ntiming)
@@ -781,7 +781,7 @@ subroutine timing_sort(iclock, show_length, unique)
     end where
     ia_qiter(1:ntiming) = ia_iter(1:ntiming, qclock)
     ia_qcall(1:ntiming) = ia_call(1:ntiming, qclock)
-  end if
+  endif
 
   forall (i=1:qntiming) ia_sort(i) = i
 
@@ -791,16 +791,16 @@ subroutine timing_sort(iclock, show_length, unique)
         k = ia_sort(i)
         ia_sort(i) = ia_sort(j)
         ia_sort(j) = k
-      end if
-    end do
-  end do
+      endif
+    enddo
+  enddo
 
   qsummax = da_qsum(ia_sort(1))
 
   if (qsummax <= 0.0) then
     write(*, *) 'WARNING in timing_sort: Maximum timing is <= 0 !!!'
     RETURN
-  end if
+  endif
 
   write(iUnit, '(a79)') sepline
 
@@ -812,7 +812,7 @@ subroutine timing_sort(iclock, show_length, unique)
       ' from step', step_reset(qclock), ' to', step
   else
     write(iUnit, '(a,i8)', ADVANCE='NO') ' at step', step
-  end if
+  endif
   write(iUnit, '(a,i4)') ' '//NameComp//' on PE ', iProc
 
   write(iUnit, '(a20)', ADVANCE='NO') 'name'//spaces
@@ -826,7 +826,7 @@ subroutine timing_sort(iclock, show_length, unique)
     showntiming = min(show_length, qntiming)
   else
     showntiming = qntiming
-  end if
+  endif
 
   do k = 1, showntiming
     i = ia_sort(k)
@@ -841,7 +841,7 @@ subroutine timing_sort(iclock, show_length, unique)
       s_parent = sa_name(ia_parent(i))
       write(iUnit, '(a20)', ADVANCE='NO') &
         '('//s_parent(1:len_trim(s_parent))//')'//spaces
-    end if
+    endif
 
     write(iUnit, '(f10.2,f10.2)', ADVANCE='NO') qsum, 100*qsum/qsummax
 
@@ -849,18 +849,18 @@ subroutine timing_sort(iclock, show_length, unique)
     write(iUnit, *)
     if (ia_depth(i) == 1) write(iUnit, '(a79)') sepline
 
-  end do
+  enddo
 
   qsum = 0
   do k = showntiming + 1, qntiming
     i = ia_sort(k)
     qsum = qsum + da_qsum(i)
-  end do
+  enddo
   if (qsum > 0.0) then
     write(iUnit, '(a20)', ADVANCE='NO') '#others'//spaces
     if (.not. unique) write(iUnit, '(a20)', ADVANCE='NO') ' '
     write(iUnit, '(f8.2,f8.2)') qsum, 100*qsum/qsummax
-  end if
+  endif
 
   write(iUnit, '(a79)') sepline
 

--- a/util/TIMING/src/timing_test.f90
+++ b/util/TIMING/src/timing_test.f90
@@ -32,7 +32,7 @@ program timing_test
       timing_version_name(1:len_trim(timing_version_name))//' version ', &
       timing_version_number, ' functional=', timing_version_on
     write(*, '(a)') '========================================================='
-  end if
+  endif
 
   ! Time processor 0 only
   ! Other processors can also call timing routines, but it has no effect
@@ -45,7 +45,7 @@ program timing_test
     call timing_active(.true.)
     call timing_depth(3)
     call timing_step(0)
-  end if
+  endif
 
   call timing_start('timing_test')
 
@@ -64,7 +64,7 @@ program timing_test
     write(*, *) '============================================================'
     write(*, *) '               STARTING ITERATIONS'
     write(*, *) '============================================================'
-  end if
+  endif
   do
     if (n_iter >= 10) EXIT
 
@@ -82,22 +82,22 @@ program timing_test
       call sleep(0.02)
       call timing_stop('calc_facevalues')
       call sleep(0.01) ! other stuff
-    end do
+    enddo
     call timing_stop('advance_expl')
     if (n_iter == 5) then
       call timing_tree(2, 2)
       call timing_reset('#all', 2)
-    end if
+    endif
 
     if (me_world == 0) write(*, *) 'speed:', &
       100/max(1.D-10, timing_func_d('sum', 1, 'advance_expl', 'timing_test')), &
       ' at n_step=', n_step
-  end do
+  enddo
   if (me_world == 0) then
     write(*, *) '============================================================'
     write(*, *) '               STOPPING ITERATIONS'
     write(*, *) '============================================================'
-  end if
+  endif
   call timing_start('calc_gradients')
   call timing_start('apply_limiters')
   call sleep(0.01)
@@ -113,7 +113,7 @@ program timing_test
     write(*, *) '============================================================'
     write(*, *) '               STOPPING CALCULATIONS'
     write(*, *) '============================================================'
-  end if
+  endif
 
   call timing_report_style('tree')
   call timing_report
@@ -145,7 +145,7 @@ contains
     time_before = MPI_WTIME()
     do
       if (MPI_WTIME() > time_before + len) EXIT
-    end do
+    enddo
   end subroutine sleep
 
 end program timing_test


### PR DESCRIPTION
## ***NOTE***

This uses an updated fprettify. Make sure to update your installation

To do this, (activate your environment if you use one and) run:

```sh
cd /path/to/fprettify
git pull
pip install .
```

# [sty] Update formatting

Only changes to whitespace, no changes to outputs expected.

A small change also made to `.gitignore`, reverting a previous commit. Still stylistic so it's ok to put here...


Tested with clean install of formatter in CLI mode & from within the bundled python script. Code still compiles too, which is not a surprise.