### PR TITLE
Fix version tag on ifort

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -37,9 +37,10 @@ NOMPI:
 	@cd ${NOMPIDIR}; make LIB
 
 VERSION:
-	git log -1 HEAD --date=format:'%Y%m%d'  --pretty="format:\"%ad_%h_" > src/.version;
-	echo -n $(shell git status --porcelain | wc -l  | cut -f1 -d' ')\" >> src/.version
-	@echo 
+	printf 'character(25), parameter :: GitmVersion = "%s_%s"\n' \
+	"$$(git log -1 --date=format:'%Y%m%d' --pretty='format:%ad_%h')" \
+	"$$(git status --porcelain | grep -v '^??' | wc -l | cut -f1 -d' ')" > src/.version
+	@echo
 
 GITM:
 	@cd ${SHAREDIR}; echo "Entering ${SHAREDIR}"; make --no-print-directory LIB
@@ -48,7 +49,7 @@ GITM:
 	@cd ${EUADIR}; echo "Entering ${EUADIR}"; make --no-print-directory LIB
 	@cd $(IODIR); echo "Entering ${IODIR}"; make --no-print-directory LIB
 	@cd $(GLDIR); echo "Entering ${GLDIR}";	make --no-print-directory LIB
-	@echo "Adding version info to executable:"; make --no-print-directory VERSION
+	@echo "Creating version file:"; make --no-print-directory VERSION
 	@cd $(MAINDIR); make --no-print-directory GITM
 
 SAMI:

--- a/src/ModGITMVersion.f90
+++ b/src/ModGITMVersion.f90
@@ -1,12 +1,11 @@
 module ModGITMVersion
 
-  ! Version information is put insto src/.version when compiling GITM
+  ! Version variable is put into src/.version when compiling GITM
   ! Format is:
   ! (last commit date)_(commit hash)_(# of files changed from HEAD)
   ! - Gives info on which commit someone is working off of,
   !   and how many files were changed from that.
 
-  character(25), parameter :: GitmVersion = &
-                              INCLUDE ".version"
+  INCLUDE ".version"
 
 end module ModGITMVersion

--- a/src/logfile.f90
+++ b/src/logfile.f90
@@ -164,7 +164,7 @@ subroutine logfile(dir)
     write(iLogFileUnit_, '(a)') &
       "   iStep yyyy mm dd hh mm ss  ms      dt "// &
       "min(T) max(T) mean(T) min(VV) max(VV) mean(VV) F107 F107A "// &
-      "By Bz Vx HP HPn HPs HPn_diff HPs_diff HPn_w HPs_w HPn_m HPs_w "// &
+      "By Bz Vx HP HPn HPs HPn_diff HPs_diff HPn_w HPs_w HPn_m HPs_m "// &
       "SubsolarLon SubsolarLat SubsolarVTEC"
   endif
 

--- a/srcTests/auto_test/ref_solns/log.UAM.in.00.default.test
+++ b/srcTests/auto_test/ref_solns/log.UAM.in.00.default.test
@@ -16,7 +16,7 @@ none
 # Ion Chemistry:  T Ion Advection:  T Neutral Chemistry:  T
  
 #START
-   iStep yyyy mm dd hh mm ss  ms      dt min(T) max(T) mean(T) min(VV) max(VV) mean(VV) F107 F107A By Bz Vx HP HPn HPs HPn_diff HPs_diff HPn_w HPs_w HPn_m HPs_w SubsolarLon SubsolarLat SubsolarVTEC
+   iStep yyyy mm dd hh mm ss  ms      dt min(T) max(T) mean(T) min(VV) max(VV) mean(VV) F107 F107A By Bz Vx HP HPn HPs HPn_diff HPs_diff HPn_w HPs_w HPn_m HPs_m SubsolarLon SubsolarLat SubsolarVTEC
        2 2002 12 21  0  0  4 105  4.1058    157.61774   1316.94000   1012.01979     -4.34856      5.73571      0.15533    177.9    149.5      6.1     -6.0    531.2     71.9    146.3    146.3 146.25404 146.25404   0.00000   0.00000   0.00000   0.00000   3.14129  -0.40992  58.07354
        3 2002 12 21  0  0  8  38  3.9331    157.65070   1316.75172   1012.15021     -5.92356      4.85690     -0.13621    177.9    149.5      6.2     -6.0    531.0     72.0    146.3    146.3 146.25404 146.25404   0.00000   0.00000   0.00000   0.00000   3.14101  -0.40992  57.96173
        4 2002 12 21  0  0 11 927  3.8884    157.66738   1316.57205   1012.29240     -6.63047      4.60426     -0.31168    177.9    149.5      6.2     -6.0    530.7     72.0    146.3    146.3 146.25404 146.25404   0.00000   0.00000   0.00000   0.00000   3.14073  -0.40992  57.89591

--- a/srcTests/auto_test/ref_solns/log.UAM.in.01.UseAeNoHPI.test
+++ b/srcTests/auto_test/ref_solns/log.UAM.in.01.UseAeNoHPI.test
@@ -16,7 +16,7 @@ none
 # Ion Chemistry:  T Ion Advection:  T Neutral Chemistry:  T
  
 #START
-   iStep yyyy mm dd hh mm ss  ms      dt min(T) max(T) mean(T) min(VV) max(VV) mean(VV) F107 F107A By Bz Vx HP HPn HPs HPn_diff HPs_diff HPn_w HPs_w HPn_m HPs_w SubsolarLon SubsolarLat SubsolarVTEC
+   iStep yyyy mm dd hh mm ss  ms      dt min(T) max(T) mean(T) min(VV) max(VV) mean(VV) F107 F107A By Bz Vx HP HPn HPs HPn_diff HPs_diff HPn_w HPs_w HPn_m HPs_m SubsolarLon SubsolarLat SubsolarVTEC
        2 2002 12 21  0  0  4 105  4.1058    157.74815   1316.94289   1012.01852     -3.86973      4.80289      0.02868    177.9    149.5      6.1     -6.0    531.2     71.9    146.3    146.3 146.25404 146.25404   0.00000   0.00000   0.00000   0.00000   3.14129  -0.40992  58.07354
        3 2002 12 21  0  0  8  39  3.9333    157.86758   1316.75126   1012.14763     -5.47890      3.73507     -0.31689    177.9    149.5      6.2     -6.0    531.0     72.0    146.3    146.3 146.25404 146.25404   0.00000   0.00000   0.00000   0.00000   3.14101  -0.40992  57.96171
        4 2002 12 21  0  0 11 927  3.8882    157.90472   1316.56583   1012.28863     -6.33135      3.28832     -0.56606    177.9    149.5      6.2     -6.0    530.7     72.0    146.3    146.3 146.25404 146.25404   0.00000   0.00000   0.00000   0.00000   3.14073  -0.40992  57.89588

--- a/srcTests/auto_test/ref_solns/log.UAM.in.03.IonLowerLimit.test
+++ b/srcTests/auto_test/ref_solns/log.UAM.in.03.IonLowerLimit.test
@@ -16,7 +16,7 @@ none
 # Ion Chemistry:  T Ion Advection:  T Neutral Chemistry:  T
  
 #START
-   iStep yyyy mm dd hh mm ss  ms      dt min(T) max(T) mean(T) min(VV) max(VV) mean(VV) F107 F107A By Bz Vx HP HPn HPs HPn_diff HPs_diff HPn_w HPs_w HPn_m HPs_w SubsolarLon SubsolarLat SubsolarVTEC
+   iStep yyyy mm dd hh mm ss  ms      dt min(T) max(T) mean(T) min(VV) max(VV) mean(VV) F107 F107A By Bz Vx HP HPn HPs HPn_diff HPs_diff HPn_w HPs_w HPn_m HPs_m SubsolarLon SubsolarLat SubsolarVTEC
        2 2002 12 21  0  0  4 105  4.1058    157.67607   1317.06366   1012.07593     -4.34841      5.73680      0.15716    177.9    149.5      6.1     -6.0    531.2     71.9    146.3    146.3 146.25404 146.25404   0.00000   0.00000   0.00000   0.00000   3.14129  -0.40992  58.75926
        3 2002 12 21  0  0  8  37  3.9320    157.71173   1316.99398   1012.26039     -5.92277      4.86210     -0.13276    177.9    149.5      6.2     -6.0    531.0     72.0    146.3    146.3 146.25404 146.25404   0.00000   0.00000   0.00000   0.00000   3.14101  -0.40992  60.82282
        4 2002 12 21  0  0 11 887  3.8494    157.76841   1316.93712   1012.45537     -6.62034      4.56263     -0.30770    177.9    149.5      6.2     -6.0    530.7     72.0    146.3    146.3 146.25404 146.25404   0.00000   0.00000   0.00000   0.00000   3.14073  -0.40992  60.34757

--- a/srcTests/auto_test/ref_solns/log.UAM.in.04.ElectrodynamicsGeoCoords.test
+++ b/srcTests/auto_test/ref_solns/log.UAM.in.04.ElectrodynamicsGeoCoords.test
@@ -15,7 +15,7 @@ none
 # Ion Chemistry:  T Ion Advection:  T Neutral Chemistry:  T
  
 #START
-   iStep yyyy mm dd hh mm ss  ms      dt min(T) max(T) mean(T) min(VV) max(VV) mean(VV) F107 F107A By Bz Vx HP HPn HPs HPn_diff HPs_diff HPn_w HPs_w HPn_m HPs_w SubsolarLon SubsolarLat SubsolarVTEC
+   iStep yyyy mm dd hh mm ss  ms      dt min(T) max(T) mean(T) min(VV) max(VV) mean(VV) F107 F107A By Bz Vx HP HPn HPs HPn_diff HPs_diff HPn_w HPs_w HPn_m HPs_m SubsolarLon SubsolarLat SubsolarVTEC
        2 2002 12 21  0  1  0   0 60.0000    157.53547   1317.47667   1011.88104      0.00000      0.00000      0.00000    177.9    149.5      6.6     -6.0    527.7     72.6      0.0      0.0   0.00000   0.00000   0.00000   0.00000   0.00000   0.00000   3.13723  -0.40992  58.50262
        3 2002 12 21  0  2  0   0 60.0000    157.47072   1317.47219   1011.87449      0.00000      0.00000      0.00000    177.9    149.5      6.4     -6.1    529.5     71.9      0.0      0.0   0.00000   0.00000   0.00000   0.00000   0.00000   0.00000   3.13287  -0.40992  58.41360
        4 2002 12 21  0  3  0   0 60.0000    157.40796   1317.45846   1011.86795      0.00000      0.00000      0.00000    177.9    149.5      6.2     -6.4    530.0     73.6      0.0      0.0   0.00000   0.00000   0.00000   0.00000   0.00000   0.00000   3.12850  -0.40992  58.32593

--- a/srcTests/auto_test/ref_solns/log.UAM.in.05.ElectrodynamicsMagCoords.test
+++ b/srcTests/auto_test/ref_solns/log.UAM.in.05.ElectrodynamicsMagCoords.test
@@ -15,7 +15,7 @@ none
 # Ion Chemistry:  T Ion Advection:  T Neutral Chemistry:  T
  
 #START
-   iStep yyyy mm dd hh mm ss  ms      dt min(T) max(T) mean(T) min(VV) max(VV) mean(VV) F107 F107A By Bz Vx HP HPn HPs HPn_diff HPs_diff HPn_w HPs_w HPn_m HPs_w SubsolarLon SubsolarLat SubsolarVTEC
+   iStep yyyy mm dd hh mm ss  ms      dt min(T) max(T) mean(T) min(VV) max(VV) mean(VV) F107 F107A By Bz Vx HP HPn HPs HPn_diff HPs_diff HPn_w HPs_w HPn_m HPs_m SubsolarLon SubsolarLat SubsolarVTEC
        2 2002 12 21  0  1  0   0 60.0000    157.53547   1317.47667   1011.88104      0.00000      0.00000      0.00000    177.9    149.5      6.6     -6.0    527.7     72.6      0.0      0.0   0.00000   0.00000   0.00000   0.00000   0.00000   0.00000   3.13723  -0.40992  58.50262
        3 2002 12 21  0  2  0   0 60.0000    157.47072   1317.47219   1011.87449      0.00000      0.00000      0.00000    177.9    149.5      6.4     -6.1    529.5     71.9      0.0      0.0   0.00000   0.00000   0.00000   0.00000   0.00000   0.00000   3.13287  -0.40992  58.41360
        4 2002 12 21  0  3  0   0 60.0000    157.40796   1317.45846   1011.86795      0.00000      0.00000      0.00000    177.9    149.5      6.2     -6.4    530.0     73.6      0.0      0.0   0.00000   0.00000   0.00000   0.00000   0.00000   0.00000   3.12850  -0.40992  58.32593

--- a/srcTests/auto_test/ref_solns/log.UAM.in.06.FreHepmay.test
+++ b/srcTests/auto_test/ref_solns/log.UAM.in.06.FreHepmay.test
@@ -15,7 +15,7 @@ none
 # Ion Chemistry:  T Ion Advection:  T Neutral Chemistry:  T
  
 #START
-   iStep yyyy mm dd hh mm ss  ms      dt min(T) max(T) mean(T) min(VV) max(VV) mean(VV) F107 F107A By Bz Vx HP HPn HPs HPn_diff HPs_diff HPn_w HPs_w HPn_m HPs_w SubsolarLon SubsolarLat SubsolarVTEC
+   iStep yyyy mm dd hh mm ss  ms      dt min(T) max(T) mean(T) min(VV) max(VV) mean(VV) F107 F107A By Bz Vx HP HPn HPs HPn_diff HPs_diff HPn_w HPs_w HPn_m HPs_m SubsolarLon SubsolarLat SubsolarVTEC
        2 2002 12 21  0  0  4 105  4.1058    157.74815   1316.94399   1012.00744     -3.86975      4.80289      0.02833    177.9    149.5      6.1     -6.0    531.2     71.9     95.5     95.5  95.48751  95.48751   0.00000   0.00000   0.00000   0.00000   3.14129  -0.40992  58.10300
        3 2002 12 21  0  0  8 203  4.0977    157.87028   1316.73590   1012.12672     -5.52743      3.91095     -0.31462    177.9    149.5      6.2     -6.0    531.0     72.0     95.5     95.5  95.48751  95.48751   0.00000   0.00000   0.00000   0.00000   3.14100  -0.40992  58.06740
        4 2002 12 21  0  0 12 301  4.0979    157.90494   1316.53883   1012.25819     -6.40138      3.49807     -0.57158    177.9    149.5      6.2     -6.0    530.7     72.0     95.5     95.5  95.48751  95.48751   0.00000   0.00000   0.00000   0.00000   3.14070  -0.40992  58.05555

--- a/srcTests/auto_test/ref_solns/log.UAM.in.07.pemWeimer.test
+++ b/srcTests/auto_test/ref_solns/log.UAM.in.07.pemWeimer.test
@@ -15,7 +15,7 @@ none
 # Ion Chemistry:  T Ion Advection:  T Neutral Chemistry:  T
  
 #START
-   iStep yyyy mm dd hh mm ss  ms      dt min(T) max(T) mean(T) min(VV) max(VV) mean(VV) F107 F107A By Bz Vx HP HPn HPs HPn_diff HPs_diff HPn_w HPs_w HPn_m HPs_w SubsolarLon SubsolarLat SubsolarVTEC
+   iStep yyyy mm dd hh mm ss  ms      dt min(T) max(T) mean(T) min(VV) max(VV) mean(VV) F107 F107A By Bz Vx HP HPn HPs HPn_diff HPs_diff HPn_w HPs_w HPn_m HPs_m SubsolarLon SubsolarLat SubsolarVTEC
        2 2002 12 21  0  0  4 105  4.1058    157.74815   1316.94399   1012.01910     -3.86975      4.80289      0.02870    177.9    149.5      6.1     -6.0    531.2     71.9     26.8     26.8  26.79307  26.79307   0.00000   0.00000   0.00000   0.00000   3.14129  -0.40992  58.10300
        3 2002 12 21  0  0  8  39  3.9333    157.86758   1316.75360   1012.14872     -5.47891      3.73504     -0.31686    177.9    149.5      6.2     -6.0    531.0     72.0     26.8     26.8  26.79307  26.79307   0.00000   0.00000   0.00000   0.00000   3.14101  -0.40992  58.06990
        4 2002 12 21  0  0 11 981  3.9420    157.90476   1316.56368   1012.29275     -6.34279      3.34487     -0.56445    177.9    149.5      6.2     -6.0    530.7     72.0     26.8     26.8  26.79307  26.79307   0.00000   0.00000   0.00000   0.00000   3.14072  -0.40992  58.05914

--- a/srcTests/auto_test/ref_solns/log.UAM.in.08.IeZeroZero.test
+++ b/srcTests/auto_test/ref_solns/log.UAM.in.08.IeZeroZero.test
@@ -15,7 +15,7 @@ none
 # Ion Chemistry:  T Ion Advection:  T Neutral Chemistry:  T
  
 #START
-   iStep yyyy mm dd hh mm ss  ms      dt min(T) max(T) mean(T) min(VV) max(VV) mean(VV) F107 F107A By Bz Vx HP HPn HPs HPn_diff HPs_diff HPn_w HPs_w HPn_m HPs_w SubsolarLon SubsolarLat SubsolarVTEC
+   iStep yyyy mm dd hh mm ss  ms      dt min(T) max(T) mean(T) min(VV) max(VV) mean(VV) F107 F107A By Bz Vx HP HPn HPs HPn_diff HPs_diff HPn_w HPs_w HPn_m HPs_m SubsolarLon SubsolarLat SubsolarVTEC
        2 2002 12 21  0  0  4 105  4.1058    157.74815   1316.94399   1012.00728     -3.86975      4.80289      0.02832    177.9    149.5************************************      0.0      0.0   0.00000   0.00000   0.00000   0.00000   0.00000   0.00000   3.14129  -0.40992  58.10300
        3 2002 12 21  0  0  8 203  4.0977    157.87028   1316.73590   1012.12627     -5.52741      3.91095     -0.31465    177.9    149.5************************************      0.0      0.0   0.00000   0.00000   0.00000   0.00000   0.00000   0.00000   3.14100  -0.40992  58.06740
        4 2002 12 21  0  0 12 301  4.0979    157.90494   1316.53883   1012.25753     -6.40138      3.49807     -0.57164    177.9    149.5************************************      0.0      0.0   0.00000   0.00000   0.00000   0.00000   0.00000   0.00000   3.14070  -0.40992  58.05555


### PR DESCRIPTION
# [BUG] Version implementation only worked for gfortran

I changed it to define the variable completely in the `src/.version` file. The makefile has two lines where the version is checked - it's not too noisy. Eventually we may want to move to a python or shell script for this...

version file now:

```bash
> cat src/.version

character(25), parameter :: GitmVersion = "20250618_3e775ae_2"
```
