### PR TITLE
Superstorms

### DIFF
--- a/src/add_sources.f90
+++ b/src/add_sources.f90
@@ -150,12 +150,12 @@ subroutine add_sources
 
   enddo
 
+  call correct_min_ion_density
+
   if (DoCheckForNans) then
     call check_for_nans_ions("After Sources")
     call check_for_nans_neutrals("After Sources")
     call check_for_nans_temps("After Sources")
   endif
-
-  call correct_min_ion_density
 
 end subroutine add_sources

--- a/src/advance_horizontal.f90
+++ b/src/advance_horizontal.f90
@@ -38,13 +38,13 @@ subroutine advance_horizontal_all
     if (.not. IsFullSphere) call set_horizontal_bcs(iBlock)
   enddo
 
+  call correct_min_ion_density
+
   if (DoCheckForNans) then
     call check_for_nans_ions("After Horizontal")
     call check_for_nans_neutrals("After Horizontal")
     call check_for_nans_temps("After Horizontal")
   endif
-
-  call correct_min_ion_density
 
   call end_timing("horizontal_all")
 

--- a/src/advance_vertical.f90
+++ b/src/advance_vertical.f90
@@ -28,13 +28,13 @@ subroutine advance_vertical_all
 
   enddo
 
+  call correct_min_ion_density
+
   if (DoCheckForNans) then
     call check_for_nans_ions("After Vertical")
     call check_for_nans_neutrals("After Vertical")
     call check_for_nans_temps("After Vertical")
   endif
-
-  call correct_min_ion_density
 
   call end_timing("vertical_all")
 

--- a/src/check_for_nans.f90
+++ b/src/check_for_nans.f90
@@ -11,7 +11,7 @@ subroutine check_for_nans_ions(cMarker)
   implicit none
 
   character(LEN=*), intent(in) :: cMarker
-  integer :: iLon, iLat, iAlt, iIon
+  integer :: iLon, iLat, iAlt, iIon, iDir
   logical :: IsFound
 
   IsFound = .false.
@@ -20,21 +20,23 @@ subroutine check_for_nans_ions(cMarker)
       do iAlt = -1, nAlts + 2
         do iIon = 1, nIons
           if (ieee_is_nan(iDensityS(iLon, iLat, iAlt, iIon, 1))) then
-            write(*, *) 'Nan found in iDensityS : '
-            write(*, *) cMarker
-            write(*, *) iLon, iLat, iAlt, iProc, iIon
+            write(*, *) 'Nan found in iDensityS : ', cMarker
+            write(*, *) "    species:", cIons(iIon)
+            call print_error_location(iLon, iLat, iAlt, 1)
             IsFound = .true.
           endif
-          if (ieee_is_nan(IVelocity(iLon, iLat, iAlt, 1, 1))) then
-            write(*, *) 'Nan found in iVelocity!! : '
-            write(*, *) cMarker
-            write(*, *) iLon, iLat, iAlt, iProc, iIon
+          do iDir = 1, 3
+          if (ieee_is_nan(IVelocity(iLon, iLat, iAlt, iDir, 1))) then
+            write(*, *) 'Nan found in iVelocity!! : ', cMarker
+            write(*, *) "    direction:", iDir
+            call print_error_location(iLon, iLat, iAlt, 1)
             IsFound = .true.
           endif
+          enddo
           if (iDensityS(iLon, iLat, iAlt, iIon, 1) < 0.0) then
-            write(*, *) 'Negative density found in iDensityS : '
-            write(*, *) cMarker
-            write(*, *) iLon, iLat, iAlt, iProc, iIon
+            write(*, *) 'Negative density found in iDensityS : ', cMarker
+            write(*, *) "    species:", cIons(iIon)
+            call print_error_location(iLon, iLat, iAlt, 1)
             IsFound = .true.
           endif
         enddo
@@ -65,15 +67,15 @@ subroutine check_for_nans_neutrals(cMarker)
       do iAlt = -1, nAlts + 2
         do iNeu = 1, nSpecies
           if (ieee_is_nan(nDensityS(iLon, iLat, iAlt, iNeu, 1))) then
-            write(*, *) 'Nan found in nDensityS : '
-            write(*, *) cMarker
-            write(*, *) iLon, iLat, iAlt, iProc, iNeu
+            write(*, *) 'Nan found in nDensityS : ', cMarker
+            write(*, *) "    species:", cSpecies(iNeu)
+            call print_error_location(iLon, iLat, iAlt, 1)
             IsFound = .true.
           endif
           if (nDensityS(iLon, iLat, iAlt, iNeu, 1) < 0.0) then
-            write(*, *) 'Negative density found in nDensityS : '
-            write(*, *) cMarker
-            write(*, *) iLon, iLat, iAlt, iProc, iNeu
+            write(*, *) 'Negative density found in nDensityS : ', cMarker
+            write(*, *) "    species:", cSpecies(iNeu)
+            call print_error_location(iLon, iLat, iAlt, 1)
             IsFound = .true.
           endif
         enddo
@@ -103,40 +105,34 @@ subroutine check_for_nans_temps(cMarker)
     do iLat = -1, nLats + 2
       do iAlt = -1, nAlts + 2
         if (ieee_is_nan(Temperature(iLon, iLat, iAlt, 1))) then
-          write(*, *) 'Nan found in Temperature : '
-          write(*, *) cMarker
-          write(*, *) iLon, iLat, iAlt, iProc
+          write(*, *) 'Nan found in Temperature : ', cMarker
+          call print_error_location(iLon, iLat, iAlt, 1)
           IsFound = .true.
         endif
         if (ieee_is_nan(iTemperature(iLon, iLat, iAlt, 1))) then
-          write(*, *) 'Nan found in iTemperature : '
-          write(*, *) cMarker
-          write(*, *) iLon, iLat, iAlt, iProc
+          write(*, *) 'Nan found in iTemperature : ', cMarker
+          call print_error_location(iLon, iLat, iAlt, 1)
           IsFound = .true.
         endif
         if (ieee_is_nan(eTemperature(iLon, iLat, iAlt, 1))) then
-          write(*, *) 'Nan found in eTemperature : '
-          write(*, *) cMarker
-          write(*, *) iLon, iLat, iAlt, iProc
+          write(*, *) 'Nan found in eTemperature : ', cMarker
+          call print_error_location(iLon, iLat, iAlt, 1)
           IsFound = .true.
         endif
         ! Check for negative Temperatures:
         if (Temperature(iLon, iLat, iAlt, 1) < 0.0) then
-          write(*, *) 'Negative found in Temperature : '
-          write(*, *) cMarker
-          write(*, *) iLon, iLat, iAlt, iProc
+          write(*, *) 'Negative found in Temperature : ', cMarker
+          call print_error_location(iLon, iLat, iAlt, 1)
           IsFound = .true.
         endif
         if (iTemperature(iLon, iLat, iAlt, 1) < 0.0) then
-          write(*, *) 'Negative found in iTemperature : '
-          write(*, *) cMarker
-          write(*, *) iLon, iLat, iAlt, iProc
+          write(*, *) 'Negative found in iTemperature : ', cMarker
+          call print_error_location(iLon, iLat, iAlt, 1)
           IsFound = .true.
         endif
         if (eTemperature(iLon, iLat, iAlt, 1) < 0.0) then
-          write(*, *) 'Negative found in eTemperature : '
-          write(*, *) cMarker
-          write(*, *) iLon, iLat, iAlt, iProc
+          write(*, *) 'Negative found in eTemperature : ', cMarker
+          call print_error_location(iLon, iLat, iAlt, 1)
           IsFound = .true.
         endif
       enddo
@@ -166,10 +162,11 @@ subroutine correct_min_ion_density
             do iLat = -1, nLats + 2
               do iAlt = -1, nAlts + 2
                 if (iDensityS(iLon, iLat, iAlt, iIon, 1) < MinIonDensity) then
