### PR TITLE
Fix gitm as bcs

### DIFF
--- a/src/ModInputs.f90
+++ b/src/ModInputs.f90
@@ -285,7 +285,7 @@ module ModInputs
   real    :: CO2ppm = 225.0
 
   logical :: DoN4SHack = .false.
-  
+
   ! Allow the user to change the planet's characteristics:
   real :: RotationPeriodInput = Rotation_Period
   real :: OmegaBodyInput = 2.0*pi/Rotation_Period

--- a/src/ModReadGitm3d.f90
+++ b/src/ModReadGitm3d.f90
@@ -3,7 +3,8 @@
 
 module ModReadGitm3d
 
-  use ModInputs, only: iCharLen_
+  use ModGITM, only: iCommGITM
+  use ModInputs, only: iCharLen_, iDebugLevel
 
   integer, parameter :: Real8_ = selected_real_kind(12, 100)
   integer, parameter :: i3dall_ = 1
@@ -349,6 +350,8 @@ contains
 
   subroutine GetGitmFileList(iError)
 
+    
+    
     integer, intent(out) :: iError
     character(len=nGitmCharLength) :: Dummy
     real(Real8_) :: time
@@ -357,8 +360,12 @@ contains
 
     ! First try 3DALL files:
     ! write(*, *) 'ls -1 '//trim(GitmDir)//'3DALL*.bin > .list_of_gitm_files 2> .gitm_err'
-    call execute_command_line('ls -1 '//trim(GitmDir)// &
-                              '3DALL*.bin > .list_of_gitm_files 2> .gitm_err')
+    if (iProc == 0) then
+       call execute_command_line('ls -1 '//trim(GitmDir)// &
+            '3DALL*.bin > .list_of_gitm_files 2> .gitm_err')
+    endif
+    call MPI_BARRIER(iCommGITM, iError)
+    
     nGitmFiles = 0
     open(iGitmUnit, file='.list_of_gitm_files', status='old')
     iError = 0
@@ -370,8 +377,11 @@ contains
 
     if (nGitmFiles == 0) then
       ! Second try LST files:
-      call execute_command_line('ls -1 '//GitmDir// &
-                                '3DLST*.bin > .list_of_gitm_files 2> .gitm_err')
+       if (iProc == 0) then
+          call execute_command_line('ls -1 '//GitmDir// &
+               '3DLST*.bin > .list_of_gitm_files 2> .gitm_err')
+       endif
+       call MPI_BARRIER(iCommGITM, iError)
       nGitmFiles = 0
       open(iGitmUnit, file='.list_of_gitm_files', status='old')
       iError = 0

--- a/src/ModReadGitm3d.f90
+++ b/src/ModReadGitm3d.f90
@@ -5,8 +5,8 @@ module ModReadGitm3d
 
   use ModGITM, only: iCommGITM
   use ModInputs, only: iCharLen_, iDebugLevel
-
-  integer, parameter :: Real8_ = selected_real_kind(12, 100)
+  use ModKind, ONLY: Real8_
+  
   integer, parameter :: i3dall_ = 1
   integer, parameter :: i3dlst_ = 2
   integer, parameter :: nGitmCharLength = iCharLen_
@@ -324,13 +324,13 @@ contains
 
     if (iGitmIndex /= iGitmIndexOld) then
 
-       if (iDebugLevel > 0) &
-            write(*, *) 'Reading First File : ', trim(GitmFileList(iGitmIndex - 1))
+       if (iDebugLevel > -1) &
+            write(*, *) '> GITM BCs -> Reading First File : ', trim(GitmFileList(iGitmIndex - 1))
        call GitmReadFile(GitmFileList(iGitmIndex - 1), iError)
        GitmDataTwoFiles(1, :, :, :, :) = GitmDataDummy
 
        if (iDebugLevel > 0) &
-            write(*, *) 'Reading Second File : ', trim(GitmFileList(iGitmIndex))
+            write(*, *) '   -> Reading Second File : ', trim(GitmFileList(iGitmIndex))
        call GitmReadFile(GitmFileList(iGitmIndex), iError)
        GitmDataTwoFiles(2, :, :, :, :) = GitmDataDummy
 
@@ -350,8 +350,6 @@ contains
 
   subroutine GetGitmFileList(iError)
 
-    
-    
     integer, intent(out) :: iError
     character(len=nGitmCharLength) :: Dummy
     real(Real8_) :: time
@@ -549,6 +547,20 @@ contains
     deallocate(GitmInAlts)
     deallocate(GitmOutData)
 
+    deallocate(GitmLonsIndex)
+    deallocate(GitmLatsIndex)
+    deallocate(GitmAltsIndex)
+
+    deallocate(GitmLonsFactor)
+    deallocate(GitmLatsFactor)
+    deallocate(GitmAltsFactor)
+
+    deallocate(GitmLons)
+    deallocate(GitmLats)
+    deallocate(GitmAlts)
+
+    iGitmIndexOld = -1
+    
   end subroutine GitmShutDown
 
   !---------------------------------------------------------------------------

--- a/src/ModReadGitm3d.f90
+++ b/src/ModReadGitm3d.f90
@@ -6,7 +6,7 @@ module ModReadGitm3d
   use ModGITM, only: iCommGITM
   use ModInputs, only: iCharLen_, iDebugLevel
   use ModKind, ONLY: Real8_
-  
+
   integer, parameter :: i3dall_ = 1
   integer, parameter :: i3dlst_ = 2
   integer, parameter :: nGitmCharLength = iCharLen_
@@ -149,7 +149,7 @@ contains
 
     integer :: iPoint, i
     logical :: IsAllGood
-    
+
     GitmInLons = InLons
     GitmInLats = InLats
     GitmInAlts = inAlts
@@ -157,113 +157,113 @@ contains
 
     do iPoint = 1, nPointsToGetGitm
 
-       ! Lons First
-       if (InLons(iPoint) < GitmLons(1)) then
+      ! Lons First
+      if (InLons(iPoint) < GitmLons(1)) then
+        GitmLonsIndex(iPoint) = -1
+        IsAllGood = .false.
+        if (iDebugLevel > -1) &
+          write(*, *) 'GitmLonsIndex < 0!', InLons(iPoint), GitmLons(1)
+      else
+        if (InLons(iPoint) > GitmLons(nLonsGitm)) then
           GitmLonsIndex(iPoint) = -1
           IsAllGood = .false.
           if (iDebugLevel > -1) &
-               write(*,*) 'GitmLonsIndex < 0!', InLons(iPoint), GitmLons(1)
-       else
-          if (InLons(iPoint) > GitmLons(nLonsGitm)) then
-             GitmLonsIndex(iPoint) = -1
-             IsAllGood = .false.
-             if (iDebugLevel > -1) &
-                  write(*,*) 'GitmLonsIndex > max!', InLons(iPoint), GitmLons(nLonsGitm)
+            write(*, *) 'GitmLonsIndex > max!', InLons(iPoint), GitmLons(nLonsGitm)
+        else
+          if (InLons(iPoint) == GitmLons(nLonsGitm)) then
+            i = nLonsGitm
           else
-             if (InLons(iPoint) == GitmLons(nLonsGitm)) then
-                i = nLonsGitm
-             else
-                i = 2
-                do while (GitmLons(i) <= InLons(iPoint))
-                   i = i + 1
-                enddo
-             endif
-             GitmLonsIndex(iPoint) = i
-             GitmLonsFactor(iPoint) = &
-                  (GitmLons(i) - InLons(iPoint))/ &
-                  (GitmLons(i) - GitmLons(i - 1))
+            i = 2
+            do while (GitmLons(i) <= InLons(iPoint))
+              i = i + 1
+            enddo
           endif
