### PR TITLE
[Hotfix]: Update crayftn Makefile & add info to `run_information.txt`

### DIFF
--- a/.github/workflows/Format-and-Test.yml
+++ b/.github/workflows/Format-and-Test.yml
@@ -5,6 +5,7 @@ on:
     branches:
       - main
       - develop
+      - hotfix
 
 jobs:
   Format:

--- a/share/Scripts/Config.pl
+++ b/share/Scripts/Config.pl
@@ -6,7 +6,7 @@ use strict;
 
 # Default compiler per machine or OS
 my %Compiler = (
-		"Linux"               => "nagfor",
+		"Linux"               => "gfortran",
 		"Darwin"              => "nagfor",
 		"OSF1"                => "f90",
 		"IRIX64"              => "f90",
@@ -35,10 +35,15 @@ my $IsStrict=1;  # If true, shell_command will stop on error
 # Obtain $OS, $DIR, and the machine name and provide it to caller script
 our $OS  = `uname`    or die "$ERROR_ could not obtain OS\n"; chop $OS;
 our $DIR = `/bin/pwd` or die "$ERROR_ could not obtain DIR\n"; chop $DIR;
-our $Machine = `hostname`; chop($Machine); $Machine =~ s/\..*//;
+our $Machine = `hostname -f`; chop($Machine); 
 
+$Machine =~ s/^login\d*\.//; # remove "login\d+." from beginning
+$Machine =~ s/\..*//;        # keep the first word
+$Machine =~ s/[\-\d\.]+$//;  # remove numbers from the machine name
+$Machine =~ s/login$//;      # remove trailing login
+$Machine =~ s/\-//;          # remove trailing "-"
 # remove numbers from the machine name
-$Machine =~ s/\d+$//; 
+$Machine =~ s/\d+$//;
 
 # These are either obtained from the calling script or set here
 our $Component;             # The SWMF component the code is representing
@@ -54,6 +59,19 @@ our $WARNING = "$Code/Config.pl WARNING:";
 our $Compiler;
 $Compiler = $Compiler{$Machine} or $Compiler = $Compiler{$OS} or
     die "$ERROR_ default compiler is not known for OS=$OS\n";
+
+
+
+if ($Machine='athfe' and $Compiler='crayftn'){
+    print "
+====================================================
+On athena we recommend using -compiler=ifortmpif90
+and running 'module switch PrgEnv-cray PrgEnv-intel'
+If you need to use crayftn, please use -O1
+====================================================
+";
+}
+
 
 # Default C compiler part of Makefile.conf
 our $CompilerC = "gcc_mpicc";

--- a/share/Scripts/Makeversion.sh
+++ b/share/Scripts/Makeversion.sh
@@ -8,6 +8,8 @@
 writegitversion(){
     # This is the float-type version placed in output files
     # Format is (date of last commit).(# of files changed from HEAD)
+    # first line defines the format, second line puts in the  date of last commit
+    # Third line calls git status, counts the number of different files, and strips that of whitespace
     printf 'character(25), parameter :: GitmVersion = & \n "%s.%s"\n' \
         "$(git log -1 --date=format:'%Y%m%d' --pretty='format:%ad')" \
         "$(git status --porcelain | grep -v '^??' | wc -l | awk '{$1=$1};1')" > src/.version
@@ -28,21 +30,32 @@ writegitversion(){
 
 
     # Here, for completeness, all of the changes files are listed.
-    printf 'character(*), parameter :: DifferentFilesGitm = &\n"' >> src/.version
+    printf 'character(*), parameter :: DifferentFilesGitm = ""' >> src/.version
 
     files=$(git status --porcelain | awk '{print $NF}')
-    for file in $files; do
-        echo "$file,&" >> src/.version
-    done
-    echo '"'>> src/.version
 
-    printf 'character(*), parameter :: DifferentFilesElectrodyunamics = &\n"' >> src/.version
+    # Storing multi-line strings in Fortran is a chore
+    # format is var = "some text" // NEW_LINE("A") // & ...
+    # NEW_LINE("A") is the newline character, where A is any text (used for decoding)
+    # This implementation seemed line the least amount of extra code & conditionals
+    # We parse thru the different files (from git status) and for each write the 
+    # continuation on the prev line, this file name, and a newline character. 
+    # This allows the first line to be a linrbreak & the last line to not have anything
+    for file in $files; do
+        printf ' // &\n\"'$file'\" // NEW_LINE(\"A\")' >> src/.version
+    done
+    echo '' >> src/.version
+    echo '' >> src/.version
+
+    printf 'character(*), parameter :: DifferentFilesElectrodynamics = ""' >> src/.version
 
     files=$(git -C ext/Electrodynamics status --porcelain | awk '{print $NF}')
     for file in $files; do
-        echo  "$file,&" >> src/.version
+        printf ' // &\n\"'$file'\" // NEW_LINE(\"A\")' >> src/.version
+        # echo  "$file,&" >> src/.version
     done
-    echo '"'>> src/.version
+    echo '' >> src/.version
+
 }
 
 ################

--- a/share/Scripts/Makeversion.sh
+++ b/share/Scripts/Makeversion.sh
@@ -10,20 +10,20 @@ writegitversion(){
     # Format is (date of last commit).(# of files changed from HEAD)
     printf 'character(25), parameter :: GitmVersion = & \n "%s.%s"\n' \
         "$(git log -1 --date=format:'%Y%m%d' --pretty='format:%ad')" \
-        "$(git status --porcelain | grep -v '^??' | wc -l | cut -f1 -d' ')" > src/.version
+        "$(git status --porcelain | grep -v '^??' | wc -l | awk '{$1=$1};1')" > src/.version
 
 
     # The "GitmVersionFull" variable has info about the last commit hash in addition to above
     printf '\ncharacter(50), parameter :: GitmVersionFull = "%s_%s.%s"\n\n' \
         "$(git rev-parse --abbrev-ref HEAD)" \
         "$(git log -1 --date=format:'%Y%m%d' --pretty='format:%h-%ad')" \
-        "$(git status --porcelain | grep -v '^??' | wc -l | cut -f1 -d' ')" >> src/.version
+        "$(git status --porcelain | grep -v '^??' | wc -l | awk '{$1=$1};1')" >> src/.version
 
     # Same as above, but for Electrodynamics
     printf '\ncharacter(50), parameter :: ElectrodynamicsVersionFull = "%s_%s.%s"\n\n' \
         "$(git -C ext/Electrodynamics rev-parse --abbrev-ref HEAD)" \
         "$(git -C ext/Electrodynamics log -1 --date=format:'%Y%m%d' --pretty='format:%h-%ad')" \
-        "$(git -C ext/Electrodynamics status --porcelain | grep -v '^??' | wc -l | cut -f1 -d' ')" \
+        "$(git -C ext/Electrodynamics status --porcelain | grep -v '^??' | wc -l | awk '{$1=$1};1')" \
         >> src/.version
 
 

--- a/share/build/Makefile.Linux.crayftn
+++ b/share/build/Makefile.Linux.crayftn
@@ -10,9 +10,9 @@ SHELL=/bin/sh
 #	Cray Fortran (ftn) Compiler with FTN for linking
 #
 
-COMPILE.f77     = ${CUSTOMPATH_F}ftn
-COMPILE.f90     = ${CUSTOMPATH_F}ftn
-LINK.f90	= ${CUSTOMPATH_MPI}ftn
+COMPILE.f77     = ${CUSTOMPATH_F}ftn -Ofp3
+COMPILE.f90     = ${CUSTOMPATH_F}ftn -Ofp3
+LINK.f90	= ${CUSTOMPATH_MPI}ftn -Ofp3
 AR = ar -rs
 
 SINGLEPREC =
@@ -33,7 +33,7 @@ DEBUG     =
 OPT0 = -O0
 OPT1 = -O1
 OPT2 = -O2
-OPT3 = -O3,fp3
+OPT3 = -O3
 OPT4 = -O4
 
 CFLAG = ${SEARCH} -c ${DEBUG}
@@ -64,19 +64,19 @@ BLAS  = lapack.o blas.o
 .SUFFIXES: .f90 .F90 .f .for .ftn .o
 
 .f90.o:
-	${COMPILE.f90} ${Cflag3} $<
+	${COMPILE.f90} ${Cflag3} -f free $<
 
 .F90.o:
 	${COMPILE.f90} -DsysLinux ${Cflag3} $<
 
 .f.o:
-	${COMPILE.f77} ${Cflag3} -f fixed $<
+	${COMPILE.f77} ${Cflag3} -f fixed -N 132 $<
 
 .for.o:
-	${COMPILE.f77} ${Cflag3} -f fixed $<
+	${COMPILE.f77} ${Cflag3} -f fixed -N 132 $<
 
 .ftn.o:
-	${COMPILE.f77} ${Cflag3} -f fixed $<
+	${COMPILE.f77} ${Cflag3} -f fixed -N 132 $<
 
 clean:	
 	rm -f *~ core *.o *.mod fort.* a.out *.exe *.a *.so *.il *.protex

--- a/src/logfile.f90
+++ b/src/logfile.f90
@@ -583,6 +583,15 @@ subroutine write_code_information(dir)
     write(iCodeInfoFileUnit_, *) ""
     write(iCodeInfoFileUnit_, *) ""
     write(iCodeInfoFileUnit_, *) ""
+    write(iCodeInfoFileUnit_, *) "Files changed in GITM from last commit:"
+    write(iCodeInfoFileUnit_, *) "--------------------"
+    write(iCodeInfoFileUnit_, *) DifferentFilesGitm
+    write(iCodeInfoFileUnit_, *) ""
+    write(iCodeInfoFileUnit_, *) ""
+    write(iCodeInfoFileUnit_, *) "Files changed in Electrodynamics from last git commit:"
+    write(iCodeInfoFileUnit_, *) "--------------------"
+    write(iCodeInfoFileUnit_, *) DifferentFilesElectrodynamics
+    write(iCodeInfoFileUnit_, *) ""
     write(iCodeInfoFileUnit_, *) ""
     write(iCodeInfoFileUnit_, *) ""
 

--- a/src/logfile.f90
+++ b/src/logfile.f90
@@ -314,6 +314,14 @@ subroutine write_code_information(dir)
     enddo
 
     write(iCodeInfoFileUnit_, *) ""
+    write(iCodeInfoFileUnit_, *) "Values set in ModSize.f90:"
+    write(iCodeInfoFileUnit_, *) ""
+    write(iCodeInfoFileUnit_, *) "nLons:", nLons
+    write(iCodeInfoFileUnit_, *) "nLats:", nLats
+    write(iCodeInfoFileUnit_, *) "nAlts:", nAlts
+    write(iCodeInfoFileUnit_, *) "nBlocksMax:", nBlocksMax
+
+    write(iCodeInfoFileUnit_, *) ""
     write(iCodeInfoFileUnit_, *) "Inputs from UAM.in:"
     write(iCodeInfoFileUnit_, *) ""
 

--- a/util/EMPIRICAL/srcUA/ModMsis21.F90
+++ b/util/EMPIRICAL/srcUA/ModMsis21.F90
@@ -2662,20 +2662,20 @@ subroutine gtd8d(iyd,sec,alt,glat,glong,stl,f107a,f107,ap,mass,d,t)
   call msiscalc(xday,xutsec,xalt,xlat,xlon,xsfluxavg,xsflux,xap,xtn,xdn,tex=xtex)
 
   ! Convert the output arguments to the legacy format (mks to cgs, re-order species)
-  t(1) = sngl(xtex)    ! Expospheric temperature
-  t(2) = sngl(xtn)     ! Temperature at altitude
+  t(1) = real(xtex)    ! Expospheric temperature
+  t(2) = real(xtn)     ! Temperature at altitude
   where (xdn .ne. dmissing) xdn = xdn*1d-6
   if (xdn(1) .ne. dmissing) xdn(1) = xdn(1)*1e3_rp
-  d(1) = sngl(xdn(5))  ! [He]
-  d(2) = sngl(xdn(4))  ! [O]
-  d(3) = sngl(xdn(2))  ! [N2]
-  d(4) = sngl(xdn(3))  ! [O2]
-  d(5) = sngl(xdn(7))  ! [Ar]
-  d(6) = sngl(xdn(1))  ! Mass density
-  d(7) = sngl(xdn(6))  ! [H]
-  d(8) = sngl(xdn(8))  ! [N]
-  d(9) = sngl(xdn(9))  ! [Anomalous O]
-  d(10) = sngl(xdn(10))  ! [NO]
+  d(1) = real(xdn(5))  ! [He]
+  d(2) = real(xdn(4))  ! [O]
+  d(3) = real(xdn(2))  ! [N2]
+  d(4) = real(xdn(3))  ! [O2]
+  d(5) = real(xdn(7))  ! [Ar]
+  d(6) = real(xdn(1))  ! Mass density
+  d(7) = real(xdn(6))  ! [H]
+  d(8) = real(xdn(8))  ! [N]
+  d(9) = real(xdn(9))  ! [Anomalous O]
+  d(10) = real(xdn(10))  ! [NO]
 
   return
 


### PR DESCRIPTION
## Compilation was not working with `crayftn`:
- Adds (rudimentary) support for crayftn
- Detect if hostname is Athena and include message that intel compilers are better supported
- ModMsis21 `sngl()` -> `real()`

> This was done in Jan but apparently never made it into the man branch. Whoops!

## Additional information in `run_information.txt`:
- Version was not working on MacOS (replace `cut` -> `awk`)
- Add values set in `ModSize.f90`
- Add list of changed files

---

Since no fundamental functionality is changed, this may not warrant updating the version on main. But maybe we need a system for how to denote "minor patches" in addition to "major releases"