### PR TITLE
Add info to `run_information.txt`

### DIFF
--- a/share/Scripts/Makeversion.sh
+++ b/share/Scripts/Makeversion.sh
@@ -8,6 +8,8 @@
 writegitversion(){
     # This is the float-type version placed in output files
     # Format is (date of last commit).(# of files changed from HEAD)
+    # first line defines the format, second line puts in the  date of last commit
+    # Third line calls git status, counts the number of different files, and strips that of whitespace
     printf 'character(25), parameter :: GitmVersion = & \n "%s.%s"\n' \
         "$(git log -1 --date=format:'%Y%m%d' --pretty='format:%ad')" \
         "$(git status --porcelain | grep -v '^??' | wc -l | awk '{$1=$1};1')" > src/.version
@@ -28,21 +30,32 @@ writegitversion(){
 
 
     # Here, for completeness, all of the changes files are listed.
-    printf 'character(*), parameter :: DifferentFilesGitm = &\n"' >> src/.version
+    printf 'character(*), parameter :: DifferentFilesGitm = ""' >> src/.version
 
     files=$(git status --porcelain | awk '{print $NF}')
-    for file in $files; do
-        echo "$file,&" >> src/.version
-    done
-    echo '"'>> src/.version
 
-    printf 'character(*), parameter :: DifferentFilesElectrodyunamics = &\n"' >> src/.version
+    # Storing multi-line strings in Fortran is a chore
+    # format is var = "some text" // NEW_LINE("A") // & ...
+    # NEW_LINE("A") is the newline character, where A is any text (used for decoding)
+    # This implementation seemed line the least amount of extra code & conditionals
+    # We parse thru the different files (from git status) and for each write the 
+    # continuation on the prev line, this file name, and a newline character. 
+    # This allows the first line to be a linrbreak & the last line to not have anything
+    for file in $files; do
+        printf ' // &\n\"'$file'\" // NEW_LINE(\"A\")' >> src/.version
+    done
+    echo '' >> src/.version
+    echo '' >> src/.version
+
+    printf 'character(*), parameter :: DifferentFilesElectrodynamics = ""' >> src/.version
 
     files=$(git -C ext/Electrodynamics status --porcelain | awk '{print $NF}')
     for file in $files; do
-        echo  "$file,&" >> src/.version
+        printf ' // &\n\"'$file'\" // NEW_LINE(\"A\")' >> src/.version
+        # echo  "$file,&" >> src/.version
     done
-    echo '"'>> src/.version
+    echo '' >> src/.version
+
 }
 
 ################

--- a/share/Scripts/Makeversion.sh
+++ b/share/Scripts/Makeversion.sh
@@ -10,20 +10,20 @@ writegitversion(){
     # Format is (date of last commit).(# of files changed from HEAD)
     printf 'character(25), parameter :: GitmVersion = & \n "%s.%s"\n' \
         "$(git log -1 --date=format:'%Y%m%d' --pretty='format:%ad')" \
-        "$(git status --porcelain | grep -v '^??' | wc -l | cut -f1 -d' ')" > src/.version
+        "$(git status --porcelain | grep -v '^??' | wc -l | awk '{$1=$1};1')" > src/.version
 
 
     # The "GitmVersionFull" variable has info about the last commit hash in addition to above
     printf '\ncharacter(50), parameter :: GitmVersionFull = "%s_%s.%s"\n\n' \
         "$(git rev-parse --abbrev-ref HEAD)" \
         "$(git log -1 --date=format:'%Y%m%d' --pretty='format:%h-%ad')" \
-        "$(git status --porcelain | grep -v '^??' | wc -l | cut -f1 -d' ')" >> src/.version
+        "$(git status --porcelain | grep -v '^??' | wc -l | awk '{$1=$1};1')" >> src/.version
 
     # Same as above, but for Electrodynamics
     printf '\ncharacter(50), parameter :: ElectrodynamicsVersionFull = "%s_%s.%s"\n\n' \
         "$(git -C ext/Electrodynamics rev-parse --abbrev-ref HEAD)" \
         "$(git -C ext/Electrodynamics log -1 --date=format:'%Y%m%d' --pretty='format:%h-%ad')" \
-        "$(git -C ext/Electrodynamics status --porcelain | grep -v '^??' | wc -l | cut -f1 -d' ')" \
+        "$(git -C ext/Electrodynamics status --porcelain | grep -v '^??' | wc -l | awk '{$1=$1};1')" \
         >> src/.version
 
 

--- a/src/logfile.f90
+++ b/src/logfile.f90
@@ -583,6 +583,15 @@ subroutine write_code_information(dir)
     write(iCodeInfoFileUnit_, *) ""
     write(iCodeInfoFileUnit_, *) ""
     write(iCodeInfoFileUnit_, *) ""
+    write(iCodeInfoFileUnit_, *) "Files changed in GITM from last commit:"
+    write(iCodeInfoFileUnit_, *) "--------------------"
+    write(iCodeInfoFileUnit_, *) DifferentFilesGitm
+    write(iCodeInfoFileUnit_, *) ""
+    write(iCodeInfoFileUnit_, *) ""
+    write(iCodeInfoFileUnit_, *) "Files changed in Electrodynamics from last git commit:"
+    write(iCodeInfoFileUnit_, *) "--------------------"
+    write(iCodeInfoFileUnit_, *) DifferentFilesElectrodynamics
+    write(iCodeInfoFileUnit_, *) ""
     write(iCodeInfoFileUnit_, *) ""
     write(iCodeInfoFileUnit_, *) ""
 

--- a/src/logfile.f90
+++ b/src/logfile.f90
@@ -314,6 +314,14 @@ subroutine write_code_information(dir)
     enddo
 
     write(iCodeInfoFileUnit_, *) ""
+    write(iCodeInfoFileUnit_, *) "Values set in ModSize.f90:"
+    write(iCodeInfoFileUnit_, *) ""
+    write(iCodeInfoFileUnit_, *) "nLons:", nLons
+    write(iCodeInfoFileUnit_, *) "nLats:", nLats
+    write(iCodeInfoFileUnit_, *) "nAlts:", nAlts
+    write(iCodeInfoFileUnit_, *) "nBlocksMax:", nBlocksMax
+
+    write(iCodeInfoFileUnit_, *) ""
     write(iCodeInfoFileUnit_, *) "Inputs from UAM.in:"
     write(iCodeInfoFileUnit_, *) ""
 


### PR DESCRIPTION
# [BUG/etc.] Adds ModSize.f90 settings & list of different files to run_information.txt

Does the above and fixes an error where the version was incorrect on MacOS due to weird locale/lang settings messing up how `cut` works. No change to logfiles or outputs other than run_information.txt

----

These changes should help improve traceability and make remote debugging easier

The number of changed files in the version of GITM & Electrodynamics should be functional on MacOS and some more settings are printed out to run_information.txt