-       endif
-       
-       ! Lats
-       if (InLats(iPoint) < GitmLats(1)) then
+          GitmLonsIndex(iPoint) = i
+          GitmLonsFactor(iPoint) = &
+            (GitmLons(i) - InLons(iPoint))/ &
+            (GitmLons(i) - GitmLons(i - 1))
+        endif
+      endif
+
+      ! Lats
+      if (InLats(iPoint) < GitmLats(1)) then
+        i = -1
+        IsAllGood = .false.
+        if (iDebugLevel > -1) &
+          write(*, *) 'GitmLatsIndex < 0!', InLats(iPoint), GitmLats(1)
+      else
+        if (InLats(iPoint) > GitmLats(nLatsGitm)) then
           i = -1
           IsAllGood = .false.
           if (iDebugLevel > -1) &
-               write(*,*) 'GitmLatsIndex < 0!', InLats(iPoint), GitmLats(1)
-       else
-          if (InLats(iPoint) > GitmLats(nLatsGitm)) then
-             i = -1
-             IsAllGood = .false.
-             if (iDebugLevel > -1) &
-                  write(*,*) 'GitmLatsIndex > max!', InLats(iPoint), GitmLats(nLonsGitm)
+            write(*, *) 'GitmLatsIndex > max!', InLats(iPoint), GitmLats(nLonsGitm)
+        else
+          if (InLats(iPoint) == GitmLats(nLatsGitm)) then
+            i = nLatsGitm
           else
-             if (InLats(iPoint) == GitmLats(nLatsGitm)) then
-                i = nLatsGitm
-             else
-                i = 2
-                do while (GitmLats(i) <= InLats(iPoint))
-                   i = i + 1
-                enddo
-             endif
-             GitmLatsIndex(iPoint) = i
-             GitmLatsFactor(iPoint) = &
-                  (GitmLats(i) - InLats(iPoint))/ &
-                  (GitmLats(i) - GitmLats(i - 1))
+            i = 2
+            do while (GitmLats(i) <= InLats(iPoint))
+              i = i + 1
+            enddo
           endif
-       endif
+          GitmLatsIndex(iPoint) = i
+          GitmLatsFactor(iPoint) = &
+            (GitmLats(i) - InLats(iPoint))/ &
+            (GitmLats(i) - GitmLats(i - 1))
+        endif
+      endif
 
-       ! Alts
-       if (InAlts(iPoint) < GitmAlts(1)) then
+      ! Alts
+      if (InAlts(iPoint) < GitmAlts(1)) then
+        i = -1
+      else
+        if (InAlts(iPoint) > GitmAlts(nAltsGitm)) then
           i = -1
-       else
-          if (InAlts(iPoint) > GitmAlts(nAltsGitm)) then
-             i = -1
+        else
+          if (InAlts(iPoint) >= GitmAlts(nAltsGitm)) then
+            i = nAltsGitm
           else
-             if (InAlts(iPoint) >= GitmAlts(nAltsGitm)) then
-                i = nAltsGitm
-             else
-                i = 2
-                do while (GitmAlts(i) <= InAlts(iPoint))
-                   i = i + 1
-                enddo
-             endif
+            i = 2
+            do while (GitmAlts(i) <= InAlts(iPoint))
+              i = i + 1
+            enddo
           endif
-       endif
+        endif
+      endif
 
-       if (i > -1) then
-          GitmAltsIndex(iPoint) = i
+      if (i > -1) then
+        GitmAltsIndex(iPoint) = i
+        GitmAltsFactor(iPoint) = &
+          (GitmAlts(i) - InAlts(iPoint))/ &
+          (GitmAlts(i) - GitmAlts(i - 1))
+      else
+        ! Extrapolate the values:
+        if (InAlts(iPoint) < GitmAlts(1)) then
+          GitmAltsIndex(iPoint) = 2
           GitmAltsFactor(iPoint) = &
-               (GitmAlts(i) - InAlts(iPoint))/ &
-               (GitmAlts(i) - GitmAlts(i - 1))
-       else
-          ! Extrapolate the values:
-          if (InAlts(iPoint) <  GitmAlts(1)) then
-             GitmAltsIndex(iPoint) = 2
-             GitmAltsFactor(iPoint) = &
-                  (GitmAlts(2) - InAlts(iPoint))/ &
-                  (GitmAlts(2) - GitmAlts(1))
-          endif
-          if (InAlts(iPoint) >  GitmAlts(nAltsGitm)) then
-             GitmAltsIndex(iPoint) = nAltsGitm
-             GitmAltsFactor(iPoint) = &
-                  (GitmAlts(nAltsGitm) - InAlts(iPoint))/ &
-                  (GitmAlts(nAltsGitm) - GitmAlts(nAltsGitm - 1))
-          endif
-       endif
+            (GitmAlts(2) - InAlts(iPoint))/ &
+            (GitmAlts(2) - GitmAlts(1))
+        endif
+        if (InAlts(iPoint) > GitmAlts(nAltsGitm)) then
+          GitmAltsIndex(iPoint) = nAltsGitm
+          GitmAltsFactor(iPoint) = &
+            (GitmAlts(nAltsGitm) - InAlts(iPoint))/ &
+            (GitmAlts(nAltsGitm) - GitmAlts(nAltsGitm - 1))
+        endif
+      endif
     enddo
 
     if (.not. IsAllGood) then
-       if (iDebugLevel > -1) then
-          write(*, *) 'Errors can happen if the requested grid extends'
-          write(*, *) 'beyond the grid of the original GITM run.'
-          write(*, *) 'This can happen because of ghostcells and resolution.'
-          write(*, *) 'Move edges away from boundaries and improve'
-          write(*, *) 'resolution, maybe?'
-       endif
-       call stop_gitm("Stopping in ModReadGitm3d.")
+      if (iDebugLevel > -1) then
+        write(*, *) 'Errors can happen if the requested grid extends'
+        write(*, *) 'beyond the grid of the original GITM run.'
+        write(*, *) 'This can happen because of ghostcells and resolution.'
+        write(*, *) 'Move edges away from boundaries and improve'
+        write(*, *) 'resolution, maybe?'
+      endif
+      call stop_gitm("Stopping in ModReadGitm3d.")
     endif
-    
+
   end subroutine GitmSetGrid
 
   !---------------------------------------------------------------------------
@@ -324,17 +324,17 @@ contains
 
     if (iGitmIndex /= iGitmIndexOld) then
 
-       if (iDebugLevel > -1) &
-            write(*, *) '> GITM BCs -> Reading First File : ', trim(GitmFileList(iGitmIndex - 1))
-       call GitmReadFile(GitmFileList(iGitmIndex - 1), iError)
-       GitmDataTwoFiles(1, :, :, :, :) = GitmDataDummy
+      if (iDebugLevel > -1) &
+        write(*, *) '> GITM BCs -> Reading First File : ', trim(GitmFileList(iGitmIndex - 1))
+      call GitmReadFile(GitmFileList(iGitmIndex - 1), iError)
+      GitmDataTwoFiles(1, :, :, :, :) = GitmDataDummy
 
-       if (iDebugLevel > 0) &
-            write(*, *) '   -> Reading Second File : ', trim(GitmFileList(iGitmIndex))
-       call GitmReadFile(GitmFileList(iGitmIndex), iError)
-       GitmDataTwoFiles(2, :, :, :, :) = GitmDataDummy
+      if (iDebugLevel > 0) &
+        write(*, *) '   -> Reading Second File : ', trim(GitmFileList(iGitmIndex))
+      call GitmReadFile(GitmFileList(iGitmIndex), iError)
+      GitmDataTwoFiles(2, :, :, :, :) = GitmDataDummy
 
-       iGitmIndexOld = iGitmIndex
+      iGitmIndexOld = iGitmIndex
 
     endif
 
@@ -359,11 +359,11 @@ contains
     ! First try 3DALL files:
     ! write(*, *) 'ls -1 '//trim(GitmDir)//'3DALL*.bin > .list_of_gitm_files 2> .gitm_err'
     if (iProc == 0) then
-       call execute_command_line('ls -1 '//trim(GitmDir)// &
-            '3DALL*.bin > .list_of_gitm_files 2> .gitm_err')
+      call execute_command_line('ls -1 '//trim(GitmDir)// &
+                                '3DALL*.bin > .list_of_gitm_files 2> .gitm_err')
     endif
     call MPI_BARRIER(iCommGITM, iError)