-                  if (iDebugLevel > 7) &
-                    write(*, *) ' -> low density found in iDensityS : ', &
-                    iLon, iLat, iAlt, iProc, iIon, iDensityS(iLon, iLat, iAlt, iIon, 1), &
-                    MinIonDensity
+                  if (iDebugLevel > 7) then
+                    write(*, *) ' -> low density found in iDensityS : '
+                    write(*, *) "    species:", cIons(iIon)
+                    call print_error_location(iLon, iLat, iAlt, 1)
+                  endif
                   iDensityS(iLon, iLat, iAlt, iIon, 1) = MinIonDensity
                 endif
               enddo
@@ -182,10 +179,11 @@ subroutine correct_min_ion_density
             do iLat = -1, nLats + 2
               do iAlt = -1, nAlts + 2
                 if (iDensityS(iLon, iLat, iAlt, iIon, 1) < MinIonDensityAdvect) then
-                  if (iDebugLevel > 7) &
-                    write(*, *) ' -> low density found in iDensityS : ', &
-                    iLon, iLat, iAlt, iProc, iIon, iDensityS(iLon, iLat, iAlt, iIon, 1), &
-                    MinIonDensity
+                  if (iDebugLevel > 7) then
+                    write(*, *) ' -> low density found in iDensityS : '
+                    write(*, *) "    species:", cIons(iIon)
+                    call print_error_location(iLon, iLat, iAlt, 1)
+                  endif
                   iDensityS(iLon, iLat, iAlt, iIon, 1) = MinIonDensityAdvect
                 endif
               enddo
@@ -199,3 +197,21 @@ subroutine correct_min_ion_density
   return
 
 end subroutine correct_min_ion_density
+
+subroutine print_error_location(iLon, iLat, iAlt, iBlock)
+  !! Refactor error message to see where error occurs more easily
+  use ModGITM
+
+  integer, intent(in) :: iLon, iLat, iAlt, iBlock
+
+  write(*, *) " ->> On iProc:", iProc, " iLon:", iLon, " iLat:", iLat, &
+    " iAlt:", iAlt, " iBlock:", iBlock
+  write(*, *) " --->>> (radians) Longitude, Latitude, Altitude: "
+  write(*, *) "       ", Longitude(iLon, iBlock), Latitude(iLat, iBlock), Altitude_GB(iLon, iLat, iAlt, iBlock)
+  write(*, *) " --->>> (degrees): "
+  write(*, *) "       ", 180.*Longitude(iLon, iBlock)/pi, 180*Latitude(iLat, iBlock)/pi, &
+    Altitude_GB(iLon, iLat, iAlt, iBlock)/1000.
+  ! if (present(varname)) write(*,*) " ->  in variable: ", varName
+  ! if (present(values)) write(*,*) " -> With value: ", values
+
+end subroutine print_error_location

--- a/src/get_potential.f90
+++ b/src/get_potential.f90
@@ -215,7 +215,7 @@ subroutine get_potential(iBlock)
         if (IsFramework) then
           LatBoundNow = 45.
         else
-          LatBoundNow = DynamoHighLatBoundary
+          LatBoundNow = min(IEModel_%LatBoundPotential, DynamoHighLatBoundary)
         endif
 
         do iDir = 1, nDir

--- a/src/output_common.f90
+++ b/src/output_common.f90
@@ -32,9 +32,10 @@ integer function bad_outputtype()
 
   ! Set up all possible/valid plot types:
   NameValidTypes = (/'3DALL', '3DLST', '3DNEU', '3DION', '3DTHM', '3DCHM', &
-                     '3DUSR', '3DGLO', '3DMAG', '3DHME', '2DGEL', '2DMEL', '2DUSR', &
-                     '2DTEC', '2DANC', '2DHME', '1DALL', '0DALL', '1DGLO', '1DTHM', '1DNEW', &
-                     '1DCHM', '1DCMS', '1DUSR', '0DUSR'/)
+                     '3DUSR', '3DGLO', '3DMAG', '3DHME', &
+                     '2DGEL', '2DMEL', '2DUSR', '2DTEC', '2DANC', '2DHME', &
+                     '1DALL', '1DGLO', '1DTHM', '1DNEW', '1DCHM', '1DCMS', '1DUSR', &
+                     '0DALL', '0DUSR'/)
 
   ! Loop over all requested output types:
   do iOutputType = 1, nOutputTypes

--- a/src/output_common.f90
+++ b/src/output_common.f90
@@ -24,7 +24,7 @@ integer function bad_outputtype()
 
   implicit none
 
-  integer, parameter :: nValidTypes = 25
+  integer, parameter :: nValidTypes = 26
   integer :: j, iOutputType
   logical :: IsFound
 
@@ -32,7 +32,7 @@ integer function bad_outputtype()
 
   ! Set up all possible/valid plot types:
   NameValidTypes = (/'3DALL', '3DLST', '3DNEU', '3DION', '3DTHM', '3DCHM', &
-                     '3DUSR', '3DGLO', '3DMAG', '3DHME', &
+                     '3DUSR', '3DGLO', '3DMAG', '3DHME', '3DPOT', &
                      '2DGEL', '2DMEL', '2DUSR', '2DTEC', '2DANC', '2DHME', &
                      '1DALL', '1DGLO', '1DTHM', '1DNEW', '1DCHM', '1DCMS', '1DUSR', &
                      '0DALL', '0DUSR'/)
@@ -347,6 +347,11 @@ subroutine output(dir, iBlock, iOutputType)
     ! for iProc=0. Header files are always written by iProc=0.
     if (DoSaveHIMEPlot) call output_3dhme(iBlock)
 
+  case ('3DPOT')
+
+    nVars_to_Write = 9
+    call output_3dpot(iBlock)
+
   case ('2DGEL')
 
     nvars_to_write = 19
@@ -636,8 +641,18 @@ contains
 
     endif
 
-    if (cType(3:5) == "TEC") then
+    if (cType(3:5) == "POT") then
 
+      write(iOutputUnit_, "(I7,A1,a)") 4, " ", "Magnetic Latitude"
+      write(iOutputUnit_, "(I7,A1,a)") 4, " ", "Magnetic Longitude"
+      write(iOutputUnit_, "(I7,A1,a)") 4, " ", "Magnetospheric Potential"
+      write(iOutputUnit_, "(I7,A1,a)") 4, " ", "Dynamo Potential"
+      write(iOutputUnit_, "(I7,A1,a)") 4, " ", "Total Potential"
+      write(iOutputUnit_, "(I7,A1,a)") 5, " ", "Potential Y"
+
+    endif
+
+    if (cType(3:5) == "TEC") then
       write(iOutputUnit_, "(I7,A1,a)") 4, " ", "Solar Zenith Angle"
       write(iOutputUnit_, "(I7,A1,a)") 5, " ", "Vertical TEC"
 
@@ -1753,6 +1768,38 @@ subroutine output_3dmag(iBlock)
   enddo
 
 end subroutine output_3dmag
+
+! The dynamo, magnetospheric, and total potential
+
+subroutine output_3dpot(iBlock)
+
+  use ModGITM
+  use ModInputs
+
+  implicit none
+
+  integer, intent(in) :: iBlock
+  integer :: iLat, iLon, iAlt
+
+  do iAlt = -1, nAlts + 2
+    do iLat = -1, nLats + 2
+      do iLon = -1, nLons + 2
+        write(iOutputUnit_) &
+          Longitude(iLon, iBlock), &
+          Latitude(iLat, iBlock), &
+          Altitude_GB(iLon, iLat, iAlt, iBlock), &
+          mLatitude(iLon, iLat, iAlt, iBlock), &
+          mLongitude(iLon, iLat, iAlt, iBlock), &
+          MagnetosphericPotential(iLon, iLat, iAlt), &
+          DynamoPotential(iLon, iLat, iAlt), &
+          Potential(iLon, iLat, iAlt, iBlock), &
+          PotentialY(iLon, iLat, iAlt, iBlock)
+        ! B0 has 4 elements of the geomag field, the E, N, Up, and magnitude
+      enddo
+    enddo
+  enddo
+
+end subroutine output_3dpot
 
 !----------------------------------------------------------------
 


### PR DESCRIPTION
Modifies GITM slightly to survive superstorms:

- reverse the order we check for nan's and correct min densities
- use WeimerBoundaryLat as DynamoHighLatBoundary when it's low enough
- (change some things in outputs, they are non-consequential)