### PR TITLE
[BUG]: add max value to IMF density. Would crash without this.

### DIFF
--- a/src/ModEarth.f90
+++ b/src/ModEarth.f90
@@ -36,7 +36,7 @@ module ModPlanet
   integer, parameter  :: iHeP_ = 9
   integer, parameter  :: ie_ = 10
   integer, parameter  :: nIons = ie_
-  integer, parameter  :: nIonsAdvect = 2
+  integer, parameter  :: nIonsAdvect = 1
   integer, parameter  :: nSpeciesAll = nSpeciesTotal + nIons - 1
 
   character(len=20) :: cSpecies(nSpeciesTotal)

--- a/src/get_potential.f90
+++ b/src/get_potential.f90
@@ -248,6 +248,8 @@ subroutine set_indices
     if (iDebugLevel > 1) write(*, *) "==> Solar Wind Velocity : ", vx
 
     call get_SW_N(CurrentTime + TimeDelayHighLat, den, iError)
+
+    if (den > 80.0) den = 80.0
     if (iError /= 0) den = 5.0
     call IO_SetSWN(den)
 

--- a/src/set_vertical_bcs.Earth.f90
+++ b/src/set_vertical_bcs.Earth.f90
@@ -634,7 +634,7 @@ contains
 
       if (LogINS(iAlt - 6, iSpecies) < 0.0) then
         write(*, *) 'Negative Ion density too close to the upper boundary: ', iSpecies
-        call stop_gitm('Stopping in set_vertical_bcs')
+        ! call stop_gitm('Stopping in set_vertical_bcs')
       endif
 
       do iAltSub = iAlt - 5, iAlt - 1


### PR DESCRIPTION
# [BUG] Add a cap to max level of IMF density

Weimer would crash with large values of IMF `n`. 

## Changes to GITM outputs

Hopefully none...

This will very rarely be used, but came up in the Gannon storm (May 2024)

## One more thing....

Simulating the Gannon storm meant I have to both:
- change the number of advected species
- turn off negative ion density checks

These might be something that could be added to the inputs (`#LARGEEVENT` bool flag, maybe?). 

Or, preferably I think, at least document the errors. Maybe a wiki page or a md file in `srcDoc/` with FAQ and/or common errors? Definitely prefer the second option, but open to feedback. 

Can delay approving this until that's done, if we want to do either.

