### PR TITLE
[BUG] Update version of uploader when building docs

### DIFF
--- a/.github/workflows/build-docs.yml
+++ b/.github/workflows/build-docs.yml
@@ -15,7 +15,7 @@ jobs:
       - name: Clone GITM repository
         uses: actions/checkout@v4
       - name: Compile LaTeX document
-        uses: xu-cheng/latex-action@v3
+        uses: xu-cheng/latex-action@v4
         with:
           root_file: manual.tex
           working_directory: srcDoc


### PR DESCRIPTION
The tests failed with v3. Update to v4.

# [BUG] **Update documentation build action**

Only one character was changed. Should be an easy PR to close. Tested this on my fork and it worked.