-    
+
     nGitmFiles = 0
     open(iGitmUnit, file='.list_of_gitm_files', status='old')
     iError = 0
@@ -375,11 +375,11 @@ contains
 
     if (nGitmFiles == 0) then
       ! Second try LST files:
-       if (iProc == 0) then
-          call execute_command_line('ls -1 '//GitmDir// &
-               '3DLST*.bin > .list_of_gitm_files 2> .gitm_err')
-       endif
-       call MPI_BARRIER(iCommGITM, iError)
+      if (iProc == 0) then
+        call execute_command_line('ls -1 '//GitmDir// &
+                                  '3DLST*.bin > .list_of_gitm_files 2> .gitm_err')
+      endif
+      call MPI_BARRIER(iCommGITM, iError)
       nGitmFiles = 0
       open(iGitmUnit, file='.list_of_gitm_files', status='old')
       iError = 0
@@ -560,7 +560,7 @@ contains
     deallocate(GitmAlts)
 
     iGitmIndexOld = -1
-    
+
   end subroutine GitmShutDown
 
   !---------------------------------------------------------------------------

--- a/src/ModReadGitm3d.f90
+++ b/src/ModReadGitm3d.f90
@@ -147,99 +147,122 @@ contains
     real, dimension(nPointsToGetGitm), intent(in) :: InAlts
 
     integer :: iPoint, i
-
+    logical :: IsAllGood
+    
     GitmInLons = InLons
     GitmInLats = InLats
     GitmInAlts = inAlts
+    IsAllGood = .true.
 
     do iPoint = 1, nPointsToGetGitm
 
-      ! Lons First
-      if (InLons(iPoint) < GitmLons(1)) then
-        GitmLonsIndex(iPoint) = -1
-      else
-        if (InLons(iPoint) > GitmLons(nLonsGitm)) then
+       ! Lons First
+       if (InLons(iPoint) < GitmLons(1)) then
           GitmLonsIndex(iPoint) = -1
-        else
-          if (InLons(iPoint) == GitmLons(nLonsGitm)) then
-            i = nLonsGitm
+          IsAllGood = .false.
+          if (iDebugLevel > -1) &
+               write(*,*) 'GitmLonsIndex < 0!', InLons(iPoint), GitmLons(1)
+       else
+          if (InLons(iPoint) > GitmLons(nLonsGitm)) then
+             GitmLonsIndex(iPoint) = -1
+             IsAllGood = .false.
+             if (iDebugLevel > -1) &
+                  write(*,*) 'GitmLonsIndex > max!', InLons(iPoint), GitmLons(nLonsGitm)
           else
-            i = 2
-            do while (GitmLons(i) <= InLons(iPoint))
-              i = i + 1
-            enddo
+             if (InLons(iPoint) == GitmLons(nLonsGitm)) then
+                i = nLonsGitm
+             else
+                i = 2
+                do while (GitmLons(i) <= InLons(iPoint))
+                   i = i + 1
+                enddo
+             endif
+             GitmLonsIndex(iPoint) = i
+             GitmLonsFactor(iPoint) = &
+                  (GitmLons(i) - InLons(iPoint))/ &
+                  (GitmLons(i) - GitmLons(i - 1))
           endif
-          GitmLonsIndex(iPoint) = i
-          GitmLonsFactor(iPoint) = &
-            (GitmLons(i) - InLons(iPoint))/ &
-            (GitmLons(i) - GitmLons(i - 1))
-        endif
-      endif
-
-      ! Lats
-      if (InLats(iPoint) < GitmLats(1)) then
-        i = -1
-      else
-        if (InLats(iPoint) > GitmLats(nLatsGitm)) then
+       endif
+       
+       ! Lats
+       if (InLats(iPoint) < GitmLats(1)) then
           i = -1
-        else
-          if (InLats(iPoint) == GitmLats(nLatsGitm)) then
-            i = nLatsGitm
+          IsAllGood = .false.
+          if (iDebugLevel > -1) &
+               write(*,*) 'GitmLatsIndex < 0!', InLats(iPoint), GitmLats(1)
+       else
+          if (InLats(iPoint) > GitmLats(nLatsGitm)) then
+             i = -1
+             IsAllGood = .false.
+             if (iDebugLevel > -1) &
+                  write(*,*) 'GitmLatsIndex > max!', InLats(iPoint), GitmLats(nLonsGitm)
           else
-            i = 2
-            do while (GitmLats(i) <= InLats(iPoint))
-              i = i + 1
-            enddo
+             if (InLats(iPoint) == GitmLats(nLatsGitm)) then
+                i = nLatsGitm
+             else
+                i = 2
+                do while (GitmLats(i) <= InLats(iPoint))
+                   i = i + 1
+                enddo
+             endif
+             GitmLatsIndex(iPoint) = i
+             GitmLatsFactor(iPoint) = &
+                  (GitmLats(i) - InLats(iPoint))/ &
+                  (GitmLats(i) - GitmLats(i - 1))
           endif
-          GitmLatsIndex(iPoint) = i
-          GitmLatsFactor(iPoint) = &
-            (GitmLats(i) - InLats(iPoint))/ &
-            (GitmLats(i) - GitmLats(i - 1))
-        endif
-      endif
+       endif
 
-      ! Alts
-      if (InAlts(iPoint) < GitmAlts(1)) then
-        i = -1
-      else
-        if (InAlts(iPoint) > GitmAlts(nAltsGitm)) then
+       ! Alts
+       if (InAlts(iPoint) < GitmAlts(1)) then
           i = -1
-        else
-          if (InAlts(iPoint) >= GitmAlts(nAltsGitm)) then
-            i = nAltsGitm
+       else
+          if (InAlts(iPoint) > GitmAlts(nAltsGitm)) then
+             i = -1
           else
-            i = 2
-            do while (GitmAlts(i) <= InAlts(iPoint))
-              i = i + 1
-            enddo
+             if (InAlts(iPoint) >= GitmAlts(nAltsGitm)) then
+                i = nAltsGitm
+             else
+                i = 2
+                do while (GitmAlts(i) <= InAlts(iPoint))
+                   i = i + 1
+                enddo
+             endif
           endif
-        endif
-     endif
+       endif
 
-     if (i > -1) then
-        GitmAltsIndex(iPoint) = i
-        GitmAltsFactor(iPoint) = &
-             (GitmAlts(i) - InAlts(iPoint))/ &
-             (GitmAlts(i) - GitmAlts(i - 1))
-     else
-        ! Extrapolate the values:
-        if (InAlts(iPoint) <  GitmAlts(1)) then
-           GitmAltsIndex(iPoint) = 2
-           GitmAltsFactor(iPoint) = &
-                (GitmAlts(2) - InAlts(iPoint))/ &
-                (GitmAlts(2) - GitmAlts(1))
-        endif
-        if (InAlts(iPoint) >  GitmAlts(nAltsGitm)) then
-           GitmAltsIndex(iPoint) = nAltsGitm
-           GitmAltsFactor(iPoint) = &
-                (GitmAlts(nAltsGitm) - InAlts(iPoint))/ &
-                (GitmAlts(nAltsGitm) - GitmAlts(nAltsGitm - 1))
-        endif
-     endif
-
-     
+       if (i > -1) then
+          GitmAltsIndex(iPoint) = i
+          GitmAltsFactor(iPoint) = &
+               (GitmAlts(i) - InAlts(iPoint))/ &
+               (GitmAlts(i) - GitmAlts(i - 1))
+       else
+          ! Extrapolate the values:
+          if (InAlts(iPoint) <  GitmAlts(1)) then
+             GitmAltsIndex(iPoint) = 2
+             GitmAltsFactor(iPoint) = &
+                  (GitmAlts(2) - InAlts(iPoint))/ &
+                  (GitmAlts(2) - GitmAlts(1))
+          endif
+          if (InAlts(iPoint) >  GitmAlts(nAltsGitm)) then
+             GitmAltsIndex(iPoint) = nAltsGitm
+             GitmAltsFactor(iPoint) = &
+                  (GitmAlts(nAltsGitm) - InAlts(iPoint))/ &
+                  (GitmAlts(nAltsGitm) - GitmAlts(nAltsGitm - 1))
+          endif
+       endif
     enddo
 
+    if (.not. IsAllGood) then
+       if (iDebugLevel > -1) then
+          write(*, *) 'Errors can happen if the requested grid extends'
+          write(*, *) 'beyond the grid of the original GITM run.'
+          write(*, *) 'This can happen because of ghostcells and resolution.'
+          write(*, *) 'Move edges away from boundaries and improve'
+          write(*, *) 'resolution, maybe?'
+       endif
+       call stop_gitm("Stopping in ModReadGitm3d.")
+    endif
+    
   end subroutine GitmSetGrid
 
   !---------------------------------------------------------------------------
@@ -300,15 +323,17 @@ contains
 
     if (iGitmIndex /= iGitmIndexOld) then
 
-      write(*, *) 'Reading First File : ', GitmFileList(iGitmIndex - 1)
-      call GitmReadFile(GitmFileList(iGitmIndex - 1), iError)
-      GitmDataTwoFiles(1, :, :, :, :) = GitmDataDummy
+       if (iDebugLevel > 0) &
+            write(*, *) 'Reading First File : ', trim(GitmFileList(iGitmIndex - 1))
+       call GitmReadFile(GitmFileList(iGitmIndex - 1), iError)
+       GitmDataTwoFiles(1, :, :, :, :) = GitmDataDummy
 
-      write(*, *) 'Reading Second File : ', GitmFileList(iGitmIndex)
-      call GitmReadFile(GitmFileList(iGitmIndex), iError)
-      GitmDataTwoFiles(2, :, :, :, :) = GitmDataDummy
+       if (iDebugLevel > 0) &
+            write(*, *) 'Reading Second File : ', trim(GitmFileList(iGitmIndex))
+       call GitmReadFile(GitmFileList(iGitmIndex), iError)
+       GitmDataTwoFiles(2, :, :, :, :) = GitmDataDummy
 
-      iGitmIndexOld = iGitmIndex
+       iGitmIndexOld = iGitmIndex
 
     endif
 

--- a/src/advance_horizontal.f90
+++ b/src/advance_horizontal.f90
@@ -360,7 +360,7 @@ subroutine advance_horizontal(iBlock)
           IsFound = .false.
           do iSpecies = 1, nSpecies
             if (NewNum_CV(iLon, iLat, iSpecies) < 0.0) then
-              write(*, *) "Species : ", iSpecies, iLon, iLat, iBlock
+              write(*, *) "Species : ", iSpecies, iLon, iLat, iAlt, iBlock
               stop
               NewNum_CV(iLon, iLat, iSpecies) = 1.0
               IsFound = .true.

--- a/src/check_for_nans.f90
+++ b/src/check_for_nans.f90
@@ -151,27 +151,27 @@ subroutine correct_min_ion_density
   integer :: iLon, iLat, iAlt, iIon
 
   if (minval(IDensityS) < MinIonDensity) then
-     if (iDebugLevel > 5) &
-          write(*,*) "low ion density found... replacing with min ion density"
-     do iIon = 1, nIons
-        if (minval(IDensityS(:,:,:,iIon,1)) < MinIonDensity) then
-           do iLon = -1, nLons + 2
-              do iLat = -1, nLats + 2
-                 do iAlt = -1, nAlts + 2
-                    if (iDensityS(iLon, iLat, iAlt, iIon, 1) < MinIonDensity) then
-                       if (iDebugLevel > 7) &
-                            write(*, *) ' -> low density found in iDensityS : ', &
-                            iLon, iLat, iAlt, iProc, iIon, iDensityS(iLon, iLat, iAlt, iIon, 1), &
-                            MinIonDensity
-                       iDensityS(iLon, iLat, iAlt, iIon, 1) = MinIonDensity
-                    endif
-                 enddo
-              enddo
-           enddo
-        endif
-     enddo
+    if (iDebugLevel > 5) &
+      write(*, *) "low ion density found... replacing with min ion density"
+    do iIon = 1, nIons
+      if (minval(IDensityS(:, :, :, iIon, 1)) < MinIonDensity) then
+        do iLon = -1, nLons + 2
+          do iLat = -1, nLats + 2
+            do iAlt = -1, nAlts + 2
+              if (iDensityS(iLon, iLat, iAlt, iIon, 1) < MinIonDensity) then
+                if (iDebugLevel > 7) &
+                  write(*, *) ' -> low density found in iDensityS : ', &
+                  iLon, iLat, iAlt, iProc, iIon, iDensityS(iLon, iLat, iAlt, iIon, 1), &
+                  MinIonDensity
+                iDensityS(iLon, iLat, iAlt, iIon, 1) = MinIonDensity
+              endif
+            enddo
+          enddo
+        enddo
+      endif
+    enddo
   endif
 
   return
-  
+
 end subroutine correct_min_ion_density

--- a/src/check_for_nans.f90
+++ b/src/check_for_nans.f90
@@ -144,14 +144,34 @@ end subroutine check_for_nans_temps
 subroutine correct_min_ion_density
   ! Corrects for ion densities below MinIonDensity
 
+  use ModSizeGitm
   use ModGitm
-  use ModInputs, only: minIonDensity
-
+  use ModInputs, only: minIonDensity, iDebugLevel
   implicit none
+  integer :: iLon, iLat, iAlt, iIon
 
-  if (minval(IDensityS) < MinIonDensity) &
-    ! This vectorizes the drop-in replacement, similar to np.where(). Syntax is:
-    ! out  = merge(value_if_true, value_if_false, condition)
-    IDensityS = merge(IDensityS, MinIonDensity, IDensityS < minIonDensity)
+  if (minval(IDensityS) < MinIonDensity) then
+     if (iDebugLevel > 5) &
+          write(*,*) "low ion density found... replacing with min ion density"
+     do iIon = 1, nIons
+        if (minval(IDensityS(:,:,:,iIon,1)) < MinIonDensity) then
+           do iLon = -1, nLons + 2
+              do iLat = -1, nLats + 2
+                 do iAlt = -1, nAlts + 2
+                    if (iDensityS(iLon, iLat, iAlt, iIon, 1) < MinIonDensity) then
+                       if (iDebugLevel > 7) &
+                            write(*, *) ' -> low density found in iDensityS : ', &
+                            iLon, iLat, iAlt, iProc, iIon, iDensityS(iLon, iLat, iAlt, iIon, 1), &
+                            MinIonDensity
+                       iDensityS(iLon, iLat, iAlt, iIon, 1) = MinIonDensity
+                    endif
+                 enddo
+              enddo
+           enddo
+        endif
+     enddo
+  endif
 
+  return
+  
 end subroutine correct_min_ion_density

--- a/src/init_altitude.f90
+++ b/src/init_altitude.f90
@@ -16,8 +16,8 @@ subroutine get_temperature(lon, lat, alt, t, h)
   !---------------------------------------------------------------------------
   if (UseMsis) then
 
-     call initialize_msis_routines
-     call get_msis_temperature(lon, lat, alt, t, h)
+    call initialize_msis_routines
+    call get_msis_temperature(lon, lat, alt, t, h)
 
   else
 

--- a/src/init_iri.Earth.f90
+++ b/src/init_iri.Earth.f90
@@ -174,8 +174,8 @@ subroutine init_iri
 
           IDensityS(iLon, iLat, iAlt, nIons, iBlock) = 0.0
           do iIon = 1, nIons - 1
-             if (IDensityS(iLon, iLat, iAlt, iIon, iBlock) < minIonDensity) &
-                  IDensityS(iLon, iLat, iAlt, iIon, iBlock) = minIonDensity
+            if (IDensityS(iLon, iLat, iAlt, iIon, iBlock) < minIonDensity) &
+              IDensityS(iLon, iLat, iAlt, iIon, iBlock) = minIonDensity
             IDensityS(iLon, iLat, iAlt, nIons, iBlock) = &
               IDensityS(iLon, iLat, iAlt, nIons, iBlock) + &
               IDensityS(iLon, iLat, iAlt, iIon, iBlock)

--- a/src/init_iri.Earth.f90
+++ b/src/init_iri.Earth.f90
@@ -139,7 +139,7 @@ subroutine init_iri
           !             utime/3600.+25.,geo_alt,nzkm
 
           ! zero out densities that are not set below
-          IRIDensity(iLon, iLat, iAlt, :, iBlock) = 1.0
+          IRIDensity(iLon, iLat, iAlt, :, iBlock) = minIonDensity
 
           call iri90(jf, jmag, geo_lat, geo_lon, -f107, -iJulianDay, &
                      utime/3600.+25., geo_alt, nzkm, 'UA/DataIn/ccir.cofcnts', &
@@ -153,9 +153,9 @@ subroutine init_iri
           IRIDensity(iLon, iLat, iAlt, iNOP_, iBlock) = &
             abs(outf(9, 1)*outf(1, 1))/100.0 + 1
           IRIDensity(iLon, iLat, iAlt, iHP_, iBlock) = &
-            1.0 ! abs(outf(6,1)*outf(1,1))/100.0+1
+            minIonDensity ! abs(outf(6,1)*outf(1,1))/100.0+1
           IRIDensity(iLon, iLat, iAlt, iHeP_, iBlock) = &
-            1.0 ! abs(outf(7,1)*outf(1,1))/100.0+1
+            minIonDensity ! abs(outf(7,1)*outf(1,1))/100.0+1
 
           ! IRI Ne from 60(day)/80(night) - 1000 km (-1 missing),
           !  ions 100-1000 km
@@ -174,6 +174,8 @@ subroutine init_iri
 
           IDensityS(iLon, iLat, iAlt, nIons, iBlock) = 0.0
           do iIon = 1, nIons - 1
+             if (IDensityS(iLon, iLat, iAlt, iIon, iBlock) < minIonDensity) &
+                  IDensityS(iLon, iLat, iAlt, iIon, iBlock) = minIonDensity
             IDensityS(iLon, iLat, iAlt, nIons, iBlock) = &
               IDensityS(iLon, iLat, iAlt, nIons, iBlock) + &
               IDensityS(iLon, iLat, iAlt, iIon, iBlock)

--- a/src/init_msis.Earth.f90
+++ b/src/init_msis.Earth.f90
@@ -29,7 +29,7 @@ subroutine call_msis(lonDeg, latDeg, altKm, f107, f107a, densities10, temp)
   use ModConstants, only: Boltzmanns_Constant, AMU
 
   implicit none
-  
+
   real, intent(in) :: lonDeg, latDeg, altKm, f107, f107a
   real, intent(out) :: densities10(10)
   real, intent(out) :: temp
@@ -58,52 +58,52 @@ subroutine call_msis(lonDeg, latDeg, altKm, f107, f107a, densities10, temp)
   AP = 10
 
   if (useMsis21) then
-     iyd = iJulianDay
-     sec = utime
-     alt = altKm
-     glat = latDeg
-     glong = lonDeg
-     stl = LST
-     f107a_4 = f107a
-     f107_4 = f107
-     ap_4 = AP
-     ! mass is not used, but passed anyways
-     mass = -1     
-     call gtd8d(iyd,sec,alt,glat,glong,stl,f107a_4,f107_4,ap_4,mass,d,t)
-     temp = t(2)
-     ! Convert to /m3
-     ! 10th density is NO now!
-     densities10 = d * 1e6
+    iyd = iJulianDay
+    sec = utime
+    alt = altKm
+    glat = latDeg
+    glong = lonDeg
+    stl = LST
+    f107a_4 = f107a
+    f107_4 = f107
+    ap_4 = AP
+    ! mass is not used, but passed anyways
+    mass = -1
+    call gtd8d(iyd, sec, alt, glat, glong, stl, f107a_4, f107_4, ap_4, mass, d, t)
+    temp = t(2)
+    ! Convert to /m3
+    ! 10th density is NO now!
+    densities10 = d*1e6
   else
-     CALL GTD7(iJulianDay, utime, AltKm, LatDeg, LonDeg, LST, &
-          f107a, f107, AP, 48, msis_dens9, msis_temp)
-     temp = msis_temp(2)
-     densities10(1:9) = msis_dens9
+    CALL GTD7(iJulianDay, utime, AltKm, LatDeg, LonDeg, LST, &
+              f107a, f107, AP, 48, msis_dens9, msis_temp)
+    temp = msis_temp(2)
+    densities10(1:9) = msis_dens9
 
-     ! Very old code:
-     !  ! The initial profile of [NO] is refered to:
-     !  !  [Charles A. Barth, AGU, 1995]
-     !
-     !  if (geo_alt < 120.) then
-     !     NDensityS(iLon,iLat,iAlt,iNO_,iBlock)=  &
-     !          max(1e14-1e10*abs((geo_alt-110.0))**3.5, 100.0)
-     !          !10**(-0.003*(geo_alt-105.)**2 +14+LOG10(3.))
-     !  else
-     !     m = (1e10-3.9e13)/(200)
-     !     k = 1e10+(-m*300.)
-     !     NDensityS(iLon,iLat,iAlt,iNO_,iBlock)=  &
-     !          MAX(k+(m*geo_alt)-(geo_alt - 120.0)**2,100.0)
-     !       !   MAX(10**(13.-LOG10(3.)*(geo_alt-165.)/35.),1.0)
-     !  endif
-     !
-     ffactor = 6.36*log(f107) - 13.8
-     no = (ffactor*1.0e13 + 8.0e13)*1.24 ! 12.4 ! 12.4 is roughly exp
-     ! This is obviously an approximation:
-     h = Boltzmanns_Constant * msis_temp(2)/ &
-          (9.5 * 28.0 * AMU)/1000.0
-     densities10(10) = no * exp(-(altKm - 100.0)/h)
+    ! Very old code:
+    !  ! The initial profile of [NO] is refered to:
+    !  !  [Charles A. Barth, AGU, 1995]
+    !
+    !  if (geo_alt < 120.) then
+    !     NDensityS(iLon,iLat,iAlt,iNO_,iBlock)=  &
+    !          max(1e14-1e10*abs((geo_alt-110.0))**3.5, 100.0)
+    !          !10**(-0.003*(geo_alt-105.)**2 +14+LOG10(3.))
+    !  else
+    !     m = (1e10-3.9e13)/(200)
+    !     k = 1e10+(-m*300.)
+    !     NDensityS(iLon,iLat,iAlt,iNO_,iBlock)=  &
+    !          MAX(k+(m*geo_alt)-(geo_alt - 120.0)**2,100.0)
+    !       !   MAX(10**(13.-LOG10(3.)*(geo_alt-165.)/35.),1.0)
+    !  endif
+    !
+    ffactor = 6.36*log(f107) - 13.8
+    no = (ffactor*1.0e13 + 8.0e13)*1.24 ! 12.4 ! 12.4 is roughly exp
+    ! This is obviously an approximation:
+    h = Boltzmanns_Constant*msis_temp(2)/ &
+        (9.5*28.0*AMU)/1000.0
+    densities10(10) = no*exp(-(altKm - 100.0)/h)
   endif
-  
+
 end subroutine call_msis
 
 subroutine get_msis_temperature(lon, lat, alt, t, h)
@@ -163,17 +163,17 @@ subroutine get_msis_temperature(lon, lat, alt, t, h)
 
   if (RCMRFlag .and. RCMROutType == "F107") then
 
-     call call_msis(lonDeg, latDeg, altKm, f107_msis, f107a_msis, msis_dens10, msis_temp1)
-     msis_dens = msis_dens10(1:9)
-     msis_temp = msis_temp1
-     !CALL GTD7(iJulianDay, utime, AltKm, LatDeg, LonDeg, LST, &
-     !         f107a_msis, f107_msis, AP, 48, msis_dens, msis_temp)
+    call call_msis(lonDeg, latDeg, altKm, f107_msis, f107a_msis, msis_dens10, msis_temp1)
+    msis_dens = msis_dens10(1:9)
+    msis_temp = msis_temp1
+    !CALL GTD7(iJulianDay, utime, AltKm, LatDeg, LonDeg, LST, &
+    !         f107a_msis, f107_msis, AP, 48, msis_dens, msis_temp)
   else
-     call call_msis(lonDeg, latDeg, altKm, f107, f107a, msis_dens10, msis_temp1)
-     msis_dens = msis_dens10(1:9)
-     msis_temp = msis_temp1
-     !call GTD7(iJulianDay, utime, AltKm, LatDeg, LonDeg, LST, &
-     !     F107A, F107, AP, 48, msis_dens, msis_temp)
+    call call_msis(lonDeg, latDeg, altKm, f107, f107a, msis_dens10, msis_temp1)
+    msis_dens = msis_dens10(1:9)
+    msis_temp = msis_temp1
+    !call GTD7(iJulianDay, utime, AltKm, LatDeg, LonDeg, LST, &
+    !     F107A, F107, AP, 48, msis_dens, msis_temp)
   endif
 
   t = msis_temp(2)
@@ -201,7 +201,7 @@ subroutine initialize_msis_routines
   use ModInputs, only: UseMsisTides, useMsis21, UseMsisOnly, sw_msis
   use EUA_ModMsis00, ONLY: meters, tselec
   use msis_init, only: msisinit
-  
+
   implicit none
 
   real*4 :: sw_msis4x25(25)
@@ -209,11 +209,11 @@ subroutine initialize_msis_routines
 
   ! We only need to initialize MSIS once!
   if (.not. isFirstTime) then
-     return
+    return
   else
-     isFirstTime = .false.
+    isFirstTime = .false.
   endif
-  
+
   ! We want units of /m3 and not /cm3
 
   call meters(.true.)
@@ -238,12 +238,12 @@ subroutine initialize_msis_routines
   sw_msis(2) = 0
 
   if (useMsis21) then
-     sw_msis4x25 = sw_msis
-     call msisinit(parmpath = 'UA/DataIn/LowerBCs/', switch_legacy=sw_msis4x25)
+    sw_msis4x25 = sw_msis
+    call msisinit(parmpath='UA/DataIn/LowerBCs/', switch_legacy=sw_msis4x25)
   else
-     call tselec(sw_msis)
+    call tselec(sw_msis)
   endif
-  
+
 end subroutine initialize_msis_routines
 
 !--------------------------------------------------------------
@@ -299,7 +299,7 @@ subroutine init_msis
   endif
 
   call initialize_msis_routines
-  
+
   !--------------------------------------------------------------------------
   !
   !  From the msis90 library:
@@ -393,10 +393,10 @@ subroutine init_msis
           NDensityS(iLon, iLat, iAlt, iH_, iBlock) = &
             max(msis_dens(7), 100.0)
           NDensityS(iLon, iLat, iAlt, iN_4S_, iBlock) = &
-               max(msis_dens(8), 100.0)
-          NDensityS(iLon, iLat, iAlt, iNO_, iBlock) =  &
-               max(msis_dens10(10), 100.0)
-          
+            max(msis_dens(8), 100.0)
+          NDensityS(iLon, iLat, iAlt, iNO_, iBlock) = &
+            max(msis_dens10(10), 100.0)
+
           NDensityS(iLon, iLat, iAlt, iN_2P_, iBlock) = &
             NDensityS(iLon, iLat, iAlt, iN_4S_, iBlock)/10000.0
           NDensityS(iLon, iLat, iAlt, iN_2D_, iBlock) = &
@@ -554,7 +554,6 @@ subroutine msis_bcs(iJulianDay, UTime, Alt, LatIn, LonIn, Lst, &
   !----------------------------------------------------------------------------
   AP_I = AP
 
-  
   !CALL GTD7(iJulianDay, uTime, Alt, Lat, Lon, LST, &
   !     F107A, F107, AP_I, 48, msis_dens, msis_temp)
   call call_msis(lon, lat, alt, f107, f107a, msis_dens10, msis_temp1)

--- a/src/initialize.f90
+++ b/src/initialize.f90
@@ -14,7 +14,7 @@ subroutine initialize_gitm(TimeIn)
   use ModIndicesInterfaces
   use ModReadGitm3d
   use ModKind, ONLY: Real8_
-  
+
   implicit none
 
   type(UAM_ITER) :: r_iter
@@ -423,81 +423,80 @@ subroutine initialize_gitm(TimeIn)
 
   if (UseGitmBCs) then
 
-     iError = 0
+    iError = 0
 
-     call GitmSetDir(GitmBCsDir)
-     call GetGitmFileList(iError)
-     if (iError /= 0) then
-        call stop_gitm("Error in trying to read GITM 3D Filelist in horizontal bcs")
-     endif
+    call GitmSetDir(GitmBCsDir)
+    call GetGitmFileList(iError)
+    if (iError /= 0) then
+      call stop_gitm("Error in trying to read GITM 3D Filelist in horizontal bcs")
+    endif
 
-     call GetGitmGeneralHeaderInfo(iError)
-     if (iError /= 0) then
-        call stop_gitm("Error in reading gitm header information in horizontal bcs")
-     endif
+    call GetGitmGeneralHeaderInfo(iError)
+    if (iError /= 0) then
+      call stop_gitm("Error in reading gitm header information in horizontal bcs")
+    endif
 
-     call GitmGetnVars(nVars)
-     if (iError /= 0) then
-        call stop_gitm("Error in getting number of variables in horizontal bcs")
-     endif
+    call GitmGetnVars(nVars)
+    if (iError /= 0) then
+      call stop_gitm("Error in getting number of variables in horizontal bcs")
+    endif
 
-     allocate(vars(nVars))
-     call GitmGetVars(vars)
+    allocate(vars(nVars))
+    call GitmGetVars(vars)
 
-     ! Need to calculate the number of boundary points.
+    ! Need to calculate the number of boundary points.
 
-     nPoints = (nAlts + 4) * (nLats + 4) * (nLons + 4)
-     call GitmSetnPointsToGet(nPoints)
+    nPoints = (nAlts + 4)*(nLats + 4)*(nLons + 4)
+    call GitmSetnPointsToGet(nPoints)
 
-     allocate(GitmFileData(nPoints, nVars))
-     allocate(lonsICs(nPoints))
-     allocate(latsICs(nPoints))
-     allocate(altsICs(nPoints))
+    allocate(GitmFileData(nPoints, nVars))
+    allocate(lonsICs(nPoints))
+    allocate(latsICs(nPoints))
+    allocate(altsICs(nPoints))
 
-     iPoint = 1
-     iBlock = 1
-     do iAlt = -1, nAlts + 2
-        do iLat = -1, nLats + 2
-           do iLon = -1, nLons + 2
-              lonsICs(iPoint) = longitude(iLon, iBlock)
-              latsICs(iPoint) = latitude(iLat, iBlock)
-              altsICs(iPoint) = Altitude_GB(iLon, iLat, iAlt, iBlock)
-              iPoint = iPoint + 1
-           enddo
+    iPoint = 1
+    iBlock = 1
+    do iAlt = -1, nAlts + 2
+      do iLat = -1, nLats + 2
+        do iLon = -1, nLons + 2
+          lonsICs(iPoint) = longitude(iLon, iBlock)
+          latsICs(iPoint) = latitude(iLat, iBlock)
+          altsICs(iPoint) = Altitude_GB(iLon, iLat, iAlt, iBlock)
+          iPoint = iPoint + 1
         enddo
-     enddo
+      enddo
+    enddo
 
-     ! Convert to degrees and km
-     lonsICs = lonsICs*360.0/twopi
-     latsICs = latsICs*360.0/twopi
-     altsICs = altsICs/1000.0
+    ! Convert to degrees and km
+    lonsICs = lonsICs*360.0/twopi
+    latsICs = latsICs*360.0/twopi
+    altsICs = altsICs/1000.0
 
-     call GitmSetGrid(lonsICs, latsICs, altsICs)
+    call GitmSetGrid(lonsICs, latsICs, altsICs)
 
-     call GitmUpdateTime(TimeIn, iError)
-     if (iError == 0) then
-        call GitmGetData(GitmFileData)
-     else
-        write(*, *) 'Error in getting GITM data in initialize!'
-        call stop_gitm('Must Stop!')
-     endif
+    call GitmUpdateTime(TimeIn, iError)
+    if (iError == 0) then
+      call GitmGetData(GitmFileData)
+    else
+      write(*, *) 'Error in getting GITM data in initialize!'
+      call stop_gitm('Must Stop!')
+    endif
 
-     iPoint = 1
-     do iAlt = -1, nAlts + 2
-        do iLat = -1, nLats + 2
-           do iLon = -1, nLons + 2
-              call set_horizontal_bcs_1point(iLon, iLat, iAlt, iBlock, iPoint)
-              iPoint = iPoint + 1
-           enddo
+    iPoint = 1
+    do iAlt = -1, nAlts + 2
+      do iLat = -1, nLats + 2
+        do iLon = -1, nLons + 2
+          call set_horizontal_bcs_1point(iLon, iLat, iAlt, iBlock, iPoint)
+          iPoint = iPoint + 1
         enddo
-     enddo
+      enddo
+    enddo
 
-     deallocate(vars, GitmFileData, lonsICs, latsICs, altsICs)
-     call GitmShutDown
-          
+    deallocate(vars, GitmFileData, lonsICs, latsICs, altsICs)
+    call GitmShutDown
+
   endif
 
-  
   if (UseWACCMTides) then
     call read_waccm_tides
     call update_waccm_tides

--- a/src/initialize.f90
+++ b/src/initialize.f90
@@ -12,6 +12,9 @@ subroutine initialize_gitm(TimeIn)
   use ModTime
   use ModEUV
   use ModIndicesInterfaces
+  use ModReadGitm3d
+  use ModKind, ONLY: Real8_
+  
   implicit none
 
   type(UAM_ITER) :: r_iter
@@ -31,6 +34,12 @@ subroutine initialize_gitm(TimeIn)
   logical :: IsThere, IsOk, IsDone, IsFirstTime = .true.
 
   real :: DistM, DistP, Ratio2, InvDenom
+
+  ! These are for setting initial conditions from a GITM run:
+  character(len=nGitmVarCharLength), allocatable :: vars(:)
+  real, allocatable :: lonsICs(:), latsICs(:), altsICs(:)
+  integer :: nPoints, iPoint, nVars
+
   !----------------------------------------------------------------------------
 
 !! Sorry but this is a double-negative
@@ -313,6 +322,7 @@ subroutine initialize_gitm(TimeIn)
     call init_isochem
   endif
 
+  !if (.not. DoRestart .and. .not. UseGitmBCs) then
   if (.not. DoRestart) then
 
     Potential = 0.0
@@ -411,6 +421,83 @@ subroutine initialize_gitm(TimeIn)
 
   endif
 
+  if (UseGitmBCs) then
+
+     iError = 0
+
+     call GitmSetDir(GitmBCsDir)
+     call GetGitmFileList(iError)
+     if (iError /= 0) then
+        call stop_gitm("Error in trying to read GITM 3D Filelist in horizontal bcs")
+     endif
+
+     call GetGitmGeneralHeaderInfo(iError)
+     if (iError /= 0) then
+        call stop_gitm("Error in reading gitm header information in horizontal bcs")
+     endif
+
+     call GitmGetnVars(nVars)
+     if (iError /= 0) then
+        call stop_gitm("Error in getting number of variables in horizontal bcs")
+     endif
+
+     allocate(vars(nVars))
+     call GitmGetVars(vars)
+
+     ! Need to calculate the number of boundary points.
+
+     nPoints = (nAlts + 4) * (nLats + 4) * (nLons + 4)
+     call GitmSetnPointsToGet(nPoints)
+
+     allocate(GitmFileData(nPoints, nVars))
+     allocate(lonsICs(nPoints))
+     allocate(latsICs(nPoints))
+     allocate(altsICs(nPoints))
+
+     iPoint = 1
+     iBlock = 1
+     do iAlt = -1, nAlts + 2
+        do iLat = -1, nLats + 2
+           do iLon = -1, nLons + 2
+              lonsICs(iPoint) = longitude(iLon, iBlock)
+              latsICs(iPoint) = latitude(iLat, iBlock)
+              altsICs(iPoint) = Altitude_GB(iLon, iLat, iAlt, iBlock)
+              iPoint = iPoint + 1
+           enddo
+        enddo
+     enddo
+
+     ! Convert to degrees and km
+     lonsICs = lonsICs*360.0/twopi
+     latsICs = latsICs*360.0/twopi
+     altsICs = altsICs/1000.0
+
+     call GitmSetGrid(lonsICs, latsICs, altsICs)
+
+     call GitmUpdateTime(TimeIn, iError)
+     if (iError == 0) then
+        call GitmGetData(GitmFileData)
+     else
+        write(*, *) 'Error in getting GITM data in initialize!'
+        call stop_gitm('Must Stop!')
+     endif
+
+     iPoint = 1
+     do iAlt = -1, nAlts + 2
+        do iLat = -1, nLats + 2
+           do iLon = -1, nLons + 2
+              call set_horizontal_bcs_1point(iLon, iLat, iAlt, iBlock, iPoint)
+              iPoint = iPoint + 1
+           enddo
+        enddo
+     enddo
+
+     deallocate(vars, GitmFileData, lonsICs, latsICs, altsICs)
+     call GitmShutDown
+          
+  endif
+
+  
   if (UseWACCMTides) then
     call read_waccm_tides
     call update_waccm_tides

--- a/src/set_horizontal_bcs.f90
+++ b/src/set_horizontal_bcs.f90
@@ -175,8 +175,8 @@ subroutine set_horizontal_bcs(iBlock)
       do iLon = 0, -1, -1
         do iLat = -1, nLats + 2
           do iAlt = -1, nAlts + 2
-             call set_horizontal_bcs_1point(iLon, iLat, iAlt, iBlock, iPoint)
-             iPoint = iPoint + 1
+            call set_horizontal_bcs_1point(iLon, iLat, iAlt, iBlock, iPoint)
+            iPoint = iPoint + 1
           enddo
         enddo
       enddo
@@ -448,7 +448,7 @@ subroutine set_horizontal_bcs_1point(iLon, iLat, iAlt, iBlock, iPoint)
 
   integer, intent(in) :: iLon, iLat, iAlt, iBlock, iPoint
   integer :: iDir, iSpecies
-  
+
   Rho(iLon, iLat, iAlt, iBlock) = GitmFileData(iPoint, iRho_)
 
   ! Densities:

--- a/src/set_horizontal_bcs.f90
+++ b/src/set_horizontal_bcs.f90
@@ -448,22 +448,17 @@ subroutine set_horizontal_bcs_1point(iLon, iLat, iAlt, iBlock, iPoint)
 
   integer, intent(in) :: iLon, iLat, iAlt, iBlock, iPoint
   integer :: iDir, iSpecies
-
+  
   Rho(iLon, iLat, iAlt, iBlock) = GitmFileData(iPoint, iRho_)
 
+  ! Densities:
   do iSpecies = 1, nSpeciesTotal
     NDensityS(iLon, iLat, iAlt, iSpecies, iBlock) = &
       GitmFileData(iPoint, iSpecies + iNeutralStart_ - 1)
-!     if (iProc == 0) then
-!        write(*,*) 'ndensity : ',iSpecies, GitmFileData(iPoint,iSpecies+iNeutralStart_-1)
-!     endif
   enddo
   do iSpecies = 1, nIons
     IDensityS(iLon, iLat, iAlt, iSpecies, iBlock) = &
       GitmFileData(iPoint, iSpecies + iIonStart_ - 1)
-!     if (iProc == 0) then
-!        write(*,*) 'idensity : ',iSpecies, GitmFileData(iPoint,iSpecies+iIonStart_-1)
-!     endif
   enddo
 
   ! Need to calculate tempunit to get normalized temperature
@@ -475,19 +470,21 @@ subroutine set_horizontal_bcs_1point(iLon, iLat, iAlt, iBlock, iPoint)
       sum(NDensityS(iLon, iLat, iAlt, :, iBlock))
   enddo
   TempUnit(iLon, iLat, iAlt) = MeanMajorMass(iLon, iLat, iAlt)/Boltzmanns_Constant
+
+  ! Temperatures:
   Temperature(iLon, iLat, iAlt, iBlock) = &
     GitmFileData(iPoint, iTn_)/TempUnit(iLon, iLat, iAlt)
-
   eTemperature(iLon, iLat, iAlt, iBlock) = GitmFileData(iPoint, iTe_)
   iTemperature(iLon, iLat, iAlt, iBlock) = GitmFileData(iPoint, iTe_ + 1)
-  ! Velocities
+
+  ! Velocities:
   do iDir = 1, 3
     Velocity(iLon, iLat, iAlt, iDir, iBlock) = &
       GitmFileData(iPoint, iVn_ + iDir - 1)
     iVelocity(iLon, iLat, iAlt, iDir, iBlock) = &
       GitmFileData(iPoint, iVi_ + iDir - 1)
   enddo
-  ! Vertical Velocities
+  ! Vertical Velocities:
   do iSpecies = 1, nSpecies
     VerticalVelocity(iLon, iLat, iAlt, iSpecies, iBlock) = &
       GitmFileData(iPoint, iVn_ + 3 + iSpecies - 1)

--- a/src/set_horizontal_bcs.f90
+++ b/src/set_horizontal_bcs.f90
@@ -175,8 +175,8 @@ subroutine set_horizontal_bcs(iBlock)
       do iLon = 0, -1, -1
         do iLat = -1, nLats + 2
           do iAlt = -1, nAlts + 2
-            call set_horizontal_bcs_1point(iLon, iLat, iAlt, iBlock, iPoint)
-            iPoint = iPoint + 1
+             call set_horizontal_bcs_1point(iLon, iLat, iAlt, iBlock, iPoint)
+             iPoint = iPoint + 1
           enddo
         enddo
       enddo

--- a/src/set_inputs.f90
+++ b/src/set_inputs.f90
@@ -374,8 +374,8 @@ subroutine set_inputs
           write(*, *) '#MSISOBC'
           write(*, *) 'UseOBCExperiment        (logical)'
           write(*, *) 'MsisOblateFactor           (real)'
-       endif
-       
+        endif
+
       case ("#MSIS21")
         call read_in_logical(UseMsis21, iError)
         if (iError /= 0) then

--- a/src/set_vertical_bcs.Earth.f90
+++ b/src/set_vertical_bcs.Earth.f90
@@ -139,18 +139,18 @@ subroutine set_vertical_bcs(LogRho, LogNS, Vel_GD, Temp, LogINS, iVel, VertVel)
     Vel_GD(-1:0, iEast_) = 0.0
     Vel_GD(-1:0, iNorth_) = 0.0
     ! The rest of the BCs will just stay constant.
- endif
+  endif
 
- if (DoN4SHack) then
+  if (DoN4SHack) then
     !! Hack for iN_4S_ for lower altitudes:
     do iAlt = nAlts, 0, -1
-       if (NS(iAlt - 1, iN_4S_) < 1000.0) then
-          NS(iAlt - 1, iN_4S_) = NS(iAlt, iN_4S_)
-          logNS(iAlt - 1, iN_4S_) = log(NS(iAlt - 1, iN_4S_))
-       endif
+      if (NS(iAlt - 1, iN_4S_) < 1000.0) then
+        NS(iAlt - 1, iN_4S_) = NS(iAlt, iN_4S_)
+        logNS(iAlt - 1, iN_4S_) = log(NS(iAlt - 1, iN_4S_))
+      endif
     enddo
- endif
- 
+  endif
+
   if (.not. DuringPerturb) then
     Vel_GD(-1:0, iUp_) = 0.0
     VertVel(-1:0, :) = 0.0

--- a/srcPython/post_process.py
+++ b/srcPython/post_process.py
@@ -7,7 +7,7 @@ import time
 from pGITM import *
 from datetime import datetime
 
-IsVerbose = True
+IsVerbose = False
 DoRm = True
 
 # ----------------------------------------------------------------------
@@ -40,10 +40,14 @@ def parse_args_post():
 
     parser.add_argument('-totaltime',
                         help = 'specify how long to run in total (in hours)',
-                        default = 24, type = int)
+                        default = 0, type = int)
 
     parser.add_argument('-q',
                         help = 'Run with verbose turned off',
+                        action = 'store_true')
+    
+    parser.add_argument('-v',
+                        help = 'Run with verbose',
                         action = 'store_true')
     
     parser.add_argument('-norm',
@@ -477,7 +481,7 @@ if __name__ == '__main__':  # main code block
 
     # make local variables for arguments:
     doTarZip = args.tgz
-    IsVerbose = not args.q
+    IsVerbose = args.v
     if (args.norm):
         DoRm = False
 

--- a/util/EMPIRICAL/srcIE/readAMIEoutput.f90
+++ b/util/EMPIRICAL/srcIE/readAMIEoutput.f90
@@ -84,7 +84,7 @@ subroutine readAMIEoutput(iBLK, IsMirror, iDebugGitm, iError)
 
   iError = 0
   if (AMIE_iDebugLevel >= 0) &
-       write(*, *) '> reading AMIE file : ', trim(AMIE_FileName)
+    write(*, *) '> reading AMIE file : ', trim(AMIE_FileName)
   open(UnitTmp_, &
        file=AMIE_FileName, &
        status='old', &
@@ -262,8 +262,8 @@ subroutine readAMIEoutput(iBLK, IsMirror, iDebugGitm, iError)
     AMIE_Time(iTime, iBLK) = rtime
 
     if (AMIE_iDebugLevel >= 0) then
-       if (iTime == 1) write(*,*) ' -> AMIE Start Time : ', itime_i
-       if (iTime == AMIE_ntimes) write(*,*) ' -> AMIE End Time : ', itime_i
+      if (iTime == 1) write(*, *) ' -> AMIE Start Time : ', itime_i
+      if (iTime == AMIE_ntimes) write(*, *) ' -> AMIE End Time : ', itime_i
     endif
 
     ! We need Potential to be in Volts

--- a/util/EMPIRICAL/srcIE/readAMIEoutput.f90
+++ b/util/EMPIRICAL/srcIE/readAMIEoutput.f90
@@ -83,7 +83,8 @@ subroutine readAMIEoutput(iBLK, IsMirror, iDebugGitm, iError)
   AMIE_iDebugLevel = iDebugGitm
 
   iError = 0
-  if (AMIE_iDebugLevel >= 0) write(*, *) '> reading AMIE file : ', trim(AMIE_FileName)
+  if (AMIE_iDebugLevel >= 0) &
+       write(*, *) '> reading AMIE file : ', trim(AMIE_FileName)
   open(UnitTmp_, &
        file=AMIE_FileName, &
        status='old', &
@@ -259,6 +260,11 @@ subroutine readAMIEoutput(iBLK, IsMirror, iDebugGitm, iError)
     itime_i(7) = 0
     call time_int_to_real(itime_i, rtime)
     AMIE_Time(iTime, iBLK) = rtime
+
+    if (AMIE_iDebugLevel >= 0) then
+       if (iTime == 1) write(*,*) ' -> AMIE Start Time : ', itime_i
+       if (iTime == AMIE_ntimes) write(*,*) ' -> AMIE End Time : ', itime_i
+    endif
 
     ! We need Potential to be in Volts
     !         AveE to be in keV


### PR DESCRIPTION
# [BUG/FEAT/DOC/*etc.*] **Description**

This fixes some issues with using GITM as a boundary condition on another run. The main issues were that (1) when run on too many processors, then there would be collision in creating the list of GITM output files - only one processor needs to actually make this file; (2) if the grids are not the same in altitude, then the new grid's top and bottom centers can be above and below the old grid's, which causes the code to crash.  This is fixed with extrapolation.

This does NOT solve issue #43!!!

## Justification

Tried to do a travelling convection vortex regional simulation and it didn't work.  So, I fixed all of the things that were wrong, and it seems to work now. :-)

## Changes to GITM outputs

Code output should be the same. 

