### PR TITLE
Crayftn

### DIFF
--- a/.github/workflows/Format-and-Test.yml
+++ b/.github/workflows/Format-and-Test.yml
@@ -5,6 +5,7 @@ on:
     branches:
       - main
       - develop
+      - hotfix
 
 jobs:
   Format:

--- a/share/Scripts/Config.pl
+++ b/share/Scripts/Config.pl
@@ -6,7 +6,7 @@ use strict;
 
 # Default compiler per machine or OS
 my %Compiler = (
-		"Linux"               => "nagfor",
+		"Linux"               => "gfortran",
 		"Darwin"              => "nagfor",
 		"OSF1"                => "f90",
 		"IRIX64"              => "f90",
@@ -35,10 +35,15 @@ my $IsStrict=1;  # If true, shell_command will stop on error
 # Obtain $OS, $DIR, and the machine name and provide it to caller script
 our $OS  = `uname`    or die "$ERROR_ could not obtain OS\n"; chop $OS;
 our $DIR = `/bin/pwd` or die "$ERROR_ could not obtain DIR\n"; chop $DIR;
-our $Machine = `hostname`; chop($Machine); $Machine =~ s/\..*//;
+our $Machine = `hostname -f`; chop($Machine); 
 
+$Machine =~ s/^login\d*\.//; # remove "login\d+." from beginning
+$Machine =~ s/\..*//;        # keep the first word
+$Machine =~ s/[\-\d\.]+$//;  # remove numbers from the machine name
+$Machine =~ s/login$//;      # remove trailing login
+$Machine =~ s/\-//;          # remove trailing "-"
 # remove numbers from the machine name
-$Machine =~ s/\d+$//; 
+$Machine =~ s/\d+$//;
 
 # These are either obtained from the calling script or set here
 our $Component;             # The SWMF component the code is representing
@@ -54,6 +59,19 @@ our $WARNING = "$Code/Config.pl WARNING:";
 our $Compiler;
 $Compiler = $Compiler{$Machine} or $Compiler = $Compiler{$OS} or
     die "$ERROR_ default compiler is not known for OS=$OS\n";
+
+
+
+if ($Machine='athfe' and $Compiler='crayftn'){
+    print "
+====================================================
+On athena we recommend using -compiler=ifortmpif90
+and running 'module switch PrgEnv-cray PrgEnv-intel'
+If you need to use crayftn, please use -O1
+====================================================
+";
+}
+
 
 # Default C compiler part of Makefile.conf
 our $CompilerC = "gcc_mpicc";

--- a/share/build/Makefile.Linux.crayftn
+++ b/share/build/Makefile.Linux.crayftn
@@ -10,9 +10,9 @@ SHELL=/bin/sh
 #	Cray Fortran (ftn) Compiler with FTN for linking
 #
 
-COMPILE.f77     = ${CUSTOMPATH_F}ftn
-COMPILE.f90     = ${CUSTOMPATH_F}ftn
-LINK.f90	= ${CUSTOMPATH_MPI}ftn
+COMPILE.f77     = ${CUSTOMPATH_F}ftn -Ofp3
+COMPILE.f90     = ${CUSTOMPATH_F}ftn -Ofp3
+LINK.f90	= ${CUSTOMPATH_MPI}ftn -Ofp3
 AR = ar -rs
 
 SINGLEPREC =
@@ -33,7 +33,7 @@ DEBUG     =
 OPT0 = -O0
 OPT1 = -O1
 OPT2 = -O2
-OPT3 = -O3,fp3
+OPT3 = -O3
 OPT4 = -O4
 
 CFLAG = ${SEARCH} -c ${DEBUG}
@@ -64,19 +64,19 @@ BLAS  = lapack.o blas.o
 .SUFFIXES: .f90 .F90 .f .for .ftn .o
 
 .f90.o:
-	${COMPILE.f90} ${Cflag3} $<
+	${COMPILE.f90} ${Cflag3} -f free $<
 
 .F90.o:
 	${COMPILE.f90} -DsysLinux ${Cflag3} $<
 
 .f.o:
-	${COMPILE.f77} ${Cflag3} -f fixed $<
+	${COMPILE.f77} ${Cflag3} -f fixed -N 132 $<
 
 .for.o:
-	${COMPILE.f77} ${Cflag3} -f fixed $<
+	${COMPILE.f77} ${Cflag3} -f fixed -N 132 $<
 
 .ftn.o:
-	${COMPILE.f77} ${Cflag3} -f fixed $<
+	${COMPILE.f77} ${Cflag3} -f fixed -N 132 $<
 
 clean:	
 	rm -f *~ core *.o *.mod fort.* a.out *.exe *.a *.so *.il *.protex

--- a/util/EMPIRICAL/srcUA/ModMsis21.F90
+++ b/util/EMPIRICAL/srcUA/ModMsis21.F90
@@ -2662,20 +2662,20 @@ subroutine gtd8d(iyd,sec,alt,glat,glong,stl,f107a,f107,ap,mass,d,t)
   call msiscalc(xday,xutsec,xalt,xlat,xlon,xsfluxavg,xsflux,xap,xtn,xdn,tex=xtex)
 
   ! Convert the output arguments to the legacy format (mks to cgs, re-order species)
-  t(1) = sngl(xtex)    ! Expospheric temperature
-  t(2) = sngl(xtn)     ! Temperature at altitude
+  t(1) = real(xtex)    ! Expospheric temperature
+  t(2) = real(xtn)     ! Temperature at altitude
   where (xdn .ne. dmissing) xdn = xdn*1d-6
   if (xdn(1) .ne. dmissing) xdn(1) = xdn(1)*1e3_rp
-  d(1) = sngl(xdn(5))  ! [He]
-  d(2) = sngl(xdn(4))  ! [O]
-  d(3) = sngl(xdn(2))  ! [N2]
-  d(4) = sngl(xdn(3))  ! [O2]
-  d(5) = sngl(xdn(7))  ! [Ar]
-  d(6) = sngl(xdn(1))  ! Mass density
-  d(7) = sngl(xdn(6))  ! [H]
-  d(8) = sngl(xdn(8))  ! [N]
-  d(9) = sngl(xdn(9))  ! [Anomalous O]
-  d(10) = sngl(xdn(10))  ! [NO]
+  d(1) = real(xdn(5))  ! [He]
+  d(2) = real(xdn(4))  ! [O]
+  d(3) = real(xdn(2))  ! [N2]
+  d(4) = real(xdn(3))  ! [O2]
+  d(5) = real(xdn(7))  ! [Ar]
+  d(6) = real(xdn(1))  ! Mass density
+  d(7) = real(xdn(6))  ! [H]
+  d(8) = real(xdn(8))  ! [N]
+  d(9) = real(xdn(9))  ! [Anomalous O]
+  d(10) = real(xdn(10))  ! [NO]
 
   return
 


### PR DESCRIPTION
# [BUILD] **Update build scripts to support crayftn on Athena**

Changes:

- Default compiler on Linux changed from nagfor to gfortran
- Ensure crayftn Makefile works
- Change `sngl()` -> `real()` in util/EMPIRICAL/srcUA/ModMsis21.F90. Not supported by all compilers.
- Add message to Config.pl when installing on Athena with crayftn about using `-O1`

GITM outputs do not change, tested several machines. 