### PR TITLE
[BUG] Implement data validity check in src/read_sme

### DIFF
--- a/src/read_sme.f90
+++ b/src/read_sme.f90
@@ -143,7 +143,7 @@ subroutine read_sme(iOutputError, StartTime, EndTime, doUseAeForHp)
   logical, intent(in) :: doUseAeForHp
 
   integer :: ierror, iAE, j, npts
-  logical :: IsDone
+  logical :: IsDone, IsGoodTime, IsGoodData
 
   ! One line of input
   character(len=iCharLenIndices_) :: line
@@ -228,10 +228,13 @@ subroutine read_sme(iOutputError, StartTime, EndTime, doUseAeForHp)
 
       ! This makes sure that we only store the values that we
       ! are really interested in
-
-      if (IndexTimes_TV(iAE, ae_) >= StartTime - BufferTime .and. &
-          IndexTimes_TV(iAE, ae_) <= EndTime + BufferTime .and. &
-          iAE < MaxIndicesEntries) then
+      IsGoodTime = (IndexTimes_TV(iAE, ae_) >= StartTime - BufferTime .and. &
+                    IndexTimes_TV(iAE, ae_) <= EndTime + BufferTime .and. &
+                    iAE < MaxIndicesEntries)
+      IsGoodData = (abs(Indices_TV(iAE, ae_)) < 90000 .and. &
+           abs(Indices_TV(iAE, al_)) < 90000 .and. &
+           abs(Indices_TV(iAE, au_)) < 90000)
+      if (IsGoodTime .and. IsGoodData) then
 
         ! Can now use AE to specify the hemispheric power:
         ! Formula taken from Wu et al, 2021.


### PR DESCRIPTION
null data is set to 99,999, so this should work. Can set the threshold lower if we want to...

# [BUG/FEAT/DOC/*etc.*] Quick fix to check validity of sme data

- I check if `abs(data) < 90000`, which should grab null values
- Put time check into a variable so the code is a little cleaner...

Fix for issue #26 ... Look at me using GitHub the right way!


Formatted and tested (gfortran), all looks OK to me. Errors when it should & passes when it should...

> Tests might fail depending on whether formatting fix has gone thru yet. Probably should put this onto #24 but I'm not because we use git correctly